### PR TITLE
Avoid @base: null as it breaks parsing as RDF

### DIFF
--- a/docs/1.1-DRAFT/context.jsonld
+++ b/docs/1.1-DRAFT/context.jsonld
@@ -2492,6 +2492,5 @@
           "wfprov": "http://purl.org/ro/wfprov#",
           "roterms": "http://purl.org/ro/roterms#",
           "wf4ever": "http://purl.org/ro/wf4ever#",
-          "@base": null
      }
 }

--- a/docs/1.1-DRAFT/context.jsonld
+++ b/docs/1.1-DRAFT/context.jsonld
@@ -2491,6 +2491,6 @@
           "wfdesc": "http://purl.org/ro/wfdesc#",
           "wfprov": "http://purl.org/ro/wfprov#",
           "roterms": "http://purl.org/ro/roterms#",
-          "wf4ever": "http://purl.org/ro/wf4ever#",
+          "wf4ever": "http://purl.org/ro/wf4ever#"
      }
 }

--- a/docs/1.1-DRAFT/index.md
+++ b/docs/1.1-DRAFT/index.md
@@ -2272,6 +2272,7 @@ Parsing this as RDF will generate triples including:
 
 Here consumers can assume `/` is the _RO-Crate Root_ and generating relative URIs can safely be achieved by  search-replace as the arcp URI is unique. Saving _RO-Crate JSON-LD_ from the triples can be done by using the arcp URI to [relativize absolute URIs within RO-Crate Root](#relativizing-absolute-uris-within-ro-crate-root).
 
+The arcp specification suggests how [BagIt identifiers](https://tools.ietf.org/html/draft-soilandreyes-arcp-03#appendix-A.4) can be used to calculate the base URI. See also section [Combining with other packaging schemes](#combining-with-other-packaging-schemes)
 
 #### Relativizing absolute URIs within RO-Crate Root
 
@@ -2428,9 +2429,9 @@ A _Data Entity_ describing example.txt would have an `@id` of `bag/data/example.
   "@id": "bag/data/example.txt",
   "name": "Example file"
 }
-
-
 ```
+
+The arcp specification suggests how [BagIt UUID identifiers](https://tools.ietf.org/html/draft-soilandreyes-arcp-03#appendix-A.4) can be used to calculate the base URI of a bag. See also section [Establishing a base URI inside a ZIP file](#establishing-a-base-uri-inside-a-zip-file).
 
 ### Repository-specific identifiers
 

--- a/docs/1.1-DRAFT/index.md
+++ b/docs/1.1-DRAFT/index.md
@@ -1863,7 +1863,7 @@ If performing
 
 Example, this JSON-LD is in [compacted form](https://www.w3.org/TR/json-ld11/#compacted-document-form) which may be beneficial for processing, but is not yet valid _RO-Crate Metadata File_ as it has not been flattened into a `@graph` array.
 
-```jsonld
+```json
 { 
   "@context": [
     {"@base": null},
@@ -1893,7 +1893,7 @@ Example, this JSON-LD is in [compacted form](https://www.w3.org/TR/json-ld11/#co
 
 Performing [JSON-LD flattening](https://www.w3.org/TR/json-ld-api/#flattening-algorithm) with:
 
-```jsonld
+```json
 { "@context": 
      "https://w3id.org/ro/crate/1.1-DRAFT/context"
 }
@@ -1901,7 +1901,7 @@ Performing [JSON-LD flattening](https://www.w3.org/TR/json-ld-api/#flattening-al
 
 Results in a valid _RO-Crate JSON-LD_ (actual order in `@graph` may differ):
 
-```jsonld
+```json
 {
   "@context": "https://w3id.org/ro/crate/1.1-DRAFT/context",
   "@graph": [
@@ -1957,7 +1957,7 @@ To avoid absoluting local identifiers, before expanding, augment the JSON-LD `@c
 
 For example, expanding
 
-```jsonld
+```json
 {
   "@context": [
     "https://w3id.org/ro/crate/1.1-DRAFT/context",
@@ -1995,7 +1995,7 @@ For example, expanding
 
 Results in a [expanded form](https://www.w3.org/TR/json-ld11/#expanded-document-form) without `@context`, using absolute URIs for properties and types, but retains relative URI references for entities within the _RO-Crate Root_:
 
-```jsonld
+```json
 [
   {
     "@id": "ro-crate-metadata.jsonld",
@@ -2152,7 +2152,7 @@ When parsing a _RO-Crate Metadata File_ into [RDF triples](https://www.w3.org/TR
 
 If a web-based URI for the _RO-Crate root_ is known, then this can be supplied as a _base URI_. Most RDF tools support a `--base` option or similar. If this is not possible, then the `@context` of the `RO-Crate JSON-LD` can be modified by ensuring the `@context` is an array that sets the desired `@base`:
 
-```jsonld
+```json
 {
   "@context": [
     "https://w3id.org/ro/crate/1.1-DRAFT/context",
@@ -2167,16 +2167,11 @@ If a web-based URI for the _RO-Crate root_ is known, then this can be supplied a
       },
       "about": {
         "@id": "./"
-      },
-      "description": "RO-Crate Metadata File Descriptor (this file)"
+      }
     },
     {
       "@id": "./",
       "@type": "Dataset",
-      "description": "The RO-Crate Root DatEstablishing absolute URI for RO-Crate Root
-          "@id": "subfolder/"
-        }
-      ],
       "name": "Example RO-Crate"
     },
     {
@@ -2223,7 +2218,7 @@ to establish a temporary/location-based UUID or hash-based (SHA256) _base URI_.
 For instance, given a randomly generated UUID `029bcde1-dfa3-43cf-b7d9-a4fb75ccd4eb` we can use `arcp://uuid,b7749d0b-0e47-5fc4-999d-f154abe68065/` as the `@base`:
 
 
-```jsonld
+```json
 {
   "@context": [
     "https://w3id.org/ro/crate/1.1-DRAFT/context",
@@ -2238,8 +2233,7 @@ For instance, given a randomly generated UUID `029bcde1-dfa3-43cf-b7d9-a4fb75ccd
       },
       "about": {
         "@id": "./"
-      },
-      "description": "RO-Crate Metadata File Descriptor (this file)"
+      }
     },
     {
       "@id": "./",
@@ -2270,8 +2264,7 @@ For instance, given a randomly generated UUID `029bcde1-dfa3-43cf-b7d9-a4fb75ccd
 
 Parsing this as RDF will generate triples including:
 
-```
-
+```turtle
 <arcp://uuid,b7749d0b-0e47-5fc4-999d-f154abe68065/ro-crate-metadata.jsonld> <http://schema.org/about> <arcp://uuid,b7749d0b-0e47-5fc4-999d-f154abe68065/> .
 
 <arcp://uuid,b7749d0b-0e47-5fc4-999d-f154abe68065/> <http://schema.org/hasPart> <arcp://uuid,b7749d0b-0e47-5fc4-999d-f154abe68065/data1.txt> .
@@ -2286,7 +2279,7 @@ Some applications may prefer working with absolute URIs, e.g. in a joint graph s
 
 Assuming a repository at `example.com` has JSON-LD with absolute URIs:
 
-```jsonld
+```json
 {
   "@context": "https://w3id.org/ro/crate/1.1-DRAFT",
   "@graph": [
@@ -2299,7 +2292,6 @@ Assuming a repository at `example.com` has JSON-LD with absolute URIs:
       "about": {
         "@id": "http://example.com/crate415/"
       },
-      "description": "RO-Crate Metadata File Descriptor (this file)"
     },
     {
       "@id": "http://example.com/crate415/",
@@ -2322,7 +2314,7 @@ Assuming a repository at `example.com` has JSON-LD with absolute URIs:
 Then performing [JSON-LD flattening](https://www.w3.org/TR/json-ld-api/#flattening-algorithm)
 with this `@context`:
 
-```jsonld
+```json
 { "@context": [
     {"@base": "http://example.com/crate415/"},
      "https://w3id.org/ro/crate/1.1-DRAFT"
@@ -2332,7 +2324,7 @@ with this `@context`:
 
 Will output _RO-Crate JSON-LD_ with relative URIs:
 
-```jsonld
+```json
 {
   "@context": [
     {
@@ -2363,8 +2355,7 @@ Will output _RO-Crate JSON-LD_ with relative URIs:
       },
       "about": {
         "@id": "./"
-      },
-      "description": "RO-Crate Metadata File Descriptor (this file)"
+      }
     }
   ]
 }

--- a/docs/1.1-DRAFT/index.md
+++ b/docs/1.1-DRAFT/index.md
@@ -2272,7 +2272,7 @@ Parsing this as RDF will generate triples including:
 
 Here consumers can assume `/` is the _RO-Crate Root_ and generating relative URIs can safely be achieved by  search-replace as the arcp URI is unique. Saving _RO-Crate JSON-LD_ from the triples can be done by using the arcp URI to [relativize absolute URIs within RO-Crate Root](#relativizing-absolute-uris-within-ro-crate-root).
 
-The arcp specification suggests how [BagIt identifiers](https://tools.ietf.org/html/draft-soilandreyes-arcp-03#appendix-A.4) can be used to calculate the base URI. See also section [Combining with other packaging schemes](#combining-with-other-packaging-schemes)
+**Bagit**: The arcp specification suggests how [BagIt identifiers](https://tools.ietf.org/html/draft-soilandreyes-arcp-03#appendix-A.4) can be used to calculate the base URI. See also section [Combining with other packaging schemes](#combining-with-other-packaging-schemes) - note that in this approach the _RO-Crate Root_ will be the payload folder `/data/` under the calculated arcp base URI.
 
 #### Relativizing absolute URIs within RO-Crate Root
 
@@ -2402,6 +2402,11 @@ payload (`data/`) directory.
       |     [payload files and directories]  # 1 or more SHOULD be present
 ```
 
+**Base URI**: The arcp specification suggests how [BagIt UUID identifiers](https://tools.ietf.org/html/draft-soilandreyes-arcp-03#appendix-A.4) can be used to calculate the base URI of a bag, see section [Establishing a base URI inside a ZIP file](#establishing-a-base-uri-inside-a-zip-file).  For this purpose it is RECOMMENDED that `bag-info.txt` includes a fresh UUID like:
+
+    External-Identifier: urn:uuid:24e51ca2-5067-4598-935a-dac4e327d05a
+
+
 #### Example of wrapping a BagIt bag in an RO-Crate
 
 Alternatively, an RO-Crate can wrap a BagIt bag, so that the RO-Crate metadata
@@ -2431,7 +2436,6 @@ A _Data Entity_ describing example.txt would have an `@id` of `bag/data/example.
 }
 ```
 
-The arcp specification suggests how [BagIt UUID identifiers](https://tools.ietf.org/html/draft-soilandreyes-arcp-03#appendix-A.4) can be used to calculate the base URI of a bag. See also section [Establishing a base URI inside a ZIP file](#establishing-a-base-uri-inside-a-zip-file).
 
 ### Repository-specific identifiers
 

--- a/scripts/schema-context.py
+++ b/scripts/schema-context.py
@@ -122,7 +122,8 @@ ADDITIONAL = OrderedDict([
           ("roterms", "http://purl.org/ro/roterms#"),
           ("wf4ever", "http://purl.org/ro/wf4ever#"),
           
-          ("@base", None)
+          # Disabled, see https://github.com/ResearchObject/ro-crate/pull/73
+#          ("@base", None) 
 ])
 
 if __name__=="__main__":


### PR DESCRIPTION
Avoid using `@base: null` as it means parsing RO-Crate JSON-LD as RDF will skip triples with relative URIs. 

Rather adding `@base: null` can be recommended for the compaction algorithm if making RO-Crates.