### PR TITLE
Wrong namespace in PCDM links

### DIFF
--- a/docs/1.1-DRAFT/appendix/changelog.md
+++ b/docs/1.1-DRAFT/appendix/changelog.md
@@ -43,6 +43,7 @@ excerpt: List of changes in releases of this specifications
   * RO-Crate preview HTML no longer needs to "contain same information as JSON-LD" [#108](https://github.com/ResearchObject/ro-crate/issues/108)
   * Change theme to `jekyll-rtd-theme` and split into multiple pages [#95](https://github.com/ResearchObject/ro-crate/pull/95)
   * Fixed typos in JSON and English 
+  * [Additional metadata standards](../metadata.md#additional-metadata-standards) showed wrong PCDM namespace [#112](https://github.com/ResearchObject/ro-crate/pull/112)
   * Several sections reviewed to improve language and examples
     [#91](https://github.com/ResearchObject/ro-crate/pull/91)
     [#92](https://github.com/ResearchObject/ro-crate/pull/92)

--- a/docs/1.1-DRAFT/metadata.md
+++ b/docs/1.1-DRAFT/metadata.md
@@ -82,16 +82,16 @@ See the appendix [RO-Crate JSON-LD](appendix/jsonld.md) for details.
 
 ## Additional metadata standards
 
-RO-Crate also uses the _Portland Common Data Model_ ([PCDM])) to describe repositories or collections of digital objects and imports these terms:
+RO-Crate also uses the _Portland Common Data Model_ ([PCDM] version <https://pcdm.org/2016/04/18/models>) to describe repositories or collections of digital objects and imports these terms:
  
-- `RepositoryObject` mapped to <https://pcdm.org/2016/04/18/models#Object>
-- `RepositoryCollection` mapped to <https://pcdm.org/2016/04/18/models#Collection>
-- `RepositoryFile` mapped to <https://pcdm.org/2016/04/18/models#Collection>
-- `hasMember` mapped to <https://pcdm.org/2016/04/18/models#hasMember>
-- `hasFile` mapped to <https://pcdm.org/2016/04/18/models#hasFile>
+- `RepositoryObject` mapped to <http://pcdm.org/models#Object>
+- `RepositoryCollection` mapped to <http://pcdm.org/models#Collection>
+- `RepositoryFile` mapped to <http://pcdm.org/models#File>
+- `hasMember` mapped to <http://pcdm.org/models#hasMember>
+- `hasFile` mapped to <http://pcdm.org/models#hasFile>
 
 ```note
-The terms `RepositoryObject` and `RepositoryCollection` were renamed to avoid collision between other vocabularies and the PCDM terms `Collection` and `Object`.
+The terms `RepositoryObject` and `RepositoryCollection` are renamed to avoid collision between other vocabularies and the PCDM terms `Collection` and `Object`. The term `RepositoryFile` is renamed to avoid clash with RO-Crate's `File` mapping to <http://schema.org/MediaObject>.
 ```
 
 From [Dublin Core Terms](http://purl.org/dc/terms/) RO-Crate use:

--- a/docs/1.1-DRAFT/provenance.md
+++ b/docs/1.1-DRAFT/provenance.md
@@ -233,7 +233,11 @@ To describe an export from a Digital Library or repository system, RO-Crate uses
 
 A [Contextual Entity](contextual-entities.md) from a repository, representing an abstract entity such as a person, or a work, or a place SHOULD have a`@type` of [RepositoryObject], in addition to any other types. 
 
-Objects MAY be grouped together in [RepositoryCollection]s with [hasMember] pointing to the the [RepositoryObject]. The aliases `RepositoryObject` and `RepositoryCollection` were chosen to avoid collision between the PCDM terms <del>Collection</del> and <del>Object</del> with other vocabularies.
+Objects MAY be grouped together in [RepositoryCollection]s with [hasMember] pointing to the the [RepositoryObject]. 
+
+```note
+The terms `RepositoryObject` and `RepositoryCollection` are renamed to avoid collision between other vocabularies and the PCDM terms `Collection` and `Object`. The term `RepositoryFile` is renamed to avoid clash with RO-Crate's `File` mapping to <http://schema.org/MediaObject>.
+```
 
 ```warning
 PCDM specifies that files should have only technical metadata, not descriptive metadata, which is _not_ a restriction in RO-Crate. If the RO-Crate is to be imported into a strict PCDM repository, modeling of object/file relationships will be necessary.


### PR DESCRIPTION
.. the namespaced terms don't use dates in the PCDM ontology. The [context.jsonld](https://github.com/ResearchObject/ro-crate/blob/75001bae93b11035f919695a4a8dae66c0166d62/docs/1.1-DRAFT/context.jsonld#L2624) had correct mapping, only the HTML description of that mapping was wrong.

So <https://pcdm.org/2016/04/18/models#hasFile> should be <http://pcdm.org/models#hasFile> etc.

Added link to the PCDM version <https://pcdm.org/2016/04/18/models> in paragraph above.

Also fixes @jmfernandez comment https://github.com/ResearchObject/ro-crate/issues/109#issuecomment-716203692
that `RepositoryFile` incorrectly mapped to `pcdm:Collection` instead of `pcdm:File`

Improve description of `RepositoryObject`/`RepositoryColletion` rename by also noting `RepositoryFile` was renamed.

This also address @ptsefton https://github.com/ResearchObject/ro-crate/issues/109#issuecomment-716276505 and https://github.com/ResearchObject/ro-crate/issues/109#issuecomment-716262338 about `(PCDM))` and `<del>`