### PR TITLE
Stian review edits for 1.1.0

### DIFF
--- a/docs/1.1-DRAFT/appendix/changelog.md
+++ b/docs/1.1-DRAFT/appendix/changelog.md
@@ -32,7 +32,7 @@ excerpt: List of changes in releases of this specifications
   * [RO-Crate Root](../structure.md) directory no longer requires payload files [#74](https://github.com/ResearchObject/ro-crate/issues/74)
   * [Workflows and scripts](../workflows.md) section now aligned with [BioSchemas ComputationalWorkflow profile](https://bioschemas.org/profiles/ComputationalWorkflow/0.5-DRAFT-2020_07_21/)  [#81](https://github.com/ResearchObject/ro-crate/issues/81) [#100](https://github.com/ResearchObject/ro-crate/pull/100)
   * Added section [Programming with JSON-LD](implementation-notes.md#programming-with-json-ld) and note that `@type` might be an array [#85](https://github.com/ResearchObject/ro-crate/issues/85)
-  * Added new section [Handling relative URI references](jsonld.html#handling-relative-uri-references) [#73](https://github.com/ResearchObject/ro-crate/issues/73)
+  * Added new section [Handling relative URI references](jsonld.md#handling-relative-uri-references) [#73](https://github.com/ResearchObject/ro-crate/issues/73)
   * JSON-LD context no longer sets `@base: null` [#73](https://github.com/ResearchObject/ro-crate/issues/73)
   * Added note on [Encoding file paths](../data-entities.md#encoding-file-paths) [#77](https://github.com/ResearchObject/ro-crate/issues/77) [#80](https://github.com/ResearchObject/ro-crate/issues/80)
   * Added section [Choosing URLs for ad hoc terms](jsonld.md#adding-new-or-ad-hoc-vocabulary-terms) [#71](https://github.com/ResearchObject/ro-crate/issues/71) [#90](https://github.com/ResearchObject/ro-crate/issues/90)

--- a/docs/1.1-DRAFT/appendix/changelog.md
+++ b/docs/1.1-DRAFT/appendix/changelog.md
@@ -22,7 +22,7 @@ excerpt: List of changes in releases of this specifications
 -->
 
 
-# Changelog
+# APPENDIX: Changelog
 
 * [RO-Crate 1.1.0](https://github.com/ResearchObject/ro-crate/releases/tag/1.1.0) <https://w3id.org/ro/crate/1.1>
   * **Note**: The RO-Crate metadata file is renamed to `ro-crate-metadata.json` to facilitate use of JSON editors.  [#82](https://github.com/ResearchObject/ro-crate/issues/82) [#84](https://github.com/ResearchObject/ro-crate/issues/84)

--- a/docs/1.1-DRAFT/appendix/changelog.md
+++ b/docs/1.1-DRAFT/appendix/changelog.md
@@ -44,6 +44,11 @@ excerpt: List of changes in releases of this specifications
   * Change theme to `jekyll-rtd-theme` and split into multiple pages [#95](https://github.com/ResearchObject/ro-crate/pull/95)
   * Fixed typos in JSON and English 
   * [Additional metadata standards](../metadata.md#additional-metadata-standards) showed wrong PCDM namespace [#112](https://github.com/ResearchObject/ro-crate/pull/112)
+  * [Citation example](../contextual-entities.md#publications-via-citation-property) expanded 12a6754
+  * [Terminology](../terminology.md) adds property, type, entity cc10e28
+  * In [People](../contextual-entities.md#people) `author` can also be applied to `CreativeWork` e086b8b
+  * [Provenance section](../provenance.md) on Software-used now points to [Workflows](../workflows.md) section (and vice versa) 5d89872 40de6c7
+  * In [JSON-LD appendix](jsonld.md) `@id` should not include `../` 74ef6f1
   * Several sections reviewed to improve language and examples
     [#91](https://github.com/ResearchObject/ro-crate/pull/91)
     [#92](https://github.com/ResearchObject/ro-crate/pull/92)
@@ -58,6 +63,7 @@ excerpt: List of changes in releases of this specifications
     [#104](https://github.com/ResearchObject/ro-crate/pull/104)
     [#105](https://github.com/ResearchObject/ro-crate/pull/105)
     [#111](https://github.com/ResearchObject/ro-crate/pull/111)
+    [#114](https://github.com/ResearchObject/ro-crate/pull/114)
 * [RO-Crate 1.0.1](https://github.com/ResearchObject/ro-crate/releases/tag/1.0.1)
   * Fix JSON typo in example  
 * [RO-Crate 1.0.0](https://github.com/ResearchObject/ro-crate/releases/tag/1.0.0) <https://w3id.org/ro/crate/1.0>

--- a/docs/1.1-DRAFT/appendix/implementation-notes.md
+++ b/docs/1.1-DRAFT/appendix/implementation-notes.md
@@ -235,7 +235,7 @@ A [Data Entity](../data-entities.md) describing `example.txt` in this scenario w
 
 ## Repository-specific identifiers
 
-_Root Data Entities_ MAY also have additional repository specific identifiers, described using [Contextual Entities](../contextual-entities.md) using a [PropertyValue], with a [name] that identifies the repository and the [identifier] as a value. The _same_ identifier MAY be used in multiple different repositories and effectively namespaced using the `name` of the `ProperyValue`.
+_Root Data Entities_ MAY include repository-specific identifiers, described using [Contextual Entities](../contextual-entities.md) using a [PropertyValue], with a [name] that identifies the repository and the [identifier] as a value. The _same_ identifier MAY be used in multiple different repositories and effectively namespaced using the `name` of the `ProperyValue`.
 
 ```json
 {

--- a/docs/1.1-DRAFT/appendix/implementation-notes.md
+++ b/docs/1.1-DRAFT/appendix/implementation-notes.md
@@ -21,7 +21,7 @@ excerpt:
    limitations under the License.
 -->
 
-# Implementation notes
+# APPENDIX: Implementation notes
 
 ## Programming with JSON-LD
 

--- a/docs/1.1-DRAFT/appendix/implementation-notes.md
+++ b/docs/1.1-DRAFT/appendix/implementation-notes.md
@@ -223,11 +223,11 @@ is outside of the bag directory and can be changed without changing the payload'
   |         example.txt 
 ```
 
-A [Data Entity](../data-entities.md) describing `example.txt` in this scenario would have an `@id` of `bag/data/example.txt`:
+A [Data Entity](../data-entities.md) describing `example.txt` in this scenario would have an `@id` of `bag1/data/example.txt`:
 
 ```json
 {
-  "@id": "bag/data/example.txt",
+  "@id": "bag1/data/example.txt",
   "name": "Example file"
 }
 ```

--- a/docs/1.1-DRAFT/appendix/jsonld.md
+++ b/docs/1.1-DRAFT/appendix/jsonld.md
@@ -215,7 +215,7 @@ ln -s ro-crate-metadata.json ro-crate-metadata.jsonld
 
 To extend RO-Crate, implementers SHOULD try to use existing <http://schema.org/> properties and classes and MAY use terms from other vocabularies and ontologies when this is not possible.
 
-The _terms_ (properties and classes) used SHOULD be added as keys to the `@context` in the _RO-Crate JSON-LD_ (if not present). To avoid duplicating the _RO-Crate JSON-LD Context_ the `@context: []` array form SHOULD be used as shown below.
+The _terms_ (properties and types) used SHOULD be added as keys to the `@context` in the _RO-Crate JSON-LD_ (if not present). To avoid duplicating the _RO-Crate JSON-LD Context_ the `@context: []` array form SHOULD be used as shown below.
 
 URIs in the `@context` SHOULD resolve to a useful human readable page. When this is not possible - for example if the URI resolves to an RDF ontology file, a human-readable URI SHOULD be provided using a [sameAs] description.
 

--- a/docs/1.1-DRAFT/appendix/jsonld.md
+++ b/docs/1.1-DRAFT/appendix/jsonld.md
@@ -170,7 +170,7 @@ The [JSON-LD flattening & compaction](https://www.w3.org/TR/json-ld-api/#flatten
 
 ## RO-Crate JSON-LD Media type
 
-The [media type][RFC 6838] for `ro-crate-metadata.json` will, when following this specification, comply
+The [media type][RFC 6838] `application/ld+json` for `ro-crate-metadata.json` will, when following this specification, comply
 with the [flattened/compacted JSON-LD profiles][JSON-LD media type] as well as `https://w3id.org/ro/crate`, which may be indicated in a [HTTP response][RFC7231 response] as:
 
 ```http
@@ -181,7 +181,7 @@ Content-Type: application/ld+json; profile="http://www.w3.org/ns/json-ld#flatten
 ```
 
 
-Note that most web servers will serve `ro-crate-metadata.json` with  `Content-Type: application/json`. 
+Note that most web servers will however serve `*.json` as `Content-Type: application/json`. 
 
 Requesting the RO-Crate metadata file from a browser may also need permission through CORS header `Access-Control-Allow-Origin` (however extra care should be taken if the RO-Crates require access control).
 

--- a/docs/1.1-DRAFT/appendix/jsonld.md
+++ b/docs/1.1-DRAFT/appendix/jsonld.md
@@ -26,7 +26,7 @@ excerpt: |
 
 # APPENDIX: RO-Crate JSON-LD
 
-It is not necessary to use [JSON-LD tooling] to generate or parse the _RO-Crate Metadata File_, although JSON-LD tools may make it easier to conform to this specification, e.g. handling relative URIs. It is RECOMMENDED to use [JSON tooling][JSON] to handle [JSON][RFC 7159] syntax and escaping rules.
+It is not necessary to use [JSON-LD tooling] to generate or parse the _RO-Crate Metadata File_, although JSON-LD tools may make it easier to conform to this specification, e.g. handling relative URIs. It is however RECOMMENDED to use [JSON tooling][JSON] to handle [JSON][RFC 7159] syntax and escaping rules.
 
 This appendix shows a brief JSON-LD introduction for complying with the _RO-Crate Metadata File_ requirements.
 
@@ -93,7 +93,9 @@ The order of the `@graph` array is not significant. Above we see that the RO-Cra
 
 Properties of an entity can refer to another URL or entity by using the form `{"@id": "uri-reference"}` as in the example above, where the [author] property in the [File] entity refer to the [Person] entity, identified as `#alice`. 
 
-Identifiers in `@id` SHOULD be either a valid _absolute URI_ like <http://example.com/>, or a _URI references_ _URI paths_ relative to the RO-Crate root directory. Care must be taken to express any relative paths using `/` separator and escape special characters like space (`%20`). As JSON-LD supports _IRIs_, international characters in identifiers SHOULD be encoded in UTF-8 rather than `%`-escaped.
+Identifiers in `@id` SHOULD be either a valid _absolute URI_ like <http://example.com/>, or a _URI path_ relative to the RO-Crate root directory. Although legal in JSON-LD, `@id` paths in RO-Crate SHOULD NOT use `../` to climb out of the _RO-Crate Root_, rather such references SHOULD be translated to absolute URIs. See also section [Core Metadata for Data Entities](../data-entities.md#core-metadata-for-data-entities).
+
+Care must be taken to express any relative paths using `/` separator and escape special characters like space (`%20`). As JSON-LD supports _IRIs_, international characters in identifiers SHOULD be encoded in UTF-8 rather than `%`-escaped.
 
 Because the _RO-Crate JSON-LD_ is _flattened_, all described entities must be JSON objects as direct children of the `@graph` element rather than being nested under another object or array. Properties referencing entities must use a JSON object with `@id` as the only key, e.g. `"author": {"@id": "https://orcid.org/0000-0002-1825-0097"}`
 

--- a/docs/1.1-DRAFT/appendix/jsonld.md
+++ b/docs/1.1-DRAFT/appendix/jsonld.md
@@ -221,7 +221,7 @@ The _terms_ (properties and types) used SHOULD be added as keys to the `@context
 
 URIs in the `@context` SHOULD resolve to a useful human readable page. When this is not possible - for example if the URI resolves to an RDF ontology file, a human-readable URI SHOULD be provided using a [sameAs] description.
 
-For example. The `@id` URI <http://purl.org/ontology/bibo/interviewee> from the [BIBO ontology] ontology intends to resolve to an ontology file, which is not useful for humans, however the HTML section <http://neologism.ecs.soton.ac.uk/bibo.html#interviewee> is human-readable. To read more about best practices for content negotiation of vocabularies, we refer the reader to <https://www.w3.org/TR/swbp-vocab-pub/>
+For example. The `@id` URI <http://purl.org/ontology/bibo/interviewee> from the [BIBO ontology] ontology intends to resolve to an ontology file, which is not useful for humans, however the HTML section <http://neologism.ecs.soton.ac.uk/bibo.html#interviewee> is human-readable. To read more about best practices for content negotiation of vocabularies, we refer the reader to [Best Practice Recipes for Publishing RDF Vocabularies].
 
 
 ```json
@@ -250,7 +250,7 @@ Where there is no RDF ontology available, then implementors SHOULD attempt to pr
 
 Context terms must ultimately map to HTTP(s) URIs which poses challenges for crate-authors wishing to use their own vocabularies.
 
-RO-Crate provides some strategies to add a new term (a Class or Property) that is not in Schema.org or another published vocabulary, so that there is a stable URI that can be added to the @context. 
+RO-Crate provides some strategies to add a new term (a [Class] or [Property]) that is not in Schema.org or another published vocabulary, so that there is a stable URI that can be added to the @context. 
 
 ### Choosing URLs for ad hoc terms
 

--- a/docs/1.1-DRAFT/appendix/jsonld.md
+++ b/docs/1.1-DRAFT/appendix/jsonld.md
@@ -254,7 +254,7 @@ RO-Crate provides some strategies to add a new term (a [Class] or [Property]) th
 
 ### Choosing URLs for ad hoc terms
 
-For projects that have their own web-presence, URLs MAY defined and SHOULD resolve to useful content. For example for a project with web page <https://criminalcharacters.com/> the property `education` could have a URL: <https://criminalcharacters.com/vocab#education> which resolves to an HTML page that explains the term using HTML anchors:
+For projects that have their own web-presence, URLs MAY be defined there and SHOULD resolve to useful content. For example for a project with web page <https://criminalcharacters.com/> the property `education` could have a URL: <https://criminalcharacters.com/vocab#education> which resolves to an HTML page that explains the term using HTML anchors:
 
 ```html
 <div id="education">
@@ -268,7 +268,7 @@ For projects that have their own web-presence, URLs MAY defined and SHOULD resol
 Ensure you have a consistent use of `http` or `https` (preferring https) as well as consistent path `/vocab` vs `/vocab/` vs `/vocab/index.html` (preferring the shortest that is also visible in browser).
 ```
 
-For ad hoc terms where the crate author does not have the resources to create and maintain an HTML page, authors may use the RO-crate public namespace (`https://w3id.org/ro/terms/`) to reserve their terms. For example, an ad-hoc URL MAY be used in the form `https://w3id.org/ro/terms/criminalcharacters#education` where `criminalcharacters` is acting as a _namespace_ for one or more related terms like `education`. Ad-hoc namespaces under `https://w3id.org/ro/terms/` are available on first-come-first-serve basis; to avoid clashes, namespaces SHOULD be registered by [submitting terms and definitions][ro-terms] to the RO-Crate terms project. 
+For ad hoc terms where the crate author does not have the resources to create and maintain an HTML page, authors may use the RO-Crate public namespace (`https://w3id.org/ro/terms/`) to reserve their terms. For example, an ad-hoc URL MAY be used in the form `https://w3id.org/ro/terms/criminalcharacters#education` where `criminalcharacters` is acting as a _namespace_ for one or more related terms like `education`. Ad-hoc namespaces under `https://w3id.org/ro/terms/` are available on first-come-first-serve basis; to avoid clashes, namespaces SHOULD be registered by [submitting terms and definitions][ro-terms] to the RO-Crate terms project. 
 
 In both cases, to use an ad-hoc term in an RO-Crate, the URI MUST be included in the local context:
 
@@ -294,7 +294,7 @@ Following the conventions used by Schema.org, ad-hoc terms SHOULD also include d
 
 ```json
 {
-    "@id": "https://criminalcharacters.com/vocab/#education",
+    "@id": "https://criminalcharacters.com/vocab#education",
     "@type": "rdf:Property",
     "rdfs:label": "education",
     "rdf:comment": "Literacy of prisoner. ..."

--- a/docs/1.1-DRAFT/appendix/relative-uris.md
+++ b/docs/1.1-DRAFT/appendix/relative-uris.md
@@ -426,7 +426,7 @@ When parsing such crates it is recommended to use the
 [Archive and Package (arcp) URI scheme][ARCP]
 to establish a temporary/location-based UUID or hash-based (SHA256) _base URI_. 
 
-For instance, given a randomly generated UUID `029bcde1-dfa3-43cf-b7d9-a4fb75ccd4eb` we can use `arcp://uuid,b7749d0b-0e47-5fc4-999d-f154abe68065/` as the `@base`:
+For instance, given a randomly generated UUID `b7749d0b-0e47-5fc4-999d-f154abe68065` we can use `arcp://uuid,b7749d0b-0e47-5fc4-999d-f154abe68065/` as the `@base`:
 
 
 ```json

--- a/docs/1.1-DRAFT/appendix/relative-uris.md
+++ b/docs/1.1-DRAFT/appendix/relative-uris.md
@@ -41,7 +41,7 @@ consistent handling:
 ## Flattening JSON-LD from nested JSON
 
 If performing
-[JSON-LD flattening] to generate a valid _RO-Crate Metadata File_ , add `@base: null` to the input JSON-LD `@context` array to avoid expanding relative URI references. The flattening `@context` SHOULD NOT need `@base: null`.
+[JSON-LD flattening] to generate a valid _RO-Crate Metadata File_, add `@base: null` to the input JSON-LD `@context` array to avoid expanding relative URI references. The flattening `@context` SHOULD NOT need `@base: null`.
 
 Example, this JSON-LD is in [compacted form][compacted] which may be beneficial for processing, but is not yet valid _RO-Crate Metadata File_ as it has not been flattened into a `@graph` array.
 
@@ -146,7 +146,7 @@ For example, expanding this JSON-LD:
   "@context": [
     "https://w3id.org/ro/crate/1.1-DRAFT/context",
     {"@base": null}
-  ]
+  ],
   "@graph": [
     {
       "@id": "ro-crate-metadata.json",
@@ -230,7 +230,7 @@ Results in a [expanded form][JSON-LD expanded form] without `@context`, using ab
 ```
 
 ```note
-Note that `@base: null` will not relativize existing absolute URIs that happen to be contained by the _RO-Crate Root_ (see section [Relativizing absolute URIs within RO-Crate Root](#relativizing-absolute-uris-within-ro-crate-root)).
+`@base: null` will not relativize existing absolute URIs that happen to be contained by the _RO-Crate Root_ (see section [Relativizing absolute URIs within RO-Crate Root](#relativizing-absolute-uris-within-ro-crate-root)).
 ```
 
 ```tip
@@ -244,7 +244,7 @@ When loading _RO-Crate JSON-LD_ as RDF, or combining the crate's Linked Data int
 to resolve URI references that are relative to the _RO-Crate Root_.
 
 ```note
-Note that when retrieving an RO-Crate over the web, servers might have performed HTTP redirections so that the base URI is different from what was requested. It is RECOMMENDED to follow section [Establishing a Base URI of RFC3986](http://tools.ietf.org/html/rfc3986#section-5.1) before resolving relative links from the _RO-Crate Metadata File_.
+When retrieving an RO-Crate over the web, servers might have performed HTTP redirections so that the base URI is different from what was requested. It is RECOMMENDED to follow section [Establishing a Base URI of RFC3986](http://tools.ietf.org/html/rfc3986#section-5.1) before resolving relative links from the _RO-Crate Metadata File_.
 ```
 
 For instance, consider this HTTP redirection from a permalink (simplified):

--- a/docs/1.1-DRAFT/contextual-entities.md
+++ b/docs/1.1-DRAFT/contextual-entities.md
@@ -67,7 +67,7 @@ See the [appendix on JSON-LD identifiers](appendix/jsonld.md#describing-entities
 
 ## People
 
-A core principle of Linked data is to use URIs to identify things such as people. The following is the minimum recommended way of representing a [author] in a RO-Crate. This property MAY be applied in the context of a directory ([Dataset]) or to a [File].
+A core principle of Linked data is to use URIs to identify important entities such as people. The following is the minimum recommended way of representing a [author] in a RO-Crate. This property MAY be applied in the context of a directory ([Dataset]) or to a [File].
 
 ```json
 {

--- a/docs/1.1-DRAFT/contextual-entities.md
+++ b/docs/1.1-DRAFT/contextual-entities.md
@@ -67,7 +67,7 @@ See the [appendix on JSON-LD identifiers](appendix/jsonld.md#describing-entities
 
 ## People
 
-A core principle of Linked data is to use URIs to identify important entities such as people. The following is the minimum recommended way of representing a [author] in a RO-Crate. This property MAY be applied in the context of a directory ([Dataset]) or to a [File].
+A core principle of Linked data is to use URIs to identify important entities such as people. The following is the minimum recommended way of representing a [author] of a RO-Crate. The [author] property MAY also be applied to a directory ([Dataset]), a [File] or other [CreativeWork] entities.
 
 ```json
 {
@@ -83,9 +83,9 @@ A core principle of Linked data is to use URIs to identify important entities su
 }
 ```
 
-This uses an [ORCID] to unambiguously identify an author, with a _Contextual Entity_ of type [Person].
+This uses an [ORCID] to unambiguously identify an author, represented as a _Contextual Entity_ of type [Person].
 
-Note the string-value of the organizational affiliation. This SHOULD be improved by also providing a _Contextual Entity_ for the organization (see example below).
+Note the string _value_ for the organizational affiliation. This SHOULD be improved by also providing a _Contextual Entity_ for the organization (see example below).
 
 
 ## Organizations as values

--- a/docs/1.1-DRAFT/contextual-entities.md
+++ b/docs/1.1-DRAFT/contextual-entities.md
@@ -32,7 +32,7 @@ jekyll-mentions: false
 
 # Representing Contextual Entities
 
-The _RO-Crate JSON-LD_ `@graph` SHOULD contain additional information about _Contextual Entities_ for the use of both humans (in `ro-crate-preview.html`) and machines (in `ro-crate-metadata.json`). This also helps to maximize the extent to which an _RO-Crate_ is self-contained and self-describing, in that it reduces the need for the consumer of an RO-Crate to refer to external information which may change or become unavailable over time.
+The RO-Crate SHOULD contain additional information about _Contextual Entities_ for the use of both humans (in `ro-crate-preview.html`) and machines (in `ro-crate-metadata.json`). This also helps to maximize the extent to which an _RO-Crate_ is self-contained and self-describing, in that it reduces the need for the consumer of an RO-Crate to refer to external information which may change or become unavailable over time.
 
 ## Contextual vs Data entities
 

--- a/docs/1.1-DRAFT/contextual-entities.md
+++ b/docs/1.1-DRAFT/contextual-entities.md
@@ -176,11 +176,16 @@ For example:
 
 
 ```json
-"citation": {"@id": "https://doi.org/10.1109/TCYB.2014.2386282"}
+{
+    "@id": "./",
+    "@type": "Dataset",
+    "citation": {"@id": "https://doi.org/10.1109/TCYB.2014.2386282"}
+}
 ```
 
-
-The publication SHOULD be described in the _RO-Crate JSON-LD_.
+The publication SHOULD be described further 
+as an additional contextual entity of
+type [ScholarlyArticle] or [CreativeWork].
 
 
 ```json
@@ -209,8 +214,30 @@ The publication SHOULD be described in the _RO-Crate JSON-LD_.
 }
 ```
 
+[citation] MAY also be used with other data and contextual entities:
 
+```json
+{
+  "@id": "communities-2018.csv",
+  "@type": "File",
+  "name": "Snapshot of RO Community efforts",
+  "citation": {"@id": "https://doi.org/10.5281/zenodo.1313066"},
+  "encodingFormat": "text/csv"
+}
+```
 
+A [data entity](data-entities.md) MAY provide a published DOI [identifier] that, compared with any related publication in [citation], primarily captures that file or dataset:
+
+```json
+{
+  "@id": "figure.png",
+  "@type": ["File", "ImageObject"],
+  "name": "XXL-CT-scan of an XXL Tyrannosaurus rex skull",
+  "identifier": "https://doi.org/10.5281/zenodo.3479743",
+  "citation": {"@id": "http://ndt.net/?id=19249"},
+  "encodingFormat": "image/png"
+}
+```
 
 
 ## Publisher

--- a/docs/1.1-DRAFT/contextual-entities.md
+++ b/docs/1.1-DRAFT/contextual-entities.md
@@ -54,16 +54,16 @@ The RO-Crate Metadata JSON `@graph` MUST NOT list multiple entities with the sam
 
 ## Identifiers for contextual entities
 
-A challenge can be how to assign [identifiers for contextual entities](appendix/jsonld.html#describing-entities-in-json-ld), that is deciding on their `@id` value.
+A challenge can be how to assign [identifiers for contextual entities](appendix/jsonld.md#describing-entities-in-json-ld), that is deciding on their `@id` value.
 
 RO-Crate recommend that if an existing permalink (e.g. `https://orcid.org/0000-0002-1825-0097`) or other absolute URI (e.g. `https://en.wikipedia.org/wiki/Josiah_S._Carberry`) is reasonably unique for that entity, that URI should be used as identifier for the contextual entity in preference of an identifier local to the RO-Crate (e.g. `#josiah` or `#0fa587c6-4580-4ece-a5df-69af3c5590e3`). 
 
-Care should be taken to not describe two conceptually different contextual entities with the same identifier - e.g. if `https://en.wikipedia.org/wiki/Josiah_S._Carberry` is a `Person` it should not also be a [CreativeWork] (although this example is a fictional person!).
+Care should be taken to not describe two conceptually different contextual entities with the same identifier - e.g. if `https://en.wikipedia.org/wiki/Josiah_S._Carberry` is a [Person] it should not also be a [CreativeWork] (although this example is a fictional person!).
 
-Where a related URL exist that may not be unique enough to serve as identifier, it can instead be added to a contextual entity using [url].
+Where a related URL exist that may not be unique enough to serve as identifier, it can instead be added to a contextual entity using the property [url].
 
 
-See the [appendix on JSON-LD identifiers](appendix/jsonld.html#describing-entities-in-json-ld) for details.
+See the [appendix on JSON-LD identifiers](appendix/jsonld.md#describing-entities-in-json-ld) for details.
 
 ## People
 

--- a/docs/1.1-DRAFT/data-entities.md
+++ b/docs/1.1-DRAFT/data-entities.md
@@ -108,8 +108,8 @@ An example _RO-Crate JSON-LD_ for the above would be as follows:
 ### Adding detailed descriptions of encodings
 
 The above example provides a media type for the file `cp7glop.ai` - which is
-useful as it may not be apparent that the file readable as a PDF file from the
-extension. To add more detail, encodings SHOULD be linked using a [PRONOM]
+useful as it may not be apparent that the file is readable as a PDF file from the
+extension alone. To add more detail, encodings SHOULD be linked using a [PRONOM]
 identifier to a _Contextual Entity_ of `@type` [WebSite].
 
 ``` json

--- a/docs/1.1-DRAFT/data-entities.md
+++ b/docs/1.1-DRAFT/data-entities.md
@@ -228,7 +228,6 @@ Example of an RO-Crate including a _File Data Entity_ external to the _RO-Crate 
     "@type": "File",
     "name": "Survey responses",
     "contentSize": "26452",
-    "description": "Survey responses",
     "encodingFormat": "text/csv"
   },
   {

--- a/docs/1.1-DRAFT/data-entities.md
+++ b/docs/1.1-DRAFT/data-entities.md
@@ -246,9 +246,9 @@ Additional care SHOULD be taken to improve persistence and long-term preservatio
 in an RO-Crate as they can be more difficult to archive or move along with the _RO-Crate root_, and
 may change intentionally or unintentionally leaving the RO-Crate with incomplete or outdated information.
 
-File Data Entries with an `@id` URI outside the _RO-Crate Root_ SHOULD at the time of RO-Crate creation be directly downloadable by a simple retrieval (e.g. HTTP GET), permitting redirections and HTTP/HTTPS authentication. For instance, in the example above, <https://zenodo.org/record/3541888> and <https://doi.org/10.5281/zenodo.3541888> cannot be used as `@id` above as retrieving these URLS give a HTML landing page rather than the desired PDF as indicated by `encodingFormat`.
+File Data Entries with an `@id` URI outside the _RO-Crate Root_ SHOULD at the time of RO-Crate creation be directly downloadable by a simple retrieval (e.g. HTTP GET), permitting redirections and HTTP/HTTPS authentication. For instance, in the example above, <https://zenodo.org/record/3541888> and <https://doi.org/10.5281/zenodo.3541888> cannot be used as `@id` above as retrieving these URLs give a HTML landing page rather than the desired PDF as indicated by `encodingFormat`.
 
-As files on the web may change, the timestamp property `sdDatePublished` SHOULD be included to indicate when the absolute URL was accessed, and derived metadata like `encodingFormat` and `contentSize` was considered to be representative:
+As files on the web may change, the timestamp property [sdDatePublished] SHOULD be included to indicate when the absolute URL was accessed, and derived metadata like [encodingFormat] and [contentSize] were considered to be representative:
 
 ```json
   {

--- a/docs/1.1-DRAFT/metadata.md
+++ b/docs/1.1-DRAFT/metadata.md
@@ -35,9 +35,9 @@ RO-Crate aims to capture and describe the [Research Object][ResearchObject] usin
 
 The _RO-Crate Metadata File Descriptor_ contains the metadata that describes the RO-Crate and its content, in particular:
 
-* Root Data Entity - the `Dataset` itself, a gathering of data
-* Data Entities - the _data_ payload, in the form of files and folders
-* Contextual Entities - related things in the world (e.g. people, organizations, places), providing provenance for the data entities and the RO-Crate.
+* [Root Data Entity](root-data-entity.md) - the RO-Crate `Dataset` itself, a gathering of data
+* [Data Entities](data-entities.md) - the _data_ payload, in the form of files and folders
+* [Contextual Entities](contextual-entities.md) - related things in the world (e.g. people, organizations, places), providing provenance for the data entities and the RO-Crate.
 
 This machine-readable metadata can also be represented for human consumption in the _RO-Crate Website_, linking to data and Web resources.
 
@@ -61,9 +61,13 @@ RO-Crate realize these principles using a particular set of technologies and bes
 
 ## Base metadata standard: Schema.org
 
-[Schema.org] is the base metadata standard for RO-Crate. Schema.org was chosen because it is widely used on the World Wide Web and supported by search engines, on the assumption that discovery is likely to be maximized if search engines index the content. NOTE: As far as we know there is no alternative, well-maintained linked-data schema for research data with the coverage needed for this project - i.e. a single standard for expressing all the examples presented in this specification.
+[Schema.org] is the base metadata standard for RO-Crate. Schema.org was chosen because it is widely used on the World Wide Web and supported by search engines, on the assumption that discovery is likely to be maximized if search engines index the content. 
 
-RO-Crate relies heavily on [Schema.org] using a constrained subset of [JSON-LD], and this document gives opinionated recommendations on how to represent the metadata using existing [linked data] best practices.
+```note
+As far as we know there is no alternative, well-maintained linked-data schema for research data with the coverage needed for this project - i.e. a single standard for expressing all the examples presented in this specification.
+```
+
+RO-Crate relies heavily on [Schema.org], using a constrained subset of [JSON-LD], and this document gives opinionated recommendations on how to represent the metadata using existing [linked data] best practices.
 
 ### Differences from Schema.org
 

--- a/docs/1.1-DRAFT/metadata.md
+++ b/docs/1.1-DRAFT/metadata.md
@@ -135,7 +135,7 @@ However, as RO-Crate uses the [Linked Data principles], adopters of RO-Crate are
 
 ## Future coverage
 
-A future version of this specification will allow for variable-level assertions: In some cases, e.g. for tabular data, additional metadata may be provided about the structure and variables within a given file see the use case [Describe a tabular data file directly in RO-Crate metadata](https://github.com/ResearchObject/ro-crate/issues/27) for work-in-progress.
+A future version of this specification aim to cater for variable-level assertions: In some cases, e.g. for tabular data, additional metadata may be provided about the structure and variables within a given file. See the use case [Describe a tabular data file directly in RO-Crate metadata](https://github.com/ResearchObject/ro-crate/issues/27) for work-in-progress.
 
 
 ## Recommended Identifiers

--- a/docs/1.1-DRAFT/metadata.md
+++ b/docs/1.1-DRAFT/metadata.md
@@ -71,7 +71,7 @@ RO-Crate relies heavily on [Schema.org], using a constrained subset of [JSON-LD]
 
 ### Differences from Schema.org
 
-Generally, the standard class and property names (_terms_) from [Schema.org] should be used. However, RO-Crate uses variant names for some elements, specifically:
+Generally, the standard _type_ and _property_ names (_terms_) from [Schema.org] should be used. However, RO-Crate uses variant names for some elements, specifically:
 
 * `File` is mapped to <http://schema.org/MediaObject> which was chosen as a compromise as it has many of the properties that are needed to describe a generic file. Future versions of Schema.org or a research data extension may re-define `File`.
 * `Journal` is mapped to <http://schema.org/Periodical>.

--- a/docs/1.1-DRAFT/provenance.md
+++ b/docs/1.1-DRAFT/provenance.md
@@ -145,7 +145,7 @@ In the below example, an image with the `@id` of `pics/2017-06-11%2012.56.14.jpg
 If representing command lines, double escape `\\` so that JSON preserves the `\` character.
 ```
 
-If multiple [SoftwareApplication]s have been used in composition, such as from a script or workflow, then the `CreateAction` SHOULD rather reference a [SoftwareSourceCode] which can be further described as explained in the [Workflows and scripts](workflows.md) section.
+If multiple [SoftwareApplication]s have been used in composition, such as from a script or workflow, then the `CreateAction`'s [instrument] SHOULD rather reference a [SoftwareSourceCode] which can be further described as explained in the [Workflows and scripts](workflows.md) section.
 
 ## Recording changes to RO-Crates
 
@@ -157,7 +157,7 @@ An Action which creates new _Data entities_ - for example, the creation of a new
 
 An Action SHOULD have a [name] and MAY have a [description].
 
-An Action SHOULD have an [endTime], which MUST be in ISO 8601 date format and SHOULD be specified to at least the precision of a day. An Action MAY have a [startTime] meeting the same specifications.
+An Action SHOULD have an [endTime], which MUST be in [ISO 8601 date format][DateTime] and SHOULD be specified to at least the precision of a day. An Action MAY have a [startTime] meeting the same specifications.
 
 An Action SHOULD have a human [agent] who was responsible for authorizing the action, and MAY have an [instrument] which associates the action with a particular piece of software (for example, the content management system or data catalogue through which an update was approved) which SHOULD be of `@type` SoftwareApplication.
 

--- a/docs/1.1-DRAFT/provenance.md
+++ b/docs/1.1-DRAFT/provenance.md
@@ -44,7 +44,7 @@ To specify which **equipment** was used to create or update a [Data Entity](data
 ```
 
 
-Uses [CreateAction] and [UpdateAction] class to model the contributions of _Context Entities_ of type [Person] or [Organization] in the creation of files.
+Uses [CreateAction] and [UpdateAction] type to model the contributions of _Context Entities_ of type [Person] or [Organization] in the creation of files.
 
 In this example the CreateAction has a human [agent], the object is a Place (a cave) and the Hovermap drone is the [instrument] used in the file creation event.
 

--- a/docs/1.1-DRAFT/provenance.md
+++ b/docs/1.1-DRAFT/provenance.md
@@ -84,7 +84,7 @@ In this example the CreateAction has a human [agent], the object is a Place (a c
 
 ## Software used to create files
 
-To specify which software was used to create or update a file the software application SHOULD be represented with an entity of type [SoftwareApplication], with a [version] property, e.g. from `tool --version`.
+To specify which software was used to create or update a file, the software application SHOULD be represented with an entity of type [SoftwareApplication], with a [version] property, e.g. from `tool --version`.
 
 For example:
 
@@ -98,9 +98,9 @@ For example:
 }
 ```
 
-The software SHOULD be associated with the [File] it created using a [CreateAction] with the [File] referenced by a [result] property. Any input files SHOULD be referenced by the [object] property.
+The software SHOULD be associated with the [File](s) (or other [data entities](data-entities.md)) it created as an [instrument] of a [CreateAction], with the [File] referenced by a [result] property. Any input files SHOULD be referenced by the [object] property.
 
-In the below example, an image with the `@id` of `pics/2017-06-11%2012.56.14.jpg` was transformed into an new image `pics/sepia_fence.jpg` using the _ImageMagick_ software application. Actions MAY have human-readable names, which MAY be machine generated for use at scale.
+In the below example, an image with the `@id` of `pics/2017-06-11%2012.56.14.jpg` was transformed into an new image `pics/sepia_fence.jpg` using the _ImageMagick_ software application as "instrument". Actions MAY have human-readable names, which MAY be machine generated for use at scale.
 
 ```json
 {
@@ -142,8 +142,10 @@ In the below example, an image with the `@id` of `pics/2017-06-11%2012.56.14.jpg
 ```
 
 ```tip
-Double escape `\\` so that JSON preserves the `\` character from the command line.
+If representing command lines, double escape `\\` so that JSON preserves the `\` character.
 ```
+
+If multiple [SoftwareApplication]s have been used in composition, such as from a script or workflow, then the `CreateAction` SHOULD rather reference a [SoftwareSourceCode] which can be further described as explained in the [Workflows and scripts](workflows.md) section.
 
 ## Recording changes to RO-Crates
 

--- a/docs/1.1-DRAFT/provenance.md
+++ b/docs/1.1-DRAFT/provenance.md
@@ -233,12 +233,12 @@ To record curation actions which modify a [File] within a Dataset - for example,
 
 To describe an export from a Digital Library or repository system, RO-Crate uses the _Portland Common Data Model_ ([PCDM]). 
 
-A [Contextual Entity](contextual-entities.md) from a repository, representing an abstract entity such as a person, or a work, or a place SHOULD have a`@type` of [RepositoryObject], in addition to any other types. 
+A [Contextual Entity](contextual-entities.md) from a repository, representing an abstract entity such as a person, or a work, or a place SHOULD have a `@type` of [RepositoryObject], in addition to any other types. 
 
-Objects MAY be grouped together in [RepositoryCollection]s with [hasMember] pointing to the the [RepositoryObject]. 
+Objects MAY be grouped together in [RepositoryCollection]s with [hasMember] pointing to the [RepositoryObject]. 
 
 ```note
-The terms `RepositoryObject` and `RepositoryCollection` are renamed to avoid collision between other vocabularies and the PCDM terms `Collection` and `Object`. The term `RepositoryFile` is renamed to avoid clash with RO-Crate's `File` mapping to <http://schema.org/MediaObject>.
+The terms `RepositoryObject` and `RepositoryCollection` are renamed in RO-Crate to avoid collision between other vocabularies and the PCDM terms `Collection` and `Object`. The term `RepositoryFile` is renamed to avoid clash with RO-Crate's `File` mapping to <http://schema.org/MediaObject>.
 ```
 
 ```warning

--- a/docs/1.1-DRAFT/provenance.md
+++ b/docs/1.1-DRAFT/provenance.md
@@ -165,9 +165,9 @@ An Action's status MAY be recorded in an [actionStatus] property. The status mus
 
 An Action which has failed MAY record any error information in an [error] property.
 
-[UpdateAction] SHOULD only be used for actions which affect the DataSet as a whole, such as movement through a workflow.
+[UpdateAction] SHOULD only be used for actions which affect the Dataset as a whole, such as movement through a workflow.
 
-To record curation actions which modify a [File] within a DataSet - for example, by correcting or enhancing metadata - the old version of the [File] SHOULD be retained, and a [CreateAction] added which has the original version as its [object] and the new version as its [result].
+To record curation actions which modify a [File] within a Dataset - for example, by correcting or enhancing metadata - the old version of the [File] SHOULD be retained, and a [CreateAction] added which has the original version as its [object] and the new version as its [result].
 
 ```json
 {

--- a/docs/1.1-DRAFT/root-data-entity.md
+++ b/docs/1.1-DRAFT/root-data-entity.md
@@ -109,7 +109,7 @@ The _Root Data Entity_ MUST have the following properties:
 *  `@id`:  MUST end with `/` and SHOULD be the string `./`
 *  `name`: SHOULD identify the dataset to humans well enough to disambiguate it from other RO-Crates
 *  `description`: SHOULD further elaborate on the name to provide a summary of the context in which the dataset is important.
-*  `datePublished`: MUST be a string in ISO 8601 date format and SHOULD be specified to at least the precision of a day, MAY be a timestamp down to the millisecond. 
+*  `datePublished`: MUST be a string in [ISO 8601 date format][DateTime] and SHOULD be specified to at least the precision of a day, MAY be a timestamp down to the millisecond. 
 *  `license`: SHOULD link to a _Contextual Entity_ in the _RO-Crate Metadata File_ with a name and description. MAY have a URI (eg for Creative Commons or Open Source licenses). MAY, if necessary be a textual description of how the RO-Crate may be used.
 
 ```note

--- a/docs/1.1-DRAFT/root-data-entity.md
+++ b/docs/1.1-DRAFT/root-data-entity.md
@@ -69,7 +69,7 @@ start with `https://w3id.org/ro/crate/`.
 ### Finding the Root Data Entity
 
 Consumers processing the RO-Crate as an JSON-LD graph can thus reliably find
-the the _Root Data Entity_ by following this algorithm:
+the _Root Data Entity_ by following this algorithm:
 
 1. For each entity in `@graph` array
 2. ..if the `conformsTo` property is a URI that starts with `https://w3id.org/ro/crate/`
@@ -77,11 +77,15 @@ the the _Root Data Entity_ by following this algorithm:
 4. For each entity in `@graph` array
 5. .. if the entity has an `@id` URI that matches _root_ return it
 
+See also the appendix on
+[finding RO-Crate Root in RDF triple stores](appendix/relative-uris.md#finding-ro-crate-root-in-rdf-triple-stores).
+
 ### Purpose of Metadata File
 
 To ensure a base-line interoperability between RO-Crates, and for an RO-Crate to
 be considered a _Valid RO-Crate_, a minimum set of metadata is required for the
-_Root Data Entity_. As stated above the _RO-Crate Metadata File_ is not an
+_Root Data Entity_. As [stated earlier](structure.md#self-describing-and-self-contained)
+the _RO-Crate Metadata File_ is not an
 exhaustive manifest or inventory, that is, it does not necessarily list or
 describe all files in the package. For this reason, there are no minimum
 metadata requirements in terms of describing [Data Entities](data-entities.md) (files and folders)

--- a/docs/1.1-DRAFT/structure.md
+++ b/docs/1.1-DRAFT/structure.md
@@ -52,7 +52,7 @@ RO-Crates can be _nested_ by including payload directories that themselves conta
 * In new RO-Crates the _RO-Crate Metadata File_ MUST be named `ro-crate-metadata.json` and appear in the _RO-Crate Root_
 * The _RO-Crate Metadata File_ MUST contain _RO-Crate JSON-LD_; a valid [JSON-LD 1.0] document in [flattened]  and [compacted] form
 * The _RO-Crate JSON-LD_ SHOULD use the _RO-Crate JSON-LD Context_ <https://w3id.org/ro/crate/1.1-DRAFT/context> by reference.
-* If an RO-Crate conforming to version 1.0 or earlier contains a file named `ro-crate-metadata.jsonld` instead of `ro-crate-metadata.json` then processing software should treat this as the _RO-Crate Metadata File_. If the crate is updated then the file should SHOULD be renamed to `ro-crate-metadata.json` and the _RO-Crate Metadata File Descriptor_ SHOULD be updated to to reference it, with an up to date [conformsTo] property naming an appropriate version of this specification. 
+* If an RO-Crate conforming to version 1.0 or earlier contains a file named `ro-crate-metadata.jsonld` instead of `ro-crate-metadata.json` then processing software should treat this as the _RO-Crate Metadata File_. If the crate is updated then the file SHOULD be renamed to `ro-crate-metadata.json` and the _RO-Crate Metadata File Descriptor_ SHOULD be updated to to reference it, with an up to date [conformsTo] property naming an appropriate version of this specification. 
 
 
 [JSON-LD](https://json-ld.org/) is a structured form of [JSON] that can represent a _Linked Data_ graph. 
@@ -102,7 +102,7 @@ If present in the root directory, `ro-crate-preview.html` MUST:
   - If it has a [name] property, provide a link to its HTML version.
   - If it does not have a name (e.g. a [GeoCoordinates] location), show it embedded in the HTML for the entity.
   - For external URI values, provide a link.
-* For keys that resolve in the `RO-Crate JSON-LD Context` to a URI, indicate this (the simplest way is to link the key to its definition.
+* For keys that resolve in the `RO-Crate JSON-LD Context` to a URI, indicate this (the simplest way is to link the key to its definition).
 * If there is sufficient metadata, contain a prominent _“Cite-as”_ text with a natural language data citation (see for example the [FORCE11 Data Citation Principles]).
 * If there are additional resources necessary to render the preview (e.g. CSS, JSON, HTML), link to them in a subdirectory `ro-crate-preview-files/`
 

--- a/docs/1.1-DRAFT/terminology.md
+++ b/docs/1.1-DRAFT/terminology.md
@@ -33,15 +33,21 @@ _RO-Crate Metadata File_: A JSON-LD file stored as `ro-crate-metadata.json` in t
 
 _RO-Crate Website_: Human-readable HTML pages which describe the RO-Crate (i.e. the _Root Data Entity_, its _Data Entities_ and _Context Entities_), with a home-page at `ro-crate-preview.html` (any additional files reside in `ro-crate-preview_files/`)
 
+_Entity_: An identified object, which have a given _type_ and may be described using a set of _properties_.
+
+_Type_: A classification of objects or their descriptions. The type (or _class_) is identified by a _URI_, mapped to a _key_ by _JSON-LD_.
+
+_Property_: A relationship from one _entity_ to another entity, or to a _value_. The type of relationship is identified by a _URI_, mapped to a _key_ by _JSON-LD_.
+
 _Data Entity_: A JSON-LD representation, in the _RO-Crate Metadata File_, of a directory, file or other resource contained or described by the RO-Crate.
 
-_Root Data Entity_: A _Data Entity_ of type [Dataset], representing the RO-Crate as a whole.  
+_Root Data Entity_: A _Data Entity_ of _type_ [Dataset], representing the RO-Crate as a whole.  
 
 _RO-Crate Metadata File Descriptor_: A _Contextual Entity_ of type [CreativeWork], which describes the _RO-Crate Metadata File_ and links it to the _Root Data Entity_.
 
 _JSON-LD_: A JSON-based file format for storing _Linked Data_. This document assumes [JSON-LD 1.0]. JSON-LD use a _context_ to map from JSON keys to _URIs_.
 
-_JSON_: The _JavaScript Object Notation (JSON) Data Interchange Format_ as defined by [RFC 7159]; a structured text file format that can be programmatically consumed and generated in a wide range of programming languages. The main JSON structures are _objects_ (`{}`), _arrays_ (`[]`) and _values_ (`""`).
+_JSON_: The _JavaScript Object Notation (JSON) Data Interchange Format_ as defined by [RFC 7159]; a structured text file format that can be programmatically consumed and generated in a wide range of programming languages. The main JSON structures are _objects_ (`{}`) indexed by _keys_, sequential _arrays_ (`[]`) and literal _values_ (`""`).
 
 _Contextual Entity_: A JSON-LD representation of an entity associated with a _Data Entity_, needed to adequately describe that _Data Entity_. For example, a [Person], [Organization] (including research projects), item of equipment ([IndividualProduct]), [license] or any other _thing_ or _event_ that forms part of the metadata for a _Data Entity_ or supporting information.
 
@@ -57,9 +63,9 @@ _RO-Crate JSON-LD_: JSON-LD structure using the _RO-Crate JSON-LD Context_ and c
 
 ## Linked Data conventions
 
-Throughout this specification, RDF terms are referred to using the keys defined in the _RO-Crate JSON-LD Context_.
+Throughout this specification, RDF terms (_properties_, _types_) are referred to using the _keys_ defined in the _RO-Crate JSON-LD Context_.
 
-Following [Schema.org] practice, `property` names start with lowercase letters and `Class` names start with uppercase letters.
+Following [Schema.org] practice, `property` names start with lowercase letters and `Type` names start with uppercase letters.
 
 In the _RO-Crate Metadata File_ the RDF terms use their RO-Crate JSON-LD names as defined in the _RO-Crate JSON-LD Context_, which is available at <https://w3id.org/ro/crate/1.1-DRAFT/context>
 

--- a/docs/1.1-DRAFT/workflows.md
+++ b/docs/1.1-DRAFT/workflows.md
@@ -29,11 +29,11 @@ sort: 10
 
 # Workflows and Scripts
 
-Scientific workflows and scripts that were used (or can be used) to analyze or generate files contained in an RO-Crate MAY be embedded in an RO-Crate. See also provenance section on [Software used to create files](provenance.md#software-used-to-create-files).
+Scientific workflows and scripts that were used (or can be used) to analyze or generate files contained in an RO-Crate MAY be embedded in an RO-Crate. See also the Provenance section on [Software Used to Create Files](provenance.md#software-used-to-create-files).
 
 _Workflows_ and _scripts_ SHOULD be described using [data entities](data-entities.md) of type [SoftwareSourceCode].
 
-The distinction between [SoftwareSourceCode] and [SoftwareApplication] for [software](provenance.md#software-used-to-create-files) is fluid, and comes down to availability and understandability. For instance, office spreadsheet applications are generally available and do not need further explanation (`SoftwareApplication`); while a Python script that is customized for a particular data analysis might be important to understand further and should therefore be included as `SoftwareSourceCode` in the RO-Crate dataset.
+The distinction between [SoftwareSourceCode] and [SoftwareApplication] for [software](provenance.md#software-used-to-create-files) is fluid, and comes down to availability and understandability. For instance, office spreadsheet applications are generally available and do not need further explanation (`SoftwareApplication`); while a Python script that is customized for a particular data analysis might be important to understand deeper and should therefore be included as `SoftwareSourceCode` in the RO-Crate dataset.
 
 ## Describing scripts and workflows
 

--- a/docs/1.1-DRAFT/workflows.md
+++ b/docs/1.1-DRAFT/workflows.md
@@ -29,7 +29,9 @@ sort: 10
 
 # Workflows and Scripts
 
-Scientific workflows and scripts that were used (or can be used) to analyze or generate files contained in an RO-Crate MAY be embedded in an RO-Crate. _Workflows_ and _scripts_ SHOULD be described using [data entities](data-entities.md) of type [SoftwareSourceCode].
+Scientific workflows and scripts that were used (or can be used) to analyze or generate files contained in an RO-Crate MAY be embedded in an RO-Crate. See also provenance section on [Software used to create files](provenance.md#software-used-to-create-files).
+
+_Workflows_ and _scripts_ SHOULD be described using [data entities](data-entities.md) of type [SoftwareSourceCode].
 
 The distinction between [SoftwareSourceCode] and [SoftwareApplication] for [software](provenance.md#software-used-to-create-files) is fluid, and comes down to availability and understandability. For instance, office spreadsheet applications are generally available and do not need further explanation (`SoftwareApplication`); while a Python script that is customized for a particular data analysis might be important to understand further and should therefore be included as `SoftwareSourceCode` in the RO-Crate dataset.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -52,6 +52,28 @@ Note that although section folders have a `README.md` (alternatively `index.md`)
 
 This is also helpful for navigating drafts as `exclude: true` does not show their sections in the left-hand menu.
 
+#### Admonition cards
+
+With jekyll-rtd-theme it is possible to insert colourful admonition cards to bring attention to caveats and best practices. 
+These are written as a Markdown code-block with the language set as `tip`, `note`, `warning` or `danger`, and can
+include a restricted set of Markdown.
+
+    ```tip
+    JSON-LD supports [many other features](https://json-ld.org/) that SHOULD NOT be used excessively.
+    ```
+
+Will be rendered in the style of:
+
+> **✅ Tip**
+> JSON-LD supports [many other features](https://json-ld.org/) that SHOULD NOT be used excessively.
+
+Try to keep the admonition card short, like a single paragraph.
+
+For the [Makefile](Makefile) rendering to PDF, a rudimentary [Pandoc filter](scripts/admonition.py)
+attempts to translate these blocks back to paragraph rendering, although they don't show up as a box. 
+See the [release procedure](RELEASE_PROCEDURE.md).
+
+
 #### Theme config
 
 The theme is locked to a fixed version in [_config.yml](_config.yml) to avoid unexpected upgrade surprises. This file also specifies some site-wide properties like copyright.

--- a/docs/_includes/references.liquid
+++ b/docs/_includes/references.liquid
@@ -128,6 +128,7 @@ This file is included by the others using this
 [contactPoint]: http://schema.org/contactPoint
 [contactType]: http://schema.org/contactType
 [contentLocation]: http://schema.org/contentLocation
+[contentSize]: http://schema.org/contentSize
 [contributor]: http://schema.org/contributor
 [copyrightHolder]: http://schema.org/copyrightHolder
 [creator]: http://schema.org/creator
@@ -162,6 +163,7 @@ This file is included by the others using this
 [sameAs]: http://schema.org/sameAs
 [sdLicense]: http://schema.org/sdLicense
 [sdPublisher]: http://schema.org/sdPublisher
+[sdDatePublished]: https://schema.org/sdDatePublished
 [startTime]: http://schema.org/startTime
 [temporalCoverage]: http://schema.org/temporalCoverage
 [thumbnail]: http://schema.org/thumbnail

--- a/docs/_includes/references.liquid
+++ b/docs/_includes/references.liquid
@@ -96,6 +96,7 @@ This file is included by the others using this
 [CreateAction]: http://schema.org/CreateAction
 [CreativeWork]: http://schema.org/CreativeWork
 [DataDownload]: http://schema.org/DataDownload
+[DateTime]: https://schema.org/DateTime
 [Dataset]: http://schema.org/Dataset
 [FailedActionStatus]: http://schema.org/FailedActionStatus
 [File]: http://schema.org/MediaObject

--- a/docs/_includes/references.liquid
+++ b/docs/_includes/references.liquid
@@ -2,10 +2,13 @@
 https://kramdown.gettalong.org/syntax.html#reference-links
 
 Be aware that this file is used by RO-Crate 1.1 and later
-versions of the specification.
+versions of the specification, 
+DO NOT DELETE entries and 
+DO NOT change VERSIONED links.
 
 This file is included by the others using this
-%include line (excluding comment/endcomment
+%include line (excluding comment/endcomment)
+and is also rendered into the end of the PDF.
 
 {% comment %}
   {% include references.liquid %}
@@ -87,10 +90,12 @@ This file is included by the others using this
 [BIBO ontology]: http://neologism.ecs.soton.ac.uk/bibo.html
 [ro-terms]: https://github.com/ResearchObject/ro-terms
 [function parameter definitions]: https://en.wikipedia.org/wiki/Parameter_(computer_programming)
+[Best Practice Recipes for Publishing RDF Vocabularies]: https://www.w3.org/TR/swbp-vocab-pub/
 
 [Action]: http://schema.org/Action
 [ActionStatusType]: http://schema.org/ActionStatusType
 [ActiveActionStatus]: http://schema.org/ActiveActionStatus
+[Class]: http://schema.org/Class
 [CompletedActionStatus]: http://schema.org/CompletedActionStatus
 [ComputerLanguage]: http://schema.org/ComputerLanguage
 [CreateAction]: http://schema.org/CreateAction
@@ -109,6 +114,7 @@ This file is included by the others using this
 [PotentialActionStatus]: http://schema.org/PotentialActionStatus
 [Place]: http://schema.org/Place
 [Product]: http://schema.org/Product
+[Property]: http://schema.org/Property
 [PropertyValue]: http://schema.org/PropertyValue
 [ScholarlyArticle]: http://schema.org/ScholarlyArticle
 [SoftwareApplication]: http://schema.org/SoftwareApplication


### PR DESCRIPTION
Following the 1.1.0 RC1 (see #109) I had another read through of the PDF and made smaller edits as I went along.

Notable changes:
* Citation example expanded https://github.com/ResearchObject/ro-crate/commit/12a675481ec2b9b9ce6eb1941b905ca364d7bab4
* Terminology adds property, type, entity https://github.com/ResearchObject/ro-crate/commit/cc10e284de7e7fd6c401cf6a2f2b037dc94884cc
* `author` can also be applied to CreativeWork https://github.com/ResearchObject/ro-crate/commit/e086b8b141daa93e8c280ea4a72f944c5d46f49c
* Provenance section on Software-used now points to Workflows section (and vice versa) https://github.com/ResearchObject/ro-crate/commit/5d898725f370301cbd113b9652739e366e706bca https://github.com/ResearchObject/ro-crate/commit/40de6c7ba9cddd487c6a4f9579cc009ef4868c5c
* `@id` should not include `../` https://github.com/ResearchObject/ro-crate/commit/74ef6f1cb65e37bfeb3aa39cf5d0fd7fd80b7e62
* More hyperlinks
* Various typos and inconsistencies fixed
* JSON fixes (extra/missing comma)
* Prisoner sentence example use consistent `vocab#term` style https://github.com/ResearchObject/ro-crate/commit/50daed0660272650686a8d48e60cdbaccb2a394d