### PR TITLE
RO-Crate Profile section

### DIFF
--- a/docs/1.2-DRAFT/context.jsonld
+++ b/docs/1.2-DRAFT/context.jsonld
@@ -2638,6 +2638,7 @@
           "retrievedOn": "http://purl.org/pav/retrievedOn",
           "retrievedBy": "http://purl.org/pav/retrievedBy",
           "conformsTo": "http://purl.org/dc/terms/conformsTo",
+          "sdConformsTo": "https://w3id.org/ro/terms#sdConformsTo",
           "@label": "http://www.w3.org/2000/01/rdf-schema#label",
           "pcdm": "http://pcdm.org/models#",
           "bibo": "http://purl.org/ontology/bibo/",

--- a/docs/1.2-DRAFT/metadata.md
+++ b/docs/1.2-DRAFT/metadata.md
@@ -117,6 +117,11 @@ These terms are being proposed by [Bioschemas profile ComputationalWorkflow 0.5-
 {: .note }
 > In this specification the proposed Bioschemas terms use the temporary <https://bioschemas.org/> namespace; future releases of RO-Crate may reflect mapping to the <http://schema.org/> namespace.
 
+Additional terms in RO-Crate's own [ro-terms vocabulary][ro-terms]:
+
+* `sdConformsTo` mapped to <https://w3id.org/ro/terms#sdConformsTo> (see [profiles](profiles.md))
+
+
 ## Summary of Coverage
 
 RO-Crate is simply a way to make metadata assertions about a set of files and folders that make up a _Dataset_. These assertions can be made at two levels:

--- a/docs/1.2-DRAFT/profiles.md
+++ b/docs/1.2-DRAFT/profiles.md
@@ -1,0 +1,107 @@
+---
+title: Profiles
+excerpt: |
+  Profiles of RO-Crates and their entities can be used to specialize and recommend
+  further which metadata types and properties are expected.
+nav_order: 9
+parent: RO-Crate 1.2-DRAFT 
+---
+    
+While RO-Crates can be considered general-purpose containers of arbitrary data and open-ended metadata, in practical use within a particular domain, application or framework, it will be beneficial to further constrain RO-Crate to a specific **profile**: a set of conventions, types and properties that one minimally can require and expect to be present in that subset of RO-Crates.
+
+Defining and conforming to such a profile enables reliable programmatic consumption of an RO-Crate’s content, as well as consistent creation, e.g. a form in a user interface form firmly suggest the required types and properties, and likewise a rendering of an RO-Crate can easier make rich UI components if it can reliably assume for instance that the [`Person`](contextual-entities.md#people) always has an `affiliation` to a [`Organization`](contextual-entities.md#organizations-as-values) which has a `url` - a restriction that may not be appropriate for all types of RO-Crates.
+
+The RO-Crate profile can also lock down serialization expectation, for instance using a particular [version of RO-Crate](https://www.researchobject.org/ro-crate/specification.html), [JSON-LD context](appendix/jsonld.md?highlight=@context#ro-crate-json-ld-context) or particular [packaging](appendix/implementation-notes.md#combining-with-other-packaging-schemes) like .zip or BagIt.
+
+## Declaring an RO-Crate profile
+
+A profile can be defined informally or formally, may be declared by an RO-Crate 
+in advance (explicit profile) or detected later (implicit profile). Profiles are identified 
+with URIs, which SHOULD be a permalink.
+
+<!--TODO: Could https://github.com/ResearchObject/ro-terms be used also for ad-hoc profiles? -->
+
+To explicitly declare that an RO-Crate conforms to a particular profile, add another [contextual entity](contextual-entities.md):
+
+```json
+{
+    "@id": "https://w3id.org/ro/curate/profile/cwl",
+    "@type": "CreativeWork",
+    "name": "Profile for Research Objects with CWL workflows"
+}
+```
+<!-- FIXME: Above permalink is to a SHACL of Wf4Ever RO Bundle, not RO-Crate.
+Make permalink for https://about.workflowhub.eu/Workflow-RO-Crate/ ? 
+-->
+
+Then expand the `conformsTo` declaration of the [metadata file descriptor](root-data-entity.md#ro-crate-metadata-file-descriptor) to be an array, adding the profile identifier:
+
+```json
+{
+    "@type": "CreativeWork",
+    "@id": "ro-crate-metadata.json",
+    "about": {"@id": "./"},
+    "conformsTo": [
+        {"@id": "https://w3id.org/ro/crate/1.2-DRAFT"},
+        {"@id": "https://w3id.org/ro/curate/profile/cwl"}
+    ]
+}
+```
+
+An RO-Crate can conform to multiple profiles at the same time.   
+
+## Which type of profile?
+
+As a starting point, an RO-Crate profile can be written down in structured human language, as exemplified by [Workflow RO-Crate](https://about.workflowhub.eu/Workflow-RO-Crate/) or indeed by the RO-Crate specification itself.
+
+For some uses of RO-Crate it may be beneficial to have a more **formal definition** of the profile, depending on the serialization requirements for the RO-Crate, and how open-ended or restricted the profile is intended to be.
+
+Machine-readable profiles SHOULD have a [encodingFormat](data-entities.md#adding-detailed-descriptions-of-encodings) declared:
+
+```json
+{
+    "@id": "https://w3id.org/ro/curate/profile/cwl",
+    "@type": "CreativeWork",
+    "name": "SHACL profile for Research Objects with CWL workflows",
+    "encodingFormat": [
+        "text/turtle",
+        { "@id": "https://www.nationalarchives.gov.uk/PRONOM/fmt/874" }
+    ]
+},
+{
+    "@id": "https://www.nationalarchives.gov.uk/PRONOM/fmt/874",
+    "@type": "WebSite",
+    "name": "Turtle",
+    "description": "Turtle (Terse RDF Triple Language) is a format for expressing data in the Resource Description Framework (RDF) data model.",
+    "url": "https://www.w3.org/TR/turtle/"
+}
+```
+
+Note here the use of the `url` field on the PRONOM file type to the W3C specification for the Turtle file format. Most structured formats for profiles will have a formal specification.
+
+### Declaring an entity's profile
+
+In some caes, the [encodingFormat](data-entities.md#adding-detailed-descriptions-of-encodings) of a profile or other data entities is not specific enough, because the file format is a generic structured data holder like JSON, XML or RDF. 
+
+In these cases we can go _turtles all the way down_, and declare the _profile of the profile_:
+
+```json
+{
+    "@id": "https://w3id.org/ro/curate/profile/cwl",
+    "@type": "CreativeWork",
+    "name": "SHACL profile for Research Objects with CWL workflows",
+    "encodingFormat": [
+        "text/turtle",
+        { "@id": "https://www.nationalarchives.gov.uk/PRONOM/fmt/874" }
+    ],
+    "conformsTo": { "@id": "https://www.w3.org/TR/shacl/"}
+},
+{
+    "@id": "https://www.w3.org/TR/shacl",
+    "@type": "WebSite",
+    "name": "Shapes Constraint Language (SHACL)"
+}
+```
+
+
+The above states that the CWL profile is declared in the Turtle syntax, following the profile [Shapes Constraint Language (SHACL)](https://www.w3.org/TR/shacl/).

--- a/docs/1.2-DRAFT/profiles.md
+++ b/docs/1.2-DRAFT/profiles.md
@@ -79,7 +79,8 @@ Machine-readable profiles SHOULD have a [encodingFormat](data-entities.md#adding
 
 Note here the use of the `url` field on the PRONOM file type to the W3C specification for the Turtle file format. Most structured formats for profiles will have a formal specification.
 
-### Declaring an entity's profile
+
+### Declaring a profile's profile
 
 In some caes, the [encodingFormat](data-entities.md#adding-detailed-descriptions-of-encodings) of a profile or other data entities is not specific enough, because the file format is a generic structured data holder like JSON, XML or RDF. 
 
@@ -103,5 +104,82 @@ In these cases we can go _turtles all the way down_, and declare the _profile of
 }
 ```
 
-
 The above states that the CWL profile is declared in the Turtle syntax, following the profile [Shapes Constraint Language (SHACL)](https://www.w3.org/TR/shacl/).
+
+
+### Declaring an entity's profile
+
+Profiles can be declared for any data entity. Even textual documents may be considered to be following a profile or guideline, for instance:
+
+```json
+{
+    "@id": "biosketch.docx",
+    "@type": "File",
+    "name": "NIH Biosketch for Alice W Land",
+    "encodingFormat": [
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        {"@id": "https://www.nationalarchives.gov.uk/PRONOM/fmt/412"}
+    ],
+    "conformsTo": {"@id": "https://grants.nih.gov/grants/forms/biosketch.htm"}
+},
+{
+    "@id": "https://www.nationalarchives.gov.uk/PRONOM/fmt/412",
+    "@type": "WebSite",
+    "name": "Microsoft Word for Windows 2007 onwards"
+}
+{
+    "@id": "https://grants.nih.gov/grants/forms/biosketch.htm",
+    "name": "Biosketch Format Pages, Instructions and Samples"
+}
+```
+
+The above states that the [data entity](data-entities.md) `biosketch.docx` is a Microsoft Word document that conforms to the profile for [NIH Biosketch](https://grants.nih.gov/grants/forms/biosketch.htm).
+
+<!-- TODO: Move to or reference from data-entities.md -->
+
+### Declaring an entity's metadata profile
+
+Occassionally it may be beneficial to declare that the _metadata_ of a single data or contextual entity is following a particular profile. This is different from above, because such a profile applies to its representation within the RO-Crate Metadata file, not its stored representation on disk.
+
+For instance, [workflows](workflows.md) are defined in their own `encodingFormat` and `programmingLanguage` depending on the engine that can execute it. But an RO-Crate _description_ of that workflow can separately follow the [Bioschemas ComputationalWorkflow profile](https://bioschemas.org/profiles/ComputationalWorkflow/), which can be indicated with `sdConformsTo`:
+
+```json
+{
+    "@id": "workflow/alignment.knime",  
+    "@type": ["File", "SoftwareSourceCode", "ComputationalWorkflow"],
+    "sdConformsTo": 
+        {"@id": "https://bioschemas.org/profiles/ComputationalWorkflow/1.0-RELEASE/"},
+    "encodingFormat": [
+        "application/xml",
+        {"@id": "https://www.nationalarchives.gov.uk/PRONOM/fmt/101"}
+    ],
+    "conformsTo": {"@id": "http://www.knime.org/XMLConfig_2008_09.xsd"},
+    "name": "Sequence alignment workflow",
+    "programmingLanguage": {"@id": "#knime"},
+    "creator": {"@id": "#alice"},
+    "dateCreated": "2020-05-23",
+    "license": { "@id": "https://spdx.org/licenses/CC-BY-NC-SA-4.0"},
+    "…": []
+}
+```
+
+The example above has been deliberately expanded to highlight the differene between:
+
+* `@type` says what **semantic type** of entity that [`workflow/alignment.knime`](https://github.com/ResearchObject/ro-crate/blob/master/examples/workflow-0.2.0/workflow/workflow.knime) is in the RO-Crate, a `ComputationalWorkflow` (specializing `SoftwareSourceCode`), also a [Data entity](data-etity.md) (`File`).
+* `sdConformsTo` indicates the **metadata profile**  JSON-LD description conforms to, that it should have `creator`, `dateCreated`, `license` etc.
+* `encodingFormat` indicates the **syntactic format** of the `.knime` file is an [XML file](https://www.nationalarchives.gov.uk/PRONOM/fmt/101)
+* `conformsTo` indicates the **profile** of the XMl file, an XML Schema that it formally conforms to - e.g. expecting `<config>` and `<element>` in a particular namespace
+* `programmingLanguage` indicates the **software platform** that can compile/run this workflow.
+
+Usually these different type/profile dimensions are not all required!
+
+### Combining formal profiles using RO-Crate
+
+Some profiles may have multiple requirements and multiple formalizations. For instance an RO-Crate profile can be defined using a combination of:
+
+* [JSON Schema](https://json-schema.org/) requiring a restricted JSON form of [RO-Crate JSON-LD](appendix/jsonld.md). May include restricted JSON forms for expressing selected [data](data-entities.md) and [contextual entities](contextual-entities.md) in a certain way.
+* RDF Shapes expressed in [ShEx](https://shex.io/) or [SHACL](https://www.w3.org/TR/shacl/) to check graph patterns like _`author` must be of `@type: Person` and have `affiliation` to a `@type: Organization` that has a `url` to a valid URL_
+* RO-Crate is packaged using a particular [BagIt profile](https://bagit-profiles.github.io/bagit-profiles-specification/), e.g. must be serialized as an `application/zip`
+* Human readable requirements, that expected folders like `test/` exists.
+
+For these cases it is recommended that `conformsTo` identifies another RO-Crate which has these multiple formalizations as data entities, indicating their individual `encodingFormat` etc.

--- a/docs/1.2-DRAFT/profiles.md
+++ b/docs/1.2-DRAFT/profiles.md
@@ -147,14 +147,15 @@ a graph-level (e.g. what types/properties) as well as serialization level
 Below are known schema types and their suggested
 [encodingFormat](data-entities.md#adding-detailed-descriptions-of-encodings) identifiers:
 
-| Name          | Media Type                | URI             |
-| ============= | ========================= | =============== | 
+| Name          | Media Type                | URI                        |
+| ------------- | ------------------------- | -------------------------- | 
 | JSON Schema   | `application/schema+json` | <https://json-schema.org/draft/2020-12/schema> |
 | Describo      | `application/json`        | <https://github.com/UTS-eResearch/describo/wiki/dsp-index> |
 | CheckMyCrate  | `application/json`        | <https://github.com/KockataEPich/CheckMyCrate#profiles> |
 | SHACL         | `text/turtle`             | <https://www.w3.org/TR/shacl/> |
 | ShEx          | `text/shex`               | <http://shex.io/shex-semantics/> |
 | BagIt Profile | `application/json`        | <https://bagit-profiles.github.io/bagit-profiles-specification/> |
+
 
 {: .tip }
 Some of the above schema languages are based on general data structure syntaxes 

--- a/docs/1.2-DRAFT/profiles.md
+++ b/docs/1.2-DRAFT/profiles.md
@@ -208,3 +208,74 @@ If conforming RO-Crates should be [packaged](https://www.researchobject.org/ro-c
 
 <!-- TODO: Make BagIt profile similar to https://w3id.org/ro/bagit -->
 
+#### Extension vocabularies
+
+A profile that [extends RO-Crate](appendix/jsonld.md#extending-ro-crate) SHOULD indicate
+which vocabulary/ontology it uses as a [DefinedTermSet]:
+
+```json
+{
+    "@id": "https://w3id.org/ro/terms/test#",
+    "@type": "DefinedTermSet",
+    "name": "Namespace for workflow testing metadata",
+    "url": "https://github.com/ResearchObject/ro-terms/tree/master/test",
+}
+```
+
+The `@id` of the vocabulary SHOULD be the _namespace_, 
+while `url` SHOULD go to a human-readable description of the vocabulary.
+
+#### Extension terms
+
+A profile that [extends RO-Crate](appendix/jsonld.md#extending-ro-crate) MAY indicate particular terms
+directly as [DefinedTerm] instances:
+
+```json
+{
+    "@id": "https://criminalcharacters.com/vocab#education",
+    "@type": "DefinedTerm",
+    "termCode": "education",
+    "name": "Literacy of prisoner",
+    "description": "Prison authorities would record the prisoner’s statement as to whether they could read and write.",
+    "url": "https://github.com/ResearchObject/ro-terms/tree/master/test",
+}
+```
+
+The `termCode` SHOULD be valid as a key in JSON-LD `@context` of conforming RO-Crates.
+
+
+#### JSON-LD Context
+
+A profile that have a corresponding JSON-LD `@context` (e.g. to map its extensions terms,
+or to suggest a version of RO-Crate's official context) SHOULD indicate the 
+context in the Profile Crate:
+
+```json
+{
+    "@id": "https://w3id.org/ro/crate/1.1/context",
+    "@type": "CreativeWork",
+    "name": "RO-Crate JSON-LD Context",
+    "encodingFormat": [
+        "application/ld+json",
+        {"@id": "http://www.w3.org/ns/json-ld#context"}
+    ],
+    "version": "1.1.1",
+}
+```
+
+The JSON-LD Context:
+
+* SHOULD have a _permalink_ (persistent identifier) as `@id`
+  - e.g. starting with <https://w3id.org/> <http://purl.org/>
+* SHOULD use `https` rather than `http` with a certificate commonly accepted by browsers
+* SHOULD have a `@id` URI that is _versioned_ with [`MAJOR.MINOR`][semver], e.g. `https://example.com/image-profile-2.4`
+* SHOULD have a descriptive [name]
+* MAY declare [version] according to [Semantic Versioning][semver]
+
+Note that the referenced context URI does _not_ have to match the `@context` of the Profile Crate itself.
+
+{: .tip }
+The `@context` MAY be the Profile Crate's Metadata JSON-LD file if 
+it is [resolvable](appendix/jsonld.md#ro-crate-json-ld-media-type)
+as media type `application/ld+json` over HTTP.
+

--- a/docs/1.2-DRAFT/profiles.md
+++ b/docs/1.2-DRAFT/profiles.md
@@ -139,9 +139,9 @@ The above states that the [data entity](data-entities.md) `biosketch.docx` is a 
 
 ### Declaring an entity's metadata profile
 
-Occassionally it may be beneficial to declare that the _metadata_ of a single data or contextual entity is following a particular profile. This is different from above, because such a profile applies to its representation within the RO-Crate Metadata file, not its stored representation on disk.
+Occassionally it may be beneficial to declare that the _metadata_ of a single data or contextual entity is following a particular profile. This is different from above, because such a profile applies to its representation within the RO-Crate Metadata file, not its representation as bytes on disk or the web.
 
-For instance, [workflows](workflows.md) are defined in their own `encodingFormat` and `programmingLanguage` depending on the engine that can execute it. But an RO-Crate _description_ of that workflow can separately follow the [Bioschemas ComputationalWorkflow profile](https://bioschemas.org/profiles/ComputationalWorkflow/), which can be indicated with `sdConformsTo`:
+For instance, [workflows](workflows.md) are defined in their own `encodingFormat` with a `programmingLanguage` depending on the engine that can execute it. But an RO-Crate _description_ of that workflow can separately follow the [Bioschemas ComputationalWorkflow profile](https://bioschemas.org/profiles/ComputationalWorkflow/), which can be indicated with `sdConformsTo`:
 
 ```json
 {
@@ -163,7 +163,7 @@ For instance, [workflows](workflows.md) are defined in their own `encodingFormat
 }
 ```
 
-The example above has been deliberately expanded to highlight the differene between:
+The example above has been deliberately expanded to highlight the difference between:
 
 * `@type` says what **semantic type** of entity that [`workflow/alignment.knime`](https://github.com/ResearchObject/ro-crate/blob/master/examples/workflow-0.2.0/workflow/workflow.knime) is in the RO-Crate, a `ComputationalWorkflow` (specializing `SoftwareSourceCode`), also a [Data entity](data-etity.md) (`File`).
 * `sdConformsTo` indicates the **metadata profile**  JSON-LD description conforms to, that it should have `creator`, `dateCreated`, `license` etc.
@@ -171,7 +171,8 @@ The example above has been deliberately expanded to highlight the differene betw
 * `conformsTo` indicates the **profile** of the XMl file, an XML Schema that it formally conforms to - e.g. expecting `<config>` and `<element>` in a particular namespace
 * `programmingLanguage` indicates the **software platform** that can compile/run this workflow.
 
-Usually these different type/profile dimensions are not all required!
+{: .tip }
+> Typically it would not be required to go to this level of detail!
 
 ### Combining formal profiles using RO-Crate
 
@@ -180,6 +181,6 @@ Some profiles may have multiple requirements and multiple formalizations. For in
 * [JSON Schema](https://json-schema.org/) requiring a restricted JSON form of [RO-Crate JSON-LD](appendix/jsonld.md). May include restricted JSON forms for expressing selected [data](data-entities.md) and [contextual entities](contextual-entities.md) in a certain way.
 * RDF Shapes expressed in [ShEx](https://shex.io/) or [SHACL](https://www.w3.org/TR/shacl/) to check graph patterns like _`author` must be of `@type: Person` and have `affiliation` to a `@type: Organization` that has a `url` to a valid URL_
 * RO-Crate is packaged using a particular [BagIt profile](https://bagit-profiles.github.io/bagit-profiles-specification/), e.g. must be serialized as an `application/zip`
-* Human readable requirements, that expected folders like `test/` exists.
+* Human readable requirements, e.g. that expected folders like `test/` exists.
 
-For these cases it is recommended that `conformsTo` identifies another RO-Crate which has these multiple formalizations as data entities, indicating their individual `encodingFormat` etc.
+For these cases it is recommended that `conformsTo` identifies another RO-Crate which in its own RO-Crate Metadata file has these multiple formalizations declared as data entities, indicating their individual `encodingFormat` etc.

--- a/docs/1.2-DRAFT/profiles.md
+++ b/docs/1.2-DRAFT/profiles.md
@@ -257,9 +257,15 @@ context in the Profile Crate:
     "name": "RO-Crate JSON-LD Context",
     "encodingFormat": [
         "application/ld+json",
-        {"@id": "http://www.w3.org/ns/json-ld#context"}
+        {"@id": "http://www.w3.org/ns/json-ld#Context"}
     ],
     "version": "1.1.1",
+},
+{
+    "@id": "http://www.w3.org/ns/json-ld#Context",
+    "@type": "Thing",
+    "name": "JSON-LD Context",
+    "url": "https://www.w3.org/TR/json-ld/"
 }
 ```
 
@@ -270,6 +276,7 @@ The JSON-LD Context:
 * SHOULD use `https` rather than `http` with a certificate commonly accepted by browsers
 * SHOULD have a `@id` URI that is _versioned_ with [`MAJOR.MINOR`][semver], e.g. `https://example.com/image-profile-2.4`
 * SHOULD have a descriptive [name]
+* SHOULD have a `encodingFormat` to the contextual entity `http://www.w3.org/ns/json-ld#Context`
 * MAY declare [version] according to [Semantic Versioning][semver]
 
 Note that the referenced context URI does _not_ have to match the `@context` of the Profile Crate itself.

--- a/docs/1.2-DRAFT/profiles.md
+++ b/docs/1.2-DRAFT/profiles.md
@@ -134,7 +134,7 @@ An optional machine-readable schema of the profile, for instance a [Describo](ht
 },
 {
     "@id": "https://github.com/UTS-eResearch/describo/wiki/dsp-index",
-    "@type": "WebSite",
+    "@type": "WebPage",
     "name": "Describo JSON profile"
 }
 ```
@@ -197,7 +197,7 @@ If conforming RO-Crates should be [packaged](https://www.researchobject.org/ro-c
 ```json
 {
    "@id": "https://w3id.org/ro/bagit/profile/0.3",
-   "@type": "WebSite",
+   "@type": "WebPage",
    "name":  "BagIt profile for RO-Crate in ZIP",
    "encodingFormat": [
         "application/json", 

--- a/docs/1.2-DRAFT/profiles.md
+++ b/docs/1.2-DRAFT/profiles.md
@@ -89,7 +89,7 @@ To resolve a Profile URI to a machine-readable _Profile Crate_, two approaches a
   Requesting `https://w3id.org/ro/profile/paradisec/0.1` with HTTP header  
   `Accept: application/ld+json;profile=https://w3id.org/ro/crate` redirects to the _RO-Crate Metadata file_
   `https://example.org/ro-profiles/paradisec-0.1.0/ro-crate-metadata.json`
-2. The above approach may fails (or returns a HTML page), e.g. for content-delivery networks that do not support content-negotiation. The fallback is to try resolving the path `./ro-crate-metadata.json` from the _resolved_ URI (after permalink redirects). For example:  
+2. The above approach may fail (or returns a HTML page), e.g. for content-delivery networks that do not support content-negotiation. The fallback is to try resolving the path `./ro-crate-metadata.json` from the _resolved_ URI (after permalink redirects). For example:  
 If permalink `https://w3id.org/ro/profile/paradisec/0.1` redirects to `https://example.org/ro-profiles/paradisec-0.1.0/`, then
 get `https://example.org/ro-profiles/paradisec-0.1.0/ro-crate-metadata.json`
 3. If none of these approaches worked, then this profile probably does not have a corresponding Profile Crate. For humans, display a hyperlink to its `@id` described by its `name`.

--- a/docs/1.2-DRAFT/profiles.md
+++ b/docs/1.2-DRAFT/profiles.md
@@ -225,7 +225,7 @@ which vocabulary/ontology it uses as a [DefinedTermSet]:
 The `@id` of the vocabulary SHOULD be the _namespace_, 
 while `url` SHOULD go to a human-readable description of the vocabulary.
 
-#### Extension terms
+#### Extension terms
 
 A profile that [extends RO-Crate](appendix/jsonld.md#extending-ro-crate) MAY indicate particular terms
 directly as [DefinedTerm] instances:

--- a/docs/1.2-DRAFT/profiles.md
+++ b/docs/1.2-DRAFT/profiles.md
@@ -6,35 +6,56 @@ excerpt: |
 nav_order: 9
 parent: RO-Crate 1.2-DRAFT 
 ---
+
+# RO-Crate profiles
     
 While RO-Crates can be considered general-purpose containers of arbitrary data and open-ended metadata, in practical use within a particular domain, application or framework, it will be beneficial to further constrain RO-Crate to a specific **profile**: a set of conventions, types and properties that one minimally can require and expect to be present in that subset of RO-Crates.
 
 Defining and conforming to such a profile enables reliable programmatic consumption of an RO-Crate’s content, as well as consistent creation, e.g. a form in a user interface form firmly suggest the required types and properties, and likewise a rendering of an RO-Crate can easier make rich UI components if it can reliably assume for instance that the [`Person`](contextual-entities.md#people) always has an `affiliation` to a [`Organization`](contextual-entities.md#organizations-as-values) which has a `url` - a restriction that may not be appropriate for all types of RO-Crates.
 
-The RO-Crate profile can also lock down serialization expectation, for instance using a particular [version of RO-Crate](https://www.researchobject.org/ro-crate/specification.html), [JSON-LD context](appendix/jsonld.md?highlight=@context#ro-crate-json-ld-context) or particular [packaging](appendix/implementation-notes.md#combining-with-other-packaging-schemes) like .zip or BagIt.
+As such RO-Crate Profiles can be considered a _duck typing_ mechanism for RO-Crates, but also as a classifier to indicate the crate's purpose, expectations and focus.
 
-## Declaring an RO-Crate profile
+## Publishing an RO-Crate profile
 
-A profile can be defined informally or formally, may be declared by an RO-Crate 
-in advance (explicit profile) or detected later (implicit profile). Profiles are identified 
-with URIs, which SHOULD be a permalink.
+An _RO-Crate profile_ is identified with a **Profile URI**.
 
-<!--TODO: Could https://github.com/ResearchObject/ro-terms be used also for ad-hoc profiles? -->
+Recommendations:
+* The profile URI MUST resolve to a human-readable _profile description_ (e.g. a HTML web page)
+  - The profile URI MAY have a corresponding machine-readable [_Profile Crate_](#profile-crate)
+* The profile URI SHOULD be a _permalink_ (persistent identifier)
+  - e.g. starting with <https://w3id.org/> <http://purl.org/> or <https://www.doi.org/>
+* The profile URI SHOULD be _versioned_ with [`MAJOR.MINOR`][semver], e.g. `http://example.com/image-profile-2.4`
+* The profile description SHOULD use key words MUST, MUST NOT, REQUIRED, SHALL, SHALL NOT, SHOULD, SHOULD NOT, RECOMMENDED, MAY, and OPTIONAL as described in [RFC2119].
 
-To explicitly declare that an RO-Crate conforms to a particular profile, add another [contextual entity](contextual-entities.md):
+Suggestions:
+* The profile MAY require/suggest which `@type` of [data entities](data-entities.md) and/or [contextual entities](contextual-entities.md) are expected.
+* The profile MAY require/suggest _properties_ expected per type of entity (e.g. _"Each [CreativeWork] must declare a [license]"_)
+* The profile MAY require/suggest a particular [version of RO-Crate](https://www.researchobject.org/ro-crate/specification.html).
+* The profile MAY recommend [RO-Crate extensions](appendix/jsonld.md#extending-ro-crate) with domain-specific terms and vocabularies.
+* The profile MAY require/suggest a particular [JSON-LD context](appendix/jsonld.md?highlight=@context#ro-crate-json-ld-context).
+* The profile MAY require/suggest a particular RO-Crate publishing method or [packaging](appendix/implementation-notes.md#combining-with-other-packaging-schemes) like .zip or BagIt.
+
+
+## Declaring conformance of an RO-Crate profile
+
+RO-Crate can describe a profile by adding it as an [contextual entity](contextual-entities.md):
 
 ```json
 {
-    "@id": "https://w3id.org/ro/curate/profile/cwl",
+    "@id": "https://w3id.org/ro/profile/paradisec/0.1",
     "@type": "CreativeWork",
-    "name": "Profile for Research Objects with CWL workflows"
+    "name": "Profile for RO-Crates for PARADISEC repository",
+    "version": "0.1.0"
 }
 ```
-<!-- FIXME: Above permalink is to a SHACL of Wf4Ever RO Bundle, not RO-Crate.
-Make permalink for https://about.workflowhub.eu/Workflow-RO-Crate/ ? 
--->
 
-Then expand the `conformsTo` declaration of the [metadata file descriptor](root-data-entity.md#ro-crate-metadata-file-descriptor) to be an array, adding the profile identifier:
+The contextual entity for a profile:
+
+* SHOULD have an absolute URI as `@id`
+* SHOULD have a descriptive [name]
+* MAY declare [version] according to [Semantic Versioning][semver]
+
+RO-Crates conforming to (or intending to conform to) such a profile SHOULD expand the `conformsTo` declaration of the [metadata file descriptor](root-data-entity.md#ro-crate-metadata-file-descriptor) to be an array and include the profile identifier:
 
 ```json
 {
@@ -43,144 +64,147 @@ Then expand the `conformsTo` declaration of the [metadata file descriptor](root-
     "about": {"@id": "./"},
     "conformsTo": [
         {"@id": "https://w3id.org/ro/crate/1.2-DRAFT"},
-        {"@id": "https://w3id.org/ro/curate/profile/cwl"}
+        {"@id": "https://w3id.org/ro/profile/paradisec/0.1"}
     ]
 }
 ```
 
-An RO-Crate can conform to multiple profiles at the same time.   
+It is valid for a crate to conform to multiple profiles.
 
-## Which type of profile?
-
-As a starting point, an RO-Crate profile can be written down in structured human language, as exemplified by [Workflow RO-Crate](https://about.workflowhub.eu/Workflow-RO-Crate/) or indeed by the RO-Crate specification itself.
-
-For some uses of RO-Crate it may be beneficial to have a more **formal definition** of the profile, depending on the serialization requirements for the RO-Crate, and how open-ended or restricted the profile is intended to be.
-
-Machine-readable profiles SHOULD have a [encodingFormat](data-entities.md#adding-detailed-descriptions-of-encodings) declared:
-
-```json
-{
-    "@id": "https://w3id.org/ro/curate/profile/cwl",
-    "@type": "CreativeWork",
-    "name": "SHACL profile for Research Objects with CWL workflows",
-    "encodingFormat": [
-        "text/turtle",
-        { "@id": "https://www.nationalarchives.gov.uk/PRONOM/fmt/874" }
-    ]
-},
-{
-    "@id": "https://www.nationalarchives.gov.uk/PRONOM/fmt/874",
-    "@type": "WebSite",
-    "name": "Turtle",
-    "description": "Turtle (Terse RDF Triple Language) is a format for expressing data in the Resource Description Framework (RDF) data model.",
-    "url": "https://www.w3.org/TR/turtle/"
-}
-```
-
-Note here the use of the `url` field on the PRONOM file type to the W3C specification for the Turtle file format. Most structured formats for profiles will have a formal specification.
+Note that although profile conformance is declared on the RO-Crate Metadata File `ro-crate-metadata.json`, the profile applies to the whole RO-Crate, and may cover aspects beyond the crate's JSON-LD serialization (e.g. identifiers, packaging, purpose).
 
 
-### Declaring a profile's profile
+## Profile Crate
 
-In some caes, the [encodingFormat](data-entities.md#adding-detailed-descriptions-of-encodings) of a profile or other data entities is not specific enough, because the file format is a generic structured data holder like JSON, XML or RDF. 
+While the Profile URI `@id` can resolve to a human-readable _profile description_, it can additionally be made to [resolve](#how-to-retrieve-a-profile-crate) to a _Profile Crate_.
 
-In these cases we can go _turtles all the way down_, and declare the _profile of the profile_:
+A **Profile Crate** is a type of RO-Crate that gathers resources which further define the profile. This allows formalizing alternative profile description for machine-readability, for instance for validation, but also additional resources like examples.
+
+
+### How to retrieve a Profile Crate
+
+To resolve a Profile URI to a machine-readable _Profile Crate_, two approaches are recommended to retrieve its [RO-Crate metadata file](root-data-entity.md#ro-crate-metadata-file-descriptor):
+
+1. [HTTP Content-negotiation](https://httpd.apache.org/docs/2.4/content-negotiation.html) for the [RO-Crate media type](appendix/jsonld.md#ro-crate-json-ld-media-type), for example:  
+  Requesting `https://w3id.org/ro/profile/paradisec/0.1` with HTTP header  
+  `Accept: application/ld+json;profile=https://w3id.org/ro/crate` redirects to the _RO-Crate Metadata file_
+  `https://example.org/ro-profiles/paradisec-0.1.0/ro-crate-metadata.json`
+2. The above approach may fails (or returns a HTML page), e.g. for content-delivery networks that do not support content-negotiation. The fallback is to try resolving the path `./ro-crate-metadata.json` from the _resolved_ URI (after permalink redirects). For example:  
+If permalink `https://w3id.org/ro/profile/paradisec/0.1` redirects to `https://example.org/ro-profiles/paradisec-0.1.0/`, then
+get `https://example.org/ro-profiles/paradisec-0.1.0/ro-crate-metadata.json`
+3. If none of these approaches worked, then this profile probably does not have a corresponding Profile Crate. For humans, display a hyperlink to its `@id` described by its `name`.
+
+<!-- TODO Make both examples above actually work! -->
+
+### What is included in the Profile Crate?
+
+Below follows the suggested [data entities](data-entities.md) to include in a Profile Crate:
+
+#### Profile description entity
+
+A Profile Crate MUST declare a human-readable _profile description_, which is [about] this Profile Crate:
 
 ```json
 {
-    "@id": "https://w3id.org/ro/curate/profile/cwl",
-    "@type": "CreativeWork",
-    "name": "SHACL profile for Research Objects with CWL workflows",
-    "encodingFormat": [
-        "text/turtle",
-        { "@id": "https://www.nationalarchives.gov.uk/PRONOM/fmt/874" }
-    ],
-    "conformsTo": { "@id": "https://www.w3.org/TR/shacl/"}
-},
-{
-    "@id": "https://www.w3.org/TR/shacl",
-    "@type": "WebSite",
-    "name": "Shapes Constraint Language (SHACL)"
-}
-```
-
-The above states that the CWL profile is declared in the Turtle syntax, following the profile [Shapes Constraint Language (SHACL)](https://www.w3.org/TR/shacl/).
-
-
-### Declaring an entity's profile
-
-Profiles can be declared for any data entity. Even textual documents may be considered to be following a profile or guideline, for instance:
-
-```json
-{
-    "@id": "biosketch.docx",
+    "@id": "index.html",
     "@type": "File",
-    "name": "NIH Biosketch for Alice W Land",
-    "encodingFormat": [
-        "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
-        {"@id": "https://www.nationalarchives.gov.uk/PRONOM/fmt/412"}
-    ],
-    "conformsTo": {"@id": "https://grants.nih.gov/grants/forms/biosketch.htm"}
-},
-{
-    "@id": "https://www.nationalarchives.gov.uk/PRONOM/fmt/412",
-    "@type": "WebSite",
-    "name": "Microsoft Word for Windows 2007 onwards"
-}
-{
-    "@id": "https://grants.nih.gov/grants/forms/biosketch.htm",
-    "name": "Biosketch Format Pages, Instructions and Samples"
+    "name": "PARADISEC profile description",
+    "about": "./",
 }
 ```
 
-The above states that the [data entity](data-entities.md) `biosketch.docx` is a Microsoft Word document that conforms to the profile for [NIH Biosketch](https://grants.nih.gov/grants/forms/biosketch.htm).
+The _profile description_ MAY be equivalent to the
+[RO-Crate Website](structure.md#ro-crate-website-ro-crate-previewhtml-and-ro-crate-preview_files)
+`ro-crate-preview.html`.
 
-<!-- TODO: Move to or reference from data-entities.md -->
+#### Profile Schema entity
 
-### Declaring an entity's metadata profile
 
-Occassionally it may be beneficial to declare that the _metadata_ of a single data or contextual entity is following a particular profile. This is different from above, because such a profile applies to its representation within the RO-Crate Metadata file, not its representation as bytes on disk or the web.
-
-For instance, [workflows](workflows.md) are defined in their own `encodingFormat` with a `programmingLanguage` depending on the engine that can execute it. But an RO-Crate _description_ of that workflow can separately follow the [Bioschemas ComputationalWorkflow profile](https://bioschemas.org/profiles/ComputationalWorkflow/), which can be indicated with `sdConformsTo`:
+An optional machine-readable schema of the profile, for instance a [Describo](https://arkisto-platform.github.io/describo/) [JSON profile](https://github.com/UTS-eResearch/describo/wiki/dsp-index):
 
 ```json
 {
-    "@id": "workflow/alignment.knime",  
-    "@type": ["File", "SoftwareSourceCode", "ComputationalWorkflow"],
-    "sdConformsTo": 
-        {"@id": "https://bioschemas.org/profiles/ComputationalWorkflow/1.0-RELEASE/"},
+    "@id": "https://raw.githubusercontent.com/UTS-eResearch/describo/v0.13.0/src/components/profiles/paradisec.describo.profile.json",
+    "@type": "File",
+    "name": "PARADISEC profile for Describo",
     "encodingFormat": [
-        "application/xml",
-        {"@id": "https://www.nationalarchives.gov.uk/PRONOM/fmt/101"}
-    ],
-    "conformsTo": {"@id": "http://www.knime.org/XMLConfig_2008_09.xsd"},
-    "name": "Sequence alignment workflow",
-    "programmingLanguage": {"@id": "#knime"},
-    "creator": {"@id": "#alice"},
-    "dateCreated": "2020-05-23",
-    "license": { "@id": "https://spdx.org/licenses/CC-BY-NC-SA-4.0"},
-    "…": []
+        "application/json", 
+        {"@id": "https://github.com/UTS-eResearch/describo/wiki/dsp-index"}
+    ]
+},
+{
+    "@id": "https://github.com/UTS-eResearch/describo/wiki/dsp-index",
+    "@type": "WebSite",
+    "name": "Describo JSON profile"
 }
 ```
 
-The example above has been deliberately expanded to highlight the difference between:
+A schema may formalize restrictions on the 
+[RO-Crate metadata file](root-data-entity.md#ro-crate-metadata-file-descriptor) on 
+a graph-level (e.g. what types/properties) as well as serialization level
+(e.g. use of JSON arrays).
 
-* `@type` says what **semantic type** of entity that [`workflow/alignment.knime`](https://github.com/ResearchObject/ro-crate/blob/master/examples/workflow-0.2.0/workflow/workflow.knime) is in the RO-Crate, a `ComputationalWorkflow` (specializing `SoftwareSourceCode`), also a [Data entity](data-etity.md) (`File`).
-* `sdConformsTo` indicates the **metadata profile**  JSON-LD description conforms to, that it should have `creator`, `dateCreated`, `license` etc.
-* `encodingFormat` indicates the **syntactic format** of the `.knime` file is an [XML file](https://www.nationalarchives.gov.uk/PRONOM/fmt/101)
-* `conformsTo` indicates the **profile** of the XMl file, an XML Schema that it formally conforms to - e.g. expecting `<config>` and `<element>` in a particular namespace
-* `programmingLanguage` indicates the **software platform** that can compile/run this workflow.
+Below are known schema types and their suggested
+[encodingFormat](data-entities.md#adding-detailed-descriptions-of-encodings) identifiers:
+
+| Name          | Media Type                | URI             |
+| ============= | ========================= | =============== | 
+| JSON Schema   | `application/schema+json` | <https://json-schema.org/draft/2020-12/schema> |
+| Describo      | `application/json`        | <https://github.com/UTS-eResearch/describo/wiki/dsp-index> |
+| CheckMyCrate  | `application/json`        | <https://github.com/KockataEPich/CheckMyCrate#profiles> |
+| SHACL         | `text/turtle`             | <https://www.w3.org/TR/shacl/> |
+| ShEx          | `text/shex`               | <http://shex.io/shex-semantics/> |
+| BagIt Profile | `application/json`        | <https://bagit-profiles.github.io/bagit-profiles-specification/> |
 
 {: .tip }
-> Typically it would not be required to go to this level of detail!
+Some of the above schema languages are based on general data structure syntaxes 
+like `application/json` and `text/turtle`, and therefore have a 
+generic  _Media Type_ accompanied by a specialized  _URI_.
 
-### Combining formal profiles using RO-Crate
 
-Some profiles may have multiple requirements and multiple formalizations. For instance an RO-Crate profile can be defined using a combination of:
+#### Software that works with the profile
 
-* [JSON Schema](https://json-schema.org/) requiring a restricted JSON form of [RO-Crate JSON-LD](appendix/jsonld.md). May include restricted JSON forms for expressing selected [data](data-entities.md) and [contextual entities](contextual-entities.md) in a certain way.
-* RDF Shapes expressed in [ShEx](https://shex.io/) or [SHACL](https://www.w3.org/TR/shacl/) to check graph patterns like _`author` must be of `@type: Person` and have `affiliation` to a `@type: Organization` that has a `url` to a valid URL_
-* RO-Crate is packaged using a particular [BagIt profile](https://bagit-profiles.github.io/bagit-profiles-specification/), e.g. must be serialized as an `application/zip`
-* Human readable requirements, e.g. that expected folders like `test/` exists.
+[Software](provenance.md#software-used-to-create-files) that may consume/validate/generate RO-Crates following this profile (potentially using the schema):
 
-For these cases it is recommended that `conformsTo` identifies another RO-Crate which in its own RO-Crate Metadata file has these multiple formalizations declared as data entities, indicating their individual `encodingFormat` etc.
+```json
+{
+      "@id": "https://arkisto-platform.github.io/describo/",
+      "@type": "SoftwareApplication",
+      "name": "Describo",
+      "version": "0.13.0",
+      "url": "https://arkisto-platform.github.io/describo/"
+}
+```
+
+#### Repositories that expect the profile
+
+A [repository](provenance.md#digital-library-and-repository-content) or collection within a repository that may accept/contain RO-Crates following this profile:
+
+```json
+{
+   "@id": "https://mod.paradisec.org.au/",
+   "@type": "RepositoryCollection",
+   "title":  "Modern PARADISEC demonstrator",   
+   "description": "PARADISEC curates digital material about small or endangered languages",
+   "publisher": {"@id": "https://paradisec.org.au/"}
+}
+```
+
+#### BagIt packaging
+
+If conforming RO-Crates should be [packaged](https://www.researchobject.org/ro-crate/1.1/appendix/implementation-notes.html#adding-ro-crate-to-bagit) according to a [BagIt profile] (e.g. must be serialized as an `application/zip`):
+
+```json
+{
+   "@id": "https://w3id.org/ro/bagit/profile/0.3",
+   "@type": "WebSite",
+   "name":  "BagIt profile for RO-Crate in ZIP",
+   "encodingFormat": [
+        "application/json", 
+        {"@id": "https://bagit-profiles.github.io/bagit-profiles-specification/"}
+   ]   
+}
+```
+
+<!-- TODO: Make BagIt profile similar to https://w3id.org/ro/bagit -->
+

--- a/docs/1.2-DRAFT/profiles.md
+++ b/docs/1.2-DRAFT/profiles.md
@@ -96,7 +96,7 @@ get `https://example.org/ro-profiles/paradisec-0.1.0/ro-crate-metadata.json`
 
 <!-- TODO Make both examples above actually work! -->
 
-### What is included in the Profile Crate?
+### What is included in the Profile Crate?
 
 Below follows the suggested [data entities](data-entities.md) to include in a Profile Crate:
 

--- a/docs/1.2-DRAFT/root-data-entity.md
+++ b/docs/1.2-DRAFT/root-data-entity.md
@@ -53,8 +53,8 @@ property referencing the _Root Data Entity_, which SHOULD have an `@id` of `./`.
     {
         "@type": "CreativeWork",
         "@id": "ro-crate-metadata.json",
-        "conformsTo": {"@id": "https://w3id.org/ro/crate/1.2-DRAFT"},
-        "about": {"@id": "./"}
+        "about": {"@id": "./"},
+        "conformsTo": {"@id": "https://w3id.org/ro/crate/1.2-DRAFT"}
     },
     
     {
@@ -71,16 +71,22 @@ SHOULD be a versioned permalink URI of the RO-Crate specification
 that the _RO-Crate JSON-LD_ conforms to. The URI SHOULD 
 start with `https://w3id.org/ro/crate/`. 
 
+```info
+The `conformsTo` property MAY be an array, to additionally indicate 
+specializing [RO-Crate profiles](profiles.md).
+```
+
 ### Finding the Root Data Entity
 
 Consumers processing the RO-Crate as an JSON-LD graph can thus reliably find
 the _Root Data Entity_ by following this algorithm:
 
 1. For each entity in `@graph` array
-2. ..if the `conformsTo` property is a URI that starts with `https://w3id.org/ro/crate/`
-3. ....from this entity's `about` object keep the `@id` URI as variable _root_
-4. For each entity in `@graph` array
-5. .. if the entity has an `@id` URI that matches _root_ return it
+2. ..for each value of the `conformsTo` property (if array) or its value (if string)
+3. ....if the value is a URI that starts with `https://w3id.org/ro/crate/`
+4. ......then from this entity's `about` object, keep the `@id` URI as variable _root_
+5. For each entity in `@graph` array
+6. .. if the entity has an `@id` URI that matches _root_ return it
 
 See also the appendix on
 [finding RO-Crate Root in RDF triple stores](appendix/relative-uris.md#finding-ro-crate-root-in-rdf-triple-stores).
@@ -136,8 +142,8 @@ The following _RO-Crate Metadata File_ represents a minimal description of an _R
  {
     "@type": "CreativeWork",
     "@id": "ro-crate-metadata.json",
-    "conformsTo": {"@id": "https://w3id.org/ro/crate/1.2-DRAFT"},
-    "about": {"@id": "./"}
+    "about": {"@id": "./"},
+    "conformsTo": {"@id": "https://w3id.org/ro/crate/1.2-DRAFT"}
  },  
  {
     "@id": "./",

--- a/docs/_includes/references.liquid
+++ b/docs/_includes/references.liquid
@@ -192,6 +192,8 @@ and is also rendered into the end of the PDF.
 [conditionsOfAccess]: http://schema.org/conditionsOfAccess
 [dateModified]: http://schema.org/dateModified
 [image]: http://schema.org/image
+[DefinedTerm]: http://schema.org/DefinedTerm
+[DefinedTermSet]: http://schema.org/DefinedTermSet
 [Grant]: http://schema.org/Grant
 [Project]: http://schema.org/Project
 [subjectOf]: http://schema.org/subjectOf

--- a/docs/_includes/references.liquid
+++ b/docs/_includes/references.liquid
@@ -17,7 +17,7 @@ and is also rendered into the end of the PDF.
 -->
 
 [BagIt]: https://en.wikipedia.org/wiki/BagIt
-[BagIt profile]: https://github.com/ruebot/bagit-profiles
+[BagIt profile]: https://bagit-profiles.github.io/bagit-profiles-specification
 [BIBO]: http://purl.org/ontology/bibo/interviewee
 [conformsTo]: http://purl.org/dc/terms/conformsTo
 [CURIE]: https://www.w3.org/TR/curie/
@@ -48,6 +48,7 @@ and is also rendered into the end of the PDF.
 [ResearchObject]: https://www.researchobject.org/
 [Schema.org]: http://schema.org
 [WorkflowSketch]: http://wf4ever.github.io/ro/2016-01-28/roterms/#Sketch
+[semver]: https://semver.org/spec/v2.0.0.html
 
 [Omeka]: https://omeka.org
 [Linked Data principles]: https://5stardata.info/en/

--- a/scripts/schema-context.py
+++ b/scripts/schema-context.py
@@ -121,6 +121,8 @@ ADDITIONAL = OrderedDict([
           ("funding", "http://schema.org/funding"),
           ## END 
 
+          ("sdConformsTo", "https://w3id.org/ro/terms#sdConformsTo")
+
           ("wasDerivedFrom", "http://www.w3.org/ns/prov#wasDerivedFrom"),
           
           ("importedFrom", "http://purl.org/pav/importedFrom"),


### PR DESCRIPTION
See issue #153. 

This adds a section to explain:
* What is an RO-Crate profile? (borrowed from https://www.researchobject.org/ro-crate/profiles.html)
* How to assign an RO-Crate profile
* How to type a formal RO-Crate profile (e.g. SHACL RDF Shape)
* How to assign profiles to other entities

It does *not* (yet) detail the [suggestions on how to formally specify an RO-Crate profile](https://docs.google.com/document/d/1-H6uhKQn-CFaB3WDwgqgQ6fJtQFNQzDA9VxEQq96kxc/edit#heading=h.xhuk5kjevxx2) as a new or adapted expression language. 

This proposal have multiple sections we may not want to all include:

* [Declaring an RO-Crate profile](https://github.com/ResearchObject/ro-crate/blob/profiles/docs/1.2-DRAFT/profiles.md#declaring-an-ro-crate-profile) – expanding `conformsTo` on Metadata File descriptor
* [Which type of profile?](https://github.com/ResearchObject/ro-crate/blob/profiles/docs/1.2-DRAFT/profiles.md#which-type-of-profile) – indicating `encodingFormat` for formal profiles
* [Declaring a profile's profile](https://github.com/ResearchObject/ro-crate/blob/profiles/docs/1.2-DRAFT/profiles.md#declaring-a-profiles-profile) –  – being more specific than `encodingFormat` - specifically to indicate the use of SHACL inside RDF Turtle.
* [Declaring an entity's profile](https://github.com/ResearchObject/ro-crate/blob/profiles/docs/1.2-DRAFT/profiles.md#declaring-an-entitys-profile) – showing how profiles can be applied to other data entities like a Word document
* [Declaring an entity's metadata profile](https://github.com/ResearchObject/ro-crate/blob/profiles/docs/1.2-DRAFT/profiles.md#declaring-an-entitys-metadata-profile) – adding a new `sdConformsTo` to show that the JSON-LD entity conforms
  - Full example with a workflow shows distinction between `@type`, `sdConformsTo`, `encodingFormat`, `conformsTo` and `programmingLanguage`
* [Combining formal profiles using RO-Crate](https://github.com/ResearchObject/ro-crate/blob/profiles/docs/1.2-DRAFT/profiles.md#combining-formal-profiles-using-ro-crate) – suggesting an RO-Crate itself can be a profile to aggregate multiple schemas etc. (not expanded to example)

Now I added all these sections mainly for discussion – I am not convinced we want all of them! And perhaps some should move to [data entity section on encoding](https://www.researchobject.org/ro-crate/1.1/data-entities.html#adding-detailed-descriptions-of-encodings) or at least be linked to from there. XML is a tricky one because there are many declared subformats of XML but even more undeclared ones.

I added `sdConformsTo` in [ro-terms](https://github.com/ResearchObject/ro-terms/blob/master/vocabulary.csv) as I realised https://www.researchobject.org/ro-crate/1.1/workflows.html#complying-with-bioschemas-computational-workflow-profile had then wrong use of `conformsTo` (the Knime file content does not conform!) - this could however be simplified by just lifting those profiles up to also be `conformsTo` on the `ro-crate-metadata.json` 

