### PR TITLE
Wrong knime file in the Complete Workflow Example

### DIFF
--- a/docs/1.1/workflows.md
+++ b/docs/1.1/workflows.md
@@ -250,7 +250,7 @@ The below is an example of an RO-Crate complying with the [Bioschemas Computatio
       "@id": "./",
       "@type": "Dataset",
       "hasPart": [
-          { "@id": "workflow/retropath.knime" }
+          { "@id": "workflow/alignment.knime" }
       ]
     },
     {

--- a/docs/1.2-DRAFT/workflows.md
+++ b/docs/1.2-DRAFT/workflows.md
@@ -248,7 +248,7 @@ The below is an example of an RO-Crate complying with the [Bioschemas Computatio
       "@id": "./",
       "@type": "Dataset",
       "hasPart": [
-          { "@id": "workflow/retropath.knime" }
+          { "@id": "workflow/alignment.knime" }
       ]
     },
     {


### PR DESCRIPTION
The hasPart points to a non-existing knime file in the RO-Crate.