### PR TITLE
Update bioschemas citations

### DIFF
--- a/docs/1.1/metadata.md
+++ b/docs/1.1/metadata.md
@@ -109,7 +109,7 @@ From [Dublin Core Terms](http://purl.org/dc/terms/) RO-Crate use:
 
 - `conformsTo` mapped to <http://purl.org/dc/terms/conformsTo>
 
-These terms are being proposed by [Bioschemas profile ComputationalWorkflow 0.5-DRAFT](https://bioschemas.org/profiles/ComputationalWorkflow/0.5-DRAFT-2020_07_21) and [FormalParameter 0.1-DRAFT](https://bioschemas.org/profiles/FormalParameter/0.1-DRAFT-2020_07_21) to be integrated into Schema.org: 
+These terms are being proposed by [Bioschemas profile ComputationalWorkflow 0.5-DRAFT][ComputationalWorkflow profile 0.5] and [FormalParameter 0.1-DRAFT][FormalParameter profile 0.1] to be integrated into Schema.org: 
 
 * `ComputationalWorkflow` mapped to <https://bioschemas.org/ComputationalWorkflow>
 * `FormalParameter` mapped to <https://bioschemas.org/FormalParameter>

--- a/docs/1.1/workflows.md
+++ b/docs/1.1/workflows.md
@@ -187,16 +187,16 @@ A workflow diagram may still be provided even if there is no programmatic `Softw
 ## Complying with Bioschemas Computational Workflow profile
 
 Data entities representing _workflows_ (`@type: ComputationalWorkflow`)
-SHOULD comply with the Bioschemas [ComputationalWorkflow profile],
+SHOULD comply with the Bioschemas [ComputationalWorkflow profile][ComputationalWorkflow profile 0.5],
 where possible. 
 
 When complying with this profile, the workflow data entities
 MUST describe these properties and their related contextual entities:
 [name], [programmingLanguage], [creator], [dateCreated], [license], [sdPublisher], [url], [version].
 
-The [ComputationalWorkflow profile] explains the above and list additional properties that a compliant [ComputationalWorkflow] data entity SHOULD include: [citation], [contributor], [creativeWorkStatus], [description], [funding], [hasPart], [isBasedOn], [keywords], [maintainer], [producer], [publisher], [runtimePlatform], [softwareRequirements], [targetProduct]
+The [ComputationalWorkflow profile][ComputationalWorkflow profile 0.5] explains the above and list additional properties that a compliant [ComputationalWorkflow][ComputationalWorkflow 0.1] data entity SHOULD include: [citation], [contributor], [creativeWorkStatus], [description], [funding], [hasPart], [isBasedOn], [keywords], [maintainer], [producer], [publisher], [runtimePlatform], [softwareRequirements], [targetProduct]
 
-A data entity conforming to the [ComputationalWorkflow profile] SHOULD declare the versioned profile URI using [conformsTo]:
+A data entity conforming to the [ComputationalWorkflow profile][ComputationalWorkflow profile 0.5] SHOULD declare the versioned profile URI using [conformsTo]:
 
 ```json
 { "@id": "workflow/alignment.knime",  
@@ -209,16 +209,16 @@ A data entity conforming to the [ComputationalWorkflow profile] SHOULD declare t
 
 ### Describing inputs and outputs
 
-The input and output _parameters_ for a workflow or script can be given with `input` and `output` to [FormalParameter]
+The input and output _parameters_ for a workflow or script can be given with `input` and `output` to [FormalParameter][FormalParameter 0.1]
 contextual entities. Note that this entity usually represent a _potential_ input/output value in a reusable
 workflow, much like [function parameter definitions] in general programming.
 
-If complying with the Bioschemas [FormalParameter profile],
-the _contextual entities_ for [FormalParameter], referenced by `input` or `output`, MUST describe: [name], [additionalType], [encodingFormat]
+If complying with the Bioschemas [FormalParameter profile][FormalParameter profile 0.1],
+the _contextual entities_ for [FormalParameter][FormalParameter 0.1], referenced by `input` or `output`, MUST describe: [name], [additionalType], [encodingFormat]
 
-The Bioschemas [FormalParameter profile] explains the above and lists additional properties that can be used, including [description], [valueRequired], [defaultValue] and [identifier].
+The Bioschemas [FormalParameter profile][FormalParameter profile 0.1] explains the above and lists additional properties that can be used, including [description], [valueRequired], [defaultValue] and [identifier].
 
-A contextual entity conforming to the [FormalParameter profile] SHOULD declare the versioned profile URI using [conformsTo], e.g.:
+A contextual entity conforming to the [FormalParameter profile][FormalParameter profile 0.1] SHOULD declare the versioned profile URI using [conformsTo], e.g.:
 
 ```json
 {
@@ -235,7 +235,7 @@ A contextual entity conforming to the [FormalParameter profile] SHOULD declare t
 
 ## Complete Workflow Example
 
-The below is an example of an RO-Crate complying with the [Bioschemas ComputationalWorkflow profile 0.5][ComputationalWorkflow profile]:
+The below is an example of an RO-Crate complying with the Bioschemas [ComputationalWorkflow profile 0.5]:
 
 ```json
 { "@context": "https://w3id.org/ro/crate/1.1/context", 

--- a/docs/1.2-DRAFT/context.jsonld
+++ b/docs/1.2-DRAFT/context.jsonld
@@ -2638,7 +2638,6 @@
           "retrievedOn": "http://purl.org/pav/retrievedOn",
           "retrievedBy": "http://purl.org/pav/retrievedBy",
           "conformsTo": "http://purl.org/dc/terms/conformsTo",
-          "sdConformsTo": "https://w3id.org/ro/terms#sdConformsTo",
           "@label": "http://www.w3.org/2000/01/rdf-schema#label",
           "pcdm": "http://pcdm.org/models#",
           "bibo": "http://purl.org/ontology/bibo/",

--- a/docs/1.2-DRAFT/metadata.md
+++ b/docs/1.2-DRAFT/metadata.md
@@ -106,7 +106,7 @@ From [Dublin Core Terms](http://purl.org/dc/terms/) RO-Crate use:
 
 - `conformsTo` mapped to <http://purl.org/dc/terms/conformsTo>
 
-These terms are being proposed by [Bioschemas profile ComputationalWorkflow 0.5-DRAFT](https://bioschemas.org/profiles/ComputationalWorkflow/0.5-DRAFT-2020_07_21) and [FormalParameter 0.1-DRAFT](https://bioschemas.org/profiles/FormalParameter/0.1-DRAFT-2020_07_21) to be integrated into Schema.org: 
+These terms are being proposed by [Bioschemas profile ComputationalWorkflow 0.5-DRAFT][ComputationalWorkflow profile 0.5] and [FormalParameter 0.1-DRAFT][FormalParameter profile 0.1] to be integrated into Schema.org: 
 
 * `ComputationalWorkflow` mapped to <https://bioschemas.org/ComputationalWorkflow>
 * `FormalParameter` mapped to <https://bioschemas.org/FormalParameter>

--- a/docs/1.2-DRAFT/metadata.md
+++ b/docs/1.2-DRAFT/metadata.md
@@ -117,10 +117,6 @@ These terms are being proposed by [Bioschemas profile ComputationalWorkflow 1.0-
 {: .note }
 > In this specification the proposed Bioschemas terms use the temporary <https://bioschemas.org/> namespace; future releases of RO-Crate may reflect mapping to the <http://schema.org/> namespace.
 
-Additional terms in RO-Crate's own [ro-terms vocabulary][ro-terms]:
-
-* `sdConformsTo` mapped to <https://w3id.org/ro/terms#sdConformsTo> (see [profiles](profiles.md))
-
 
 ## Summary of Coverage
 

--- a/docs/1.2-DRAFT/metadata.md
+++ b/docs/1.2-DRAFT/metadata.md
@@ -106,7 +106,7 @@ From [Dublin Core Terms](http://purl.org/dc/terms/) RO-Crate use:
 
 - `conformsTo` mapped to <http://purl.org/dc/terms/conformsTo>
 
-These terms are being proposed by [Bioschemas profile ComputationalWorkflow 0.5-DRAFT][ComputationalWorkflow profile 0.5] and [FormalParameter 0.1-DRAFT][FormalParameter profile 0.1] to be integrated into Schema.org: 
+These terms are being proposed by [Bioschemas profile ComputationalWorkflow 1.0-RELEASE][ComputationalWorkflow profile 1.0] and [FormalParameter 1.0-RELEASE][FormalParameter profile 1.0] to be integrated into Schema.org: 
 
 * `ComputationalWorkflow` mapped to <https://bioschemas.org/ComputationalWorkflow>
 * `FormalParameter` mapped to <https://bioschemas.org/FormalParameter>

--- a/docs/1.2-DRAFT/workflows.md
+++ b/docs/1.2-DRAFT/workflows.md
@@ -185,16 +185,16 @@ A workflow diagram may still be provided even if there is no programmatic `Softw
 ## Complying with Bioschemas Computational Workflow profile
 
 Data entities representing _workflows_ (`@type: ComputationalWorkflow`)
-SHOULD comply with the Bioschemas [ComputationalWorkflow profile],
+SHOULD comply with the Bioschemas [ComputationalWorkflow profile][ComputationalWorkflow profile 0.5],
 where possible. 
 
 When complying with this profile, the workflow data entities
 MUST describe these properties and their related contextual entities:
 [name], [programmingLanguage], [creator], [dateCreated], [license], [sdPublisher], [url], [version].
 
-The [ComputationalWorkflow profile] explains the above and list additional properties that a compliant [ComputationalWorkflow] data entity SHOULD include: [citation], [contributor], [creativeWorkStatus], [description], [funding], [hasPart], [isBasedOn], [keywords], [maintainer], [producer], [publisher], [runtimePlatform], [softwareRequirements], [targetProduct]
+The [ComputationalWorkflow profile][ComputationalWorkflow profile 0.5] explains the above and list additional properties that a compliant [ComputationalWorkflow][ComputationalWorkflow 0.1] data entity SHOULD include: [citation], [contributor], [creativeWorkStatus], [description], [funding], [hasPart], [isBasedOn], [keywords], [maintainer], [producer], [publisher], [runtimePlatform], [softwareRequirements], [targetProduct]
 
-A data entity conforming to the [ComputationalWorkflow profile] SHOULD declare the versioned profile URI using [conformsTo]:
+A data entity conforming to the [ComputationalWorkflow profile][ComputationalWorkflow profile 0.5] SHOULD declare the versioned profile URI using [conformsTo]:
 
 ```json
 { "@id": "workflow/alignment.knime",  
@@ -207,16 +207,16 @@ A data entity conforming to the [ComputationalWorkflow profile] SHOULD declare t
 
 ### Describing inputs and outputs
 
-The input and output _parameters_ for a workflow or script can be given with `input` and `output` to [FormalParameter]
+The input and output _parameters_ for a workflow or script can be given with `input` and `output` to [FormalParameter][FormalParameter 0.1]
 contextual entities. Note that this entity usually represent a _potential_ input/output value in a reusable
 workflow, much like [function parameter definitions] in general programming.
 
-If complying with the Bioschemas [FormalParameter profile],
-the _contextual entities_ for [FormalParameter], referenced by `input` or `output`, MUST describe: [name], [additionalType], [encodingFormat]
+If complying with the Bioschemas [FormalParameter profile][FormalParameter profile 0.1],
+the _contextual entities_ for [FormalParameter][FormalParameter 0.1], referenced by `input` or `output`, MUST describe: [name], [additionalType], [encodingFormat]
 
-The Bioschemas [FormalParameter profile] explains the above and lists additional properties that can be used, including [description], [valueRequired], [defaultValue] and [identifier].
+The Bioschemas [FormalParameter profile][FormalParameter profile 0.1] explains the above and lists additional properties that can be used, including [description], [valueRequired], [defaultValue] and [identifier].
 
-A contextual entity conforming to the [FormalParameter profile] SHOULD declare the versioned profile URI using [conformsTo], e.g.:
+A contextual entity conforming to the [FormalParameter profile][FormalParameter profile 0.1] SHOULD declare the versioned profile URI using [conformsTo], e.g.:
 
 ```json
 {
@@ -233,7 +233,7 @@ A contextual entity conforming to the [FormalParameter profile] SHOULD declare t
 
 ## Complete Workflow Example
 
-The below is an example of an RO-Crate complying with the [Bioschemas ComputationalWorkflow profile 0.5][ComputationalWorkflow profile]:
+The below is an example of an RO-Crate complying with the Bioschemas [ComputationalWorkflow profile 0.5]:
 
 ```json
 { "@context": "https://w3id.org/ro/crate/1.2-DRAFT/context", 

--- a/docs/1.2-DRAFT/workflows.md
+++ b/docs/1.2-DRAFT/workflows.md
@@ -194,18 +194,18 @@ MUST describe these properties and their related contextual entities:
 
 The [ComputationalWorkflow profile][ComputationalWorkflow profile 1.0] explains the above and list additional properties that a compliant [ComputationalWorkflow][ComputationalWorkflow 1.0] data entity SHOULD include: [citation], [contributor], [creativeWorkStatus], [description], [funding], [hasPart], [isBasedOn], [keywords], [maintainer], [producer], [publisher], [runtimePlatform], [softwareRequirements], [targetProduct]
 
-A data entity conforming to the [ComputationalWorkflow profile][ComputationalWorkflow profile 1.0] SHOULD declare the versioned profile URI using `sdConformsTo` [^18]:
+A data entity conforming to the [ComputationalWorkflow profile][ComputationalWorkflow profile 1.0] SHOULD declare the versioned profile URI using [conformsTo] [^18]:
 
 ```json
 { "@id": "workflow/alignment.knime",  
   "@type": ["File", "SoftwareSourceCode", "ComputationalWorkflow"],
-  "sdConformsTo": 
+  "conformsTo": 
     {"@id": "https://bioschemas.org/profiles/ComputationalWorkflow/1.0-RELEASE"},
   "..": ""
 }
 ```
 
-[^18]: The reason for introducing the RO-Crate term `sdConformsTo` instead of [conformsTo] is that here it is the _structured data_ about the workflow (this JSON-LD object) that conforms to the ComputationalWorkflow profile, not the file content of a workflow data entity (`workflow/alignment.knime`). See [schema.org issue #1516](https://github.com/schemaorg/schemaorg/issues/1516#issuecomment-855842619). Similarly, [sdPublisher] indicates who catalogued/published the JSON-LD structured data in his RO-Crate Metadata file, which may be different from the [publisher] of the workflow file. 
+[^18]: This is a liberal interpretation of [conformsTo] as it is the _structured data_ about the workflow (this JSON-LD object) that conforms to the ComputationalWorkflow profile, not the file content of a workflow data entity (`workflow/alignment.knime`). Instead of introducing a `sdConformsTo` similar to [sdPublisher], we here follow the current Bioschemas convention of indicating profile conformance when the JSON-LD is embedded within HTML pages.
 
 
 ### Describing inputs and outputs
@@ -219,13 +219,13 @@ the _contextual entities_ for [FormalParameter][FormalParameter 1.0], referenced
 
 The Bioschemas [FormalParameter profile][FormalParameter profile 1.0] explains the above and lists additional properties that can be used, including [description], [valueRequired], [defaultValue] and [identifier].
 
-A contextual entity conforming to the [FormalParameter profile][FormalParameter profile 1.0] SHOULD declare the versioned profile URI using `sdConformsTo` e.g.:
+A contextual entity conforming to the [FormalParameter profile][FormalParameter profile 1.0] SHOULD declare the versioned profile URI using `conformsTo` e.g.:
 
 ```json
 {
   "@id": "#36aadbd4-4a2d-4e33-83b4-0cbf6a6a8c5b",
   "@type": "FormalParameter",
-  "sdConformsTo": 
+  "conformsTo": 
     {"@id": "https://bioschemas.org/profiles/FormalParameter/1.0-RELEASE"},
   "..": ""
 }
@@ -257,7 +257,7 @@ The below is an example of an RO-Crate complying with the Bioschemas [Computatio
     {
       "@id": "workflow/alignment.knime",  
       "@type": ["File", "SoftwareSourceCode", "ComputationalWorkflow"],
-      "sdConformsTo": {
+      "conformsTo": {
         "@id": "https://bioschemas.org/profiles/ComputationalWorkflow/1.0-RELEASE"
       },
       "name": "Sequence alignment workflow",
@@ -272,14 +272,14 @@ The below is an example of an RO-Crate complying with the Bioschemas [Computatio
         { "@id": "#6c703fee-6af7-4fdb-a57d-9e8bc4486044"},
         { "@id": "#2f32b861-e43c-401f-8c42-04fd84273bdf"}
       ],
-      "sdPublisher": {"@id": "#workflow-hub"},
+      "sdPublisher": {"@id": "#workflow-repo"},
       "url": "http://example.com/workflows/alignment",
       "version": "0.5.0"
     },
     {
       "@id": "#36aadbd4-4a2d-4e33-83b4-0cbf6a6a8c5b",
       "@type": "FormalParameter",
-      "sdConformsTo": {
+      "conformsTo": {
         "@id": "https://bioschemas.org/profiles/FormalParameter/1.0-RELEASE"
       },
       "name": "genome_sequence",
@@ -290,7 +290,7 @@ The below is an example of an RO-Crate complying with the Bioschemas [Computatio
     {
       "@id": "#6c703fee-6af7-4fdb-a57d-9e8bc4486044",
       "@type": "FormalParameter",
-      "sdConformsTo": {
+      "conformsTo": {
         "@id": "https://bioschemas.org/profiles/FormalParameter/1.0-RELEASE"
       },
       "name": "cleaned_sequence",
@@ -300,7 +300,7 @@ The below is an example of an RO-Crate complying with the Bioschemas [Computatio
     {
       "@id": "#2f32b861-e43c-401f-8c42-04fd84273bdf",
       "@type": "FormalParameter",
-      "sdConformsTo": {"@id": "
+      "conformsTo": {"@id": "
         https://bioschemas.org/profiles/FormalParameter/1.0-RELEASE"
       },
       "name": "sequence_alignment",
@@ -327,9 +327,9 @@ The below is an example of an RO-Crate complying with the Bioschemas [Computatio
       "name": "Alice Brown"
     },
     {
-      "@id": "#workflow-hub",
+      "@id": "#workflow-repo",
       "@type": "Organization",
-      "name": "Example Workflow Hub",
+      "name": "Example Workflow repository",
       "url":"http://example.com/workflows/"
     },
     {

--- a/docs/1.2-DRAFT/workflows.md
+++ b/docs/1.2-DRAFT/workflows.md
@@ -185,45 +185,48 @@ A workflow diagram may still be provided even if there is no programmatic `Softw
 ## Complying with Bioschemas Computational Workflow profile
 
 Data entities representing _workflows_ (`@type: ComputationalWorkflow`)
-SHOULD comply with the Bioschemas [ComputationalWorkflow profile][ComputationalWorkflow profile 0.5],
+SHOULD comply with the Bioschemas [ComputationalWorkflow profile][ComputationalWorkflow profile 1.0],
 where possible. 
 
 When complying with this profile, the workflow data entities
 MUST describe these properties and their related contextual entities:
 [name], [programmingLanguage], [creator], [dateCreated], [license], [sdPublisher], [url], [version].
 
-The [ComputationalWorkflow profile][ComputationalWorkflow profile 0.5] explains the above and list additional properties that a compliant [ComputationalWorkflow][ComputationalWorkflow 0.1] data entity SHOULD include: [citation], [contributor], [creativeWorkStatus], [description], [funding], [hasPart], [isBasedOn], [keywords], [maintainer], [producer], [publisher], [runtimePlatform], [softwareRequirements], [targetProduct]
+The [ComputationalWorkflow profile][ComputationalWorkflow profile 1.0] explains the above and list additional properties that a compliant [ComputationalWorkflow][ComputationalWorkflow 1.0] data entity SHOULD include: [citation], [contributor], [creativeWorkStatus], [description], [funding], [hasPart], [isBasedOn], [keywords], [maintainer], [producer], [publisher], [runtimePlatform], [softwareRequirements], [targetProduct]
 
-A data entity conforming to the [ComputationalWorkflow profile][ComputationalWorkflow profile 0.5] SHOULD declare the versioned profile URI using [conformsTo]:
+A data entity conforming to the [ComputationalWorkflow profile][ComputationalWorkflow profile 1.0] SHOULD declare the versioned profile URI using `sdConformsTo` [^18]:
 
 ```json
 { "@id": "workflow/alignment.knime",  
   "@type": ["File", "SoftwareSourceCode", "ComputationalWorkflow"],
-  "conformsTo": 
-    {"@id": "https://bioschemas.org/profiles/ComputationalWorkflow/0.5-DRAFT-2020_07_21/"},
+  "sdConformsTo": 
+    {"@id": "https://bioschemas.org/profiles/ComputationalWorkflow/1.0-RELEASE"},
   "..": ""
 }
 ```
 
+[^18]: The reason for introducing the RO-Crate term `sdConformsTo` instead of [conformsTo] is that here it is the _structured data_ about the workflow (this JSON-LD object) that conforms to the ComputationalWorkflow profile, not the file content of a workflow data entity (`workflow/alignment.knime`). See [schema.org issue #1516](https://github.com/schemaorg/schemaorg/issues/1516#issuecomment-855842619). Similarly, [sdPublisher] indicates who catalogued/published the JSON-LD structured data in his RO-Crate Metadata file, which may be different from the [publisher] of the workflow file. 
+
+
 ### Describing inputs and outputs
 
-The input and output _parameters_ for a workflow or script can be given with `input` and `output` to [FormalParameter][FormalParameter 0.1]
+The input and output _parameters_ for a workflow or script can be given with `input` and `output` to [FormalParameter][FormalParameter 1.0]
 contextual entities. Note that this entity usually represent a _potential_ input/output value in a reusable
 workflow, much like [function parameter definitions] in general programming.
 
-If complying with the Bioschemas [FormalParameter profile][FormalParameter profile 0.1],
-the _contextual entities_ for [FormalParameter][FormalParameter 0.1], referenced by `input` or `output`, MUST describe: [name], [additionalType], [encodingFormat]
+If complying with the Bioschemas [FormalParameter profile][FormalParameter profile 1.0],
+the _contextual entities_ for [FormalParameter][FormalParameter 1.0], referenced by `input` or `output`, MUST describe: [name], [additionalType], [encodingFormat]
 
-The Bioschemas [FormalParameter profile][FormalParameter profile 0.1] explains the above and lists additional properties that can be used, including [description], [valueRequired], [defaultValue] and [identifier].
+The Bioschemas [FormalParameter profile][FormalParameter profile 1.0] explains the above and lists additional properties that can be used, including [description], [valueRequired], [defaultValue] and [identifier].
 
-A contextual entity conforming to the [FormalParameter profile][FormalParameter profile 0.1] SHOULD declare the versioned profile URI using [conformsTo], e.g.:
+A contextual entity conforming to the [FormalParameter profile][FormalParameter profile 1.0] SHOULD declare the versioned profile URI using `sdConformsTo` e.g.:
 
 ```json
 {
   "@id": "#36aadbd4-4a2d-4e33-83b4-0cbf6a6a8c5b",
   "@type": "FormalParameter",
-  "conformsTo": 
-    {"@id": "https://bioschemas.org/profiles/FormalParameter/0.1-DRAFT-2020_07_21/"},
+  "sdConformsTo": 
+    {"@id": "https://bioschemas.org/profiles/FormalParameter/1.0-RELEASE"},
   "..": ""
 }
 ```
@@ -233,7 +236,7 @@ A contextual entity conforming to the [FormalParameter profile][FormalParameter 
 
 ## Complete Workflow Example
 
-The below is an example of an RO-Crate complying with the Bioschemas [ComputationalWorkflow profile 0.5]:
+The below is an example of an RO-Crate complying with the Bioschemas [ComputationalWorkflow profile 1.0]:
 
 ```json
 { "@context": "https://w3id.org/ro/crate/1.2-DRAFT/context", 
@@ -254,8 +257,9 @@ The below is an example of an RO-Crate complying with the Bioschemas [Computatio
     {
       "@id": "workflow/alignment.knime",  
       "@type": ["File", "SoftwareSourceCode", "ComputationalWorkflow"],
-      "conformsTo": 
-        {"@id": "https://bioschemas.org/profiles/ComputationalWorkflow/0.5-DRAFT-2020_07_21/"},
+      "sdConformsTo": {
+        "@id": "https://bioschemas.org/profiles/ComputationalWorkflow/1.0-RELEASE"
+      },
       "name": "Sequence alignment workflow",
       "programmingLanguage": {"@id": "#knime"},
       "creator": {"@id": "#alice"},
@@ -275,7 +279,9 @@ The below is an example of an RO-Crate complying with the Bioschemas [Computatio
     {
       "@id": "#36aadbd4-4a2d-4e33-83b4-0cbf6a6a8c5b",
       "@type": "FormalParameter",
-      "conformsTo": {"@id": "https://bioschemas.org/profiles/FormalParameter/0.1-DRAFT-2020_07_21/"},
+      "sdConformsTo": {
+        "@id": "https://bioschemas.org/profiles/FormalParameter/1.0-RELEASE"
+      },
       "name": "genome_sequence",
       "valueRequired": true,
       "additionalType": {"@id": "http://edamontology.org/data_2977"},
@@ -284,7 +290,9 @@ The below is an example of an RO-Crate complying with the Bioschemas [Computatio
     {
       "@id": "#6c703fee-6af7-4fdb-a57d-9e8bc4486044",
       "@type": "FormalParameter",
-      "conformsTo": {"@id": "https://bioschemas.org/profiles/FormalParameter/0.1-DRAFT-2020_07_21/"},
+      "sdConformsTo": {
+        "@id": "https://bioschemas.org/profiles/FormalParameter/1.0-RELEASE"
+      },
       "name": "cleaned_sequence",
       "additionalType": {"@id": "http://edamontology.org/data_2977"},
       "encodingFormat": {"@id": "http://edamontology.org/format_2572"}
@@ -292,7 +300,9 @@ The below is an example of an RO-Crate complying with the Bioschemas [Computatio
     {
       "@id": "#2f32b861-e43c-401f-8c42-04fd84273bdf",
       "@type": "FormalParameter",
-      "conformsTo": {"@id": "https://bioschemas.org/profiles/FormalParameter/0.1-DRAFT-2020_07_21/"},
+      "sdConformsTo": {"@id": "
+        https://bioschemas.org/profiles/FormalParameter/1.0-RELEASE"
+      },
       "name": "sequence_alignment",
       "additionalType": {"@id": "http://edamontology.org/data_1383"},
       "encodingFormat": {"@id": "http://edamontology.org/format_1982"}
@@ -324,27 +334,27 @@ The below is an example of an RO-Crate complying with the Bioschemas [Computatio
     },
     {
       "@id": "http://edamontology.org/format_1929",
-      "@type": "Thing",
+      "@type": "NamedTerm",
       "name": "FASTA sequence format"
     },
     {
       "@id": "http://edamontology.org/format_1982",
-      "@type": "Thing",
+      "@type": "NamedTerm",
       "name": "ClustalW alignment format"
     },
     {
       "@id": "http://edamontology.org/format_2572",
-      "@type": "Thing",
+      "@type": "NamedTerm",
       "name": "BAM format"
     },
     {
       "@id": "http://edamontology.org/data_2977",
-      "@type": "Thing",
+      "@type": "NamedTerm",
       "name": "Nucleic acid sequence"
     },
     {
       "@id": "http://edamontology.org/data_1383",
-      "@type": "Thing",
+      "@type": "NamedTerm",
       "name": "Nucleic acid sequence alignment"
     }
   ]

--- a/docs/1.2-DRAFT/workflows.md
+++ b/docs/1.2-DRAFT/workflows.md
@@ -334,27 +334,27 @@ The below is an example of an RO-Crate complying with the Bioschemas [Computatio
     },
     {
       "@id": "http://edamontology.org/format_1929",
-      "@type": "NamedTerm",
+      "@type": "DefinedTerm",
       "name": "FASTA sequence format"
     },
     {
       "@id": "http://edamontology.org/format_1982",
-      "@type": "NamedTerm",
+      "@type": "DefinedTerm",
       "name": "ClustalW alignment format"
     },
     {
       "@id": "http://edamontology.org/format_2572",
-      "@type": "NamedTerm",
+      "@type": "DefinedTerm",
       "name": "BAM format"
     },
     {
       "@id": "http://edamontology.org/data_2977",
-      "@type": "NamedTerm",
+      "@type": "DefinedTerm",
       "name": "Nucleic acid sequence"
     },
     {
       "@id": "http://edamontology.org/data_1383",
-      "@type": "NamedTerm",
+      "@type": "DefinedTerm",
       "name": "Nucleic acid sequence alignment"
     }
   ]

--- a/docs/_includes/references.liquid
+++ b/docs/_includes/references.liquid
@@ -200,12 +200,19 @@ and is also rendered into the end of the PDF.
 [mainEntityOfPage]: http://schema.org/mainEntityOfPage
 [WebPage]: https://schema.org/WebPage
 
-[input]: https://bioschemas.org/types/ComputationalWorkflow/0.1-DRAFT-2020_07_21#input
-[output]: https://bioschemas.org/types/ComputationalWorkflow/0.1-DRAFT-2020_07_21#output
-[FormalParameter]: https://bioschemas.org/types/FormalParameter/0.1-DRAFT-2020_07_21
-[ComputationalWorkflow]: https://bioschemas.org/types/ComputationalWorkflow/0.1-DRAFT-2020_07_21
-[ComputationalWorkflow profile]: https://bioschemas.org/profiles/ComputationalWorkflow/0.5-DRAFT-2020_07_21
-[FormalParameter profile]: https://bioschemas.org/profiles/FormalParameter/0.1-DRAFT-2020_07_21
+[ComputationalWorkflow 0.1]: https://bioschemas.org/types/ComputationalWorkflow/0.1-DRAFT-2020_07_21
+[ComputationalWorkflow 0.1 input]: https://bioschemas.org/types/ComputationalWorkflow/0.1-DRAFT-2020_07_21#input
+[ComputationalWorkflow 0.1 output]: https://bioschemas.org/types/ComputationalWorkflow/0.1-DRAFT-2020_07_21#output
+[FormalParameter 0.1]: https://bioschemas.org/types/FormalParameter/0.1-DRAFT-2020_07_21
+[ComputationalWorkflow profile 0.5]: https://bioschemas.org/profiles/ComputationalWorkflow/0.5-DRAFT-2020_07_21
+[FormalParameter profile 0.1]: https://bioschemas.org/profiles/FormalParameter/0.1-DRAFT-2020_07_21
+
+[ComputationalWorkflow 1.0]: https://bioschemas.org/types/ComputationalWorkflow/1.0-RELEASE
+[ComputationalWorkflow 1.0 input]: https://bioschemas.org/types/ComputationalWorkflow/1.0-RELEASE#input
+[ComputationalWorkflow 1.0 output]: https://bioschemas.org/types/ComputationalWorkflow/1.0-RELEASE#output
+[FormalParameter 1.0]: https://bioschemas.org/types/FormalParameter/1.0-RELEASE
+[ComputationalWorkflow profile 1.0]: https://bioschemas.org/profiles/ComputationalWorkflow/1.0-RELEASE
+[FormalParameter profile 1.0]: https://bioschemas.org/profiles/FormalParameter/1.0-RELEASE
 
 [RFC 2119]: https://tools.ietf.org/html/rfc2119
 [RFC 3986]: https://tools.ietf.org/html/rfc3986

--- a/scripts/schema-context.py
+++ b/scripts/schema-context.py
@@ -121,7 +121,7 @@ ADDITIONAL = OrderedDict([
           ("funding", "http://schema.org/funding"),
           ## END 
 
-          ("sdConformsTo", "https://w3id.org/ro/terms#sdConformsTo"),
+          ##("sdConformsTo", "https://w3id.org/ro/terms#sdConformsTo"),
 
           ("wasDerivedFrom", "http://www.w3.org/ns/prov#wasDerivedFrom"),
           


### PR DESCRIPTION
Refer to BioSchemas 1.0-RELEASE versions without `/` in their `@id` URIs. Example:

```json
{ "@id": "workflow/alignment.knime",  
  "@type": ["File", "SoftwareSourceCode", "ComputationalWorkflow"],
  "conformsTo": 
      {"@id": "https://bioschemas.org/profiles/ComputationalWorkflow/1.0-RELEASE"},
  "input": [  {"@id": "#36aadbd4-4a2d-4e33-83b4-0cbf6a6a8c5b"} ]
},
{
  "@id": "#36aadbd4-4a2d-4e33-83b4-0cbf6a6a8c5b",
  "@type": "FormalParameter",
  "conformsTo": 
    {"@id": "https://bioschemas.org/profiles/FormalParameter/1.0-RELEASE"},
  "..": ""
}
```
  
This fixes issue #185
  
This also removes the early attempt of `sdConformsTo` structure from #154 and adds a footnote:

> This is a liberal interpretation of `conformsTo` as it is the _structured data_ about the workflow (this JSON-LD object) that conforms to the ComputationalWorkflow profile, not the file content of a workflow data entity (`workflow/alignment.knime`). Instead of introducing a `sdConformsTo` similar to [sdPublisher](https://schema.org/sdPublisher), we here follow the current Bioschemas convention of indicating profile conformance when the JSON-LD is embedded within HTML pages.

Discussion in schemaorg/schemaorg#1516   schemaorg/schemaorg#2887 seems to suggest a `structuredData` property to another blank node entity about the metadata itself, which could then have its own `creator`, etc. (and in our case `conformsTo`).  My view now is that adding a nested `structuredData` contextual entity in RO-Crate will get  excessively verbose (particularly on the `FormalParameter` which is already a #nonDownloadable contextual entity).