### PR TITLE
Update docs on finding the root dataset

### DIFF
--- a/docs/1.2-DRAFT/appendix/relative-uris.md
+++ b/docs/1.2-DRAFT/appendix/relative-uris.md
@@ -308,30 +308,13 @@ When parsing _RO-Crate JSON-LD_ as RDF, where the RDF framework performs resolut
 The algoritm proposed in section [Root Data Entity](../root-data-entity.md#finding-the-root-data-entity) allows finding the RDF resource describing `ro-crate-metadata.json`, independent of its parsed base URI. We can adopt this for RDF triples, thus finding crates conforming to this specification can be queried with [SPARQL]:
 
 ```sparql
-PREFIX dcterms: <http://purl.org/dc/terms/>
 PREFIX schema:  <http://schema.org/>
 
 SELECT ?crate ?metadatafile
 WHERE {
   ?crate        a                  schema:Dataset .
   ?metadatafile schema:about       ?crate .
-  ?metadatafile dcterms:conformsTo <https://w3id.org/ro/crate/1.2-DRAFT> .
-}
-```
-
-..or (less efficient) for any RO-Crate version:
-
-```sparql
-PREFIX dcterms: <http://purl.org/dc/terms/>
-PREFIX schema:  <http://schema.org/>
-
-SELECT ?crate ?metadatafile ?spec
-WHERE {
-  ?crate        a                  schema:Dataset .
-  ?metadatafile schema:about       ?crate .
-  ?metadatafile dcterms:conformsTo ?spec .
-
-  FILTER STRSTARTS(str(?spec), "https://w3id.org/ro/crate/")
+  filter(contains(str(?metadatafile), "ro-crate-metadata.json"))
 }
 ```
 

--- a/docs/1.2-DRAFT/root-data-entity.md
+++ b/docs/1.2-DRAFT/root-data-entity.md
@@ -101,7 +101,7 @@ root_entity = entity_map[metadata_entity["about"]["@id"]]
 ```
 
 More generally, the metadata id can be a URI whose last path segment is
-`ro-crate-metadata.json`: in this case, the first lookup will fail. We can
+`ro-crate-metadata.json`, so the above lookup can fail. In this case we can
 find the root entity by executing an algorithm similar to the one shown above,
 with the only difference that step 2 must be replaced by:
 
@@ -117,28 +117,28 @@ be told apart from the actual metadata file descriptor. A scenario that can
 potentially lead to confusion is when a dataset in the crate is itself an
 RO-Crate (_nested_ RO-Crate): again, the crate could be a collection of
 RO-Crate examples. In this case, the top-level crate SHOULD NOT list any files
-or directories belonging to the nested crates, but only the nested crate
-directories as [Dataset] entries. For instance:
+or directories belonging to the nested crates, but only the nested crates
+themselves as [Dataset] entries. For instance:
 
 ```json
 {
   "@context": "https://w3id.org/ro/crate/1.2-DRAFT/context",
   "@graph": [
     {
-      "@id": "http://example.org/ro-crate-metadata.json",
+      "@id": "http://example.org/crate/ro-crate-metadata.json",
       "@type": "CreativeWork",
-      "about": {"@id": "http://example.org/"},
+      "about": {"@id": "http://example.org/crate/"},
       "conformsTo": {"@id": "https://w3id.org/ro/crate/1.2-DRAFT"}
     },
     {
-      "@id": "http://example.org/",
+      "@id": "http://example.org/crate/",
       "@type": "Dataset",
       "hasPart": [
-        {"@id": "http://example.org/nested/"}
+        {"@id": "http://example.org/crate/nested/"}
       ]
     },
     {
-      "@id": "http://example.org/nested/",
+      "@id": "http://example.org/crate/nested/",
       "@type": "Dataset"
     }
   ]

--- a/docs/1.2-DRAFT/root-data-entity.md
+++ b/docs/1.2-DRAFT/root-data-entity.md
@@ -96,55 +96,49 @@ root_entity = entity_map[metadata_entity["about"]["@id"]]
 ```
 
 More generally, the metadata id can be a URI whose last path segment is
-`ro-crate-metadata.json`. In this case, an additional entity map can be built
-using the last path segment of each id as the key and the set of corresponding
-ids as the value. In most cases there is only one such URI, so the search
-ends with two simple lookups as before. Things get a bit complicated when
-there is more than one candidate URI, for instance in the case of nested
-crates:
+`ro-crate-metadata.json`: in this case, the first lookup will fail. We can
+find the root entity by executing an algorithm similar to the one shown above,
+with the only difference that step 2 must be replaced by:
+
+2. .. if the `@id`'s last path segment is `ro-crate-metadata.json`
+
+It is possible to build an RO-Crate having more than one entity whose `@id`
+has `ro-crate-metadata.json` as its last path segment. For instance, the crate
+could reference a collection of sample RO-Crate metadata files available from
+different web sites, or from the same web site but at different locations. In
+order to facilitate consumption, data entities representing such files SHOULD
+NOT have an `about` property pointing to a [Dataset] in the crate, so they can
+be told apart from the actual metadata file descriptor. A scenario that can
+potentially lead to confusion is when a dataset in the crate is itself an
+RO-Crate (_nested_ RO-Crate): again, the crate could be a collection of
+RO-Crate examples. In this case, the top-level crate SHOULD NOT list any files
+or directories belonging to the nested crates, but only the nested crate
+directories as [Dataset] entries. For instance:
 
 ```json
 {
-    "@context": "https://w3id.org/ro/crate/1.1/context",
-    "@graph": [
-        {
-            "@id": "https://example.org/crate/ro-crate-metadata.json",
-            "@type": "CreativeWork",
-            "about": {"@id": "https://example.org/crate"},
-            "conformsTo": {"@id": "https://w3id.org/ro/crate/1.1"}
-        },
-        {
-            "@id": "https://example.org/crate",
-            "@type": "Dataset",
-            "hasPart": [
-                {"@id": "https://example.org/crate/nested"},
-                {"@id": "https://example.org/crate/nested/ro-crate-metadata.json"}
-            ],
-        },
-        {
-            "@id": "https://example.org/crate/nested/ro-crate-metadata.json",
-            "@type": "CreativeWork",
-            "about": {"@id": "https://example.org/crate/nested"},
-            "conformsTo": {"@id": "https://w3id.org/ro/crate/1.1"}
-        },
-        {
-            "@id": "https://example.org/crate/nested",
-            "@type": "Dataset",
-            "hasPart": [{"@id": "https://example.org/crate/nested/foo.txt"}]
-        },
-        {
-            "@id": "https://example.org/crate/nested/foo.txt",
-            "@type": "File"
-        }
-    ]
+  "@context": "https://w3id.org/ro/crate/1.2-DRAFT/context",
+  "@graph": [
+    {
+      "@id": "http://example.org/ro-crate-metadata.json",
+      "@type": "CreativeWork",
+      "about": {"@id": "http://example.org/"},
+      "conformsTo": {"@id": "https://w3id.org/ro/crate/1.2-DRAFT"}
+    },
+    {
+      "@id": "http://example.org/",
+      "@type": "Dataset",
+      "hasPart": [
+        {"@id": "http://example.org/nested/"}
+      ]
+    },
+    {
+      "@id": "http://example.org/nested/",
+      "@type": "Dataset"
+    }
+  ]
 }
 ```
-
-In the above case, there are two candidates:
-`https://example.org/crate/ro-crate-metadata.json` and
-`https://example.org/crate/nested/ro-crate-metadata.json`. However, the former
-is `about` a dataset that contains (`hasPart`) the latter, but the opposite is
-not true. Thus, `https://example.org/crate` is the actual root dataset.
 
 See also the appendix on
 [finding RO-Crate Root in RDF triple stores](appendix/relative-uris.md#finding-ro-crate-root-in-rdf-triple-stores).

--- a/docs/1.2-DRAFT/root-data-entity.md
+++ b/docs/1.2-DRAFT/root-data-entity.md
@@ -40,11 +40,11 @@ the _RO-Crate root_ directory.
 
 ## RO-Crate Metadata File Descriptor
 
-The _RO-Crate JSON-LD_ MUST contain a self-describing **RO-Crate Metadata File
-Descriptor** whose `@id` MUST have `ro-crate-metadata.json` (or
-`ro-crate-metadata.jsonld` in legacy crates) as its last path segment, and
-`@type` [CreativeWork]. This descriptor MUST have an [about] property
-referencing the _Root Data Entity_, which SHOULD have an `@id` of `./`.
+The _RO-Crate JSON-LD_ MUST contain a self-describing
+**RO-Crate Metadata File Descriptor** with
+the `@id` value `ro-crate-metadata.json` (or `ro-crate-metadata.jsonld` in legacy
+crates) and `@type` [CreativeWork]. This descriptor MUST have an [about]
+property referencing the _Root Data Entity_, which SHOULD have an `@id` of `./`.
 
 ```json
 
@@ -74,6 +74,11 @@ start with `https://w3id.org/ro/crate/`.
 {: .tip }
 > The `conformsTo` property MAY be an array, to additionally indicate 
 specializing [RO-Crate profiles](profiles.md).
+
+If the root data entity `@id` is an absolute URI, the RO-Crate is considered
+web-based: in this case, the metadata descriptor SHOULD also have an absolute
+URI as its `@id`, which MUST have `ro-crate-metadata.json` (or
+`ro-crate-metadata.jsonld` in legacy crates) as its last path segment.
 
 ### Finding the Root Data Entity
 


### PR DESCRIPTION
Updates the root data entity section as follows:

* Adds a paragraph to the metadata file descriptor spec to allow absolute URIs (e.g., `https://example.org/crate/ro-crate-metadata.json`) when the root data entity is also an absolute URI.
* Changes the recommended algorithm for finding the root data entity to leverage the constraint that the metadata MUST contain an `ro-crate-metadata.json` (or absolute URI whose last path segment is `ro-crate-metadata.json`) entry. This makes the algorithm simpler and more efficient in the "standard" case of a single entry with an `@id` of `ro-crate-metadata.json` (see https://github.com/ResearchObject/ro-crate-py/pull/119).

Note that, in order to make this PR independent from #189, I've avoided using the term "detached crate". If we merge that PR first, however, we should change this one to explicitly mention detached crates.
