### PR TITLE
Attempting to address #122 and #124 - mainEntity and mentions

### DIFF
--- a/docs/1.2-DRAFT/contextual-entities.md
+++ b/docs/1.2-DRAFT/contextual-entities.md
@@ -55,18 +55,20 @@ Likewise, some data entities may also be described as contextual entities, for i
 
 The RO-Crate Metadata JSON `@graph` MUST NOT list multiple entities with the same `@id`; behaviour of consumers of an RO-Crate encountering multiple entities with the same `@id` is undefined.
 
+
 ## Identifiers for contextual entities
 
 A challenge can be how to assign [identifiers for contextual entities](appendix/jsonld.md#describing-entities-in-json-ld), that is deciding on their `@id` value.
 
-RO-Crate recommend that if an existing permalink (e.g. `https://orcid.org/0000-0002-1825-0097`) or other absolute URI (e.g. `https://en.wikipedia.org/wiki/Josiah_S._Carberry`) is reasonably unique for that entity, that URI should be used as identifier for the contextual entity in preference of an identifier local to the RO-Crate (e.g. `#josiah` or `#0fa587c6-4580-4ece-a5df-69af3c5590e3`). 
+If an existing permalink (e.g. `https://orcid.org/0000-0002-1825-0097`) or other absolute URI (e.g. `https://en.wikipedia.org/wiki/Josiah_S._Carberry`) is reasonably unique for that entity, that URI SHOULD be used as identifier for the contextual entity in preference of an identifier local to the RO-Crate (e.g. `#josiah` or `#0fa587c6-4580-4ece-a5df-69af3c5590e3`). 
 
-Care should be taken to not describe two conceptually different contextual entities with the same identifier - e.g. if `https://en.wikipedia.org/wiki/Josiah_S._Carberry` is a [Person] it should not also be a [CreativeWork] (although this example is a fictional person!).
+Care should be taken to not describe two conceptually different contextual entities with the same identifier - e.g. if `https://en.wikipedia.org/wiki/Josiah_S._Carberry` is a [Person] it SHOULD NOT also be a [CreativeWork] (although this example is a fictional person!).
 
 Where a related URL exist that may not be unique enough to serve as identifier, it can instead be added to a contextual entity using the property [url].
 
 
 See the [appendix on JSON-LD identifiers](appendix/jsonld.md#describing-entities-in-json-ld) for details.
+
 
 ## People
 

--- a/docs/1.2-DRAFT/crate-focus.md
+++ b/docs/1.2-DRAFT/crate-focus.md
@@ -1,0 +1,207 @@
+---
+title: The focus of an RO-Crate
+excerpt: |
+  In addition to simple data packaging, Crates may have a "main" entry point or topic (referenced with a singleton `mainEntity` property), or function as a bundle of one or more Contextual Entities referenced via the `mentions` property.
+nav_order: 7
+jekyll-mentions: false
+parent: RO-Crate 1.2-DRAFT
+---
+<!--
+   Copyright 2019-2020 University of Technology Sydney
+   Copyright 2019-2020 The University of Manchester UK 
+   Copyright 2019-2022 RO-Crate contributors <https://github.com/ResearchObject/ro-crate/graphs/contributors>
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+
+# The focus of an RO-Crate
+<div id="crate-focus"></div>
+
+In addition to simple data packaging, Crates may have a "main" entry point or topic (referenced with a singleton `mainEntity` property), or function as a bundle of one or more Contextual Entities referenced via the `mentions` property.
+
+## Crates with a "main entity"
+
+An RO-Crate may have a single main entity that is considered the point, or focus of the crate.
+
+### mainEntity is a _Data Entity_
+
+In the [Workflow RO_Crate profile](https://www.researchobject.org/ro-crate/profiles.html#workflow-ro-crate-profile) - where the `mainEntity` has a compund type `File,SoftwareSourceCode,ComputationalWorkflow`. the use of `mainEntity` singles-out the workflow file from supporting files.
+
+```
+{
+    "@id": "./",
+    "@type": "Dataset",
+    "name": "Example Workflow",
+    "description": "An example workflow RO Crate",
+    "license": "Apache-2.0",
+    "mainEntity": {
+    "@id": "example_workflow.cwl"
+    },
+    "hasPart": [
+    {
+        "@id": "example_workflow.cwl"
+    },
+    {
+        "@id": "diagram.svg"
+    },
+    {
+        "@id": "README.md"
+    }
+    ]
+}
+
+```
+
+
+### mainEntity is a _contextualEntity_
+
+The focus of the RO-Crate may be a description of a _Contextual Entity_ for example in an RO-Crate used in repository or encyclopedia where a RepositoryObject bundles together images and other files, but the main focus of the RO-Crate is on describing a person.
+
+
+```
+ {
+    "@id": "./",
+    "@type": ["Dataset", "RepostioryObject"],
+    "name": "Reibey, Mary (1777 - 1855)",
+    "mainEntity": {
+        "@id": "https://en.wikipedia.org/wiki/Mary_Reibey"
+    }
+    "hasPart" : [
+        {"@id": "photo1.jpg"},
+        {"@id": "photo2.jpg"}
+    ]
+
+}
+
+    {
+        "@id": "https://en.wikipedia.org/wiki/Mary_Reibey",
+        "@type": "Person",
+        "name": "Mary Reibey",
+        "description": "Mary Reibey née Haydock (12 May 1777 – 30 May 1855) was an English-born merchant, shipowner and trader ..."
+    }
+
+
+}
+```
+
+## Crates which describe _Contetual Entities_ 
+
+RO-Crates may describe _Contextual Entities_ which are not linked to a_Root Dataset_ via `hasPart` relationships.
+
+For example RO-Crates can be used as containers for schema.org-style vocabularies.
+
+```
+
+{
+      "@id": "./",
+      "@type": "Dataset",
+      "hasFile": "",
+      "description": "This is an experimental language data ontology based on OLAC terms for use in the ATAP and LDaCA projects",
+      "hasPart": [],
+      "name": "Language Data Ontology",
+      "mentions": ["txc:Annotation", t"xc:CollectionEvent"]
+    },
+    {
+      "@id": "txc:Annotation",
+      "@type": "rdfs:Class",
+      "name": "Annotation",
+      "sameAs": "http://www.language-archives.org/REC/type-20020628.html#annotation",
+      "rdfs:comment": "The resource includes information which annotates, describes or otherwise an some other linguistic record.",
+      "rdfs:label": "Annotation",
+      "rdfs:subClassOf": {
+        "@id": "schema:CreativeWork"
+      }
+    },
+    {
+      "@id": "txc:CollectionEvent",
+      "@type": "rdfs:Class",
+      "name": "CollectionEvent",
+      "rdfs:comment": "A description of an event at which one or more PrimaryTexts were captured,  eg as video or audio",
+      "rdfs:label": "CollectionEvent",
+      "rdfs:subClassOf": [
+        {
+          "@id": "schema:Event"
+        },
+        {
+          "@id": "schema:CreateAction"
+        }
+      ]
+    }
+```
+
+
+
+The following example shows both a `mainEntity` which is a _Data Entity_ and also a _Contextual Entity_ which is a test suite (`#test1`)
+
+```
+ {
+            "@id": "./",
+            "@type": "Dataset",
+            "name": "sort-and-change-case",
+            "description": "sort lines and change text to upper case",
+            "license": "Apache-2.0",
+            "mainEntity": {
+                "@id": "sort-and-change-case.ga"
+            },
+            "mentions": [ {"@id": "#test1" } ],
+            "hasPart": [
+                {
+                    "@id": "sort-and-change-case.ga"
+                },
+                {
+                    "@id": "test/test1/sort-and-change-case-test.yml"
+                }
+            ]
+        } {
+            "@id": "#test1",
+            "name": "test1",
+            "@type": "TestSuite",
+            "instance": [
+                {"@id": "#test1_1"}
+            ],
+            "definition": {"@id": "test/test1/sort-and-change-case-test.yml"}
+        },
+        {
+            "@id": "#test1_1",
+            "name": "test1_1",
+            "@type": "TestInstance",
+            "runsOn": {"@id": "#jenkins"},
+            "url": "http://example.org/jenkins",
+            "resource": "job/tests/"
+        },
+        {
+            "@id": "test/test1/sort-and-change-case-test.yml",
+            "@type": [
+                "File",
+                "TestDefinition"
+            ],
+            "conformsTo": {"@id": "#planemo"}
+        },
+        {
+            "@id": "#jenkins",
+            "@type": "TestService",
+            "name": "Jenkins",
+            "url": {"@id": "https://www.jenkins.io"}
+        },
+        {
+            "@id": "#planemo",
+            "@type": "SoftwareApplication",
+            "name": "Planemo",
+            "url": {"@id": "https://github.com/galaxyproject/planemo"},
+            "version": ">=0.70"
+        }
+
+
+```
+
+{% include references.liquid %}

--- a/docs/1.2-DRAFT/crate-focus.md
+++ b/docs/1.2-DRAFT/crate-focus.md
@@ -35,7 +35,7 @@ An RO-Crate may have a single main entity that is considered the point, or focus
 
 ### mainEntity is a _Data Entity_
 
-In the [Workflow RO_Crate profile](https://www.researchobject.org/ro-crate/profiles.html#workflow-ro-crate-profile) - where the `mainEntity` has a compund type `File,SoftwareSourceCode,ComputationalWorkflow`. the use of `mainEntity` singles-out the workflow file from supporting files.
+In the [Workflow RO-Crate profile](https://www.researchobject.org/ro-crate/profiles.html#workflow-ro-crate-profile), where the `mainEntity` has a compound type `["File", "SoftwareSourceCode", "ComputationalWorkflow"]`, the use of `mainEntity` singles-out the workflow file from supporting files.
 
 ```
 {
@@ -45,33 +45,30 @@ In the [Workflow RO_Crate profile](https://www.researchobject.org/ro-crate/profi
     "description": "An example workflow RO Crate",
     "license": "Apache-2.0",
     "mainEntity": {
-    "@id": "example_workflow.cwl"
+      "@id": "example_workflow.cwl"
     },
     "hasPart": [
-    {
+      {
         "@id": "example_workflow.cwl"
-    },
-    {
+      },
+      {
         "@id": "diagram.svg"
-    },
-    {
+      },
+      {
         "@id": "README.md"
-    }
+      }
     ]
 }
-
 ```
 
+### mainEntity is a _Contextual Entity_
 
-### mainEntity is a _contextualEntity_
-
-The focus of the RO-Crate may be a description of a _Contextual Entity_ for example in an RO-Crate used in repository or encyclopedia where a RepositoryObject bundles together images and other files, but the main focus of the RO-Crate is on describing a person.
-
+The focus of the RO-Crate may be a description of a _Contextual Entity_, for example in an RO-Crate used in a repository or encyclopedia where a RepositoryObject bundles together images and other files, but the main focus of the RO-Crate is on describing a person.
 
 ```
- {
+{
     "@id": "./",
-    "@type": ["Dataset", "RepostioryObject"],
+    "@type": ["Dataset", "RepositoryObject"],
     "name": "Reibey, Mary (1777 - 1855)",
     "mainEntity": {
         "@id": "https://en.wikipedia.org/wiki/Mary_Reibey"
@@ -80,28 +77,23 @@ The focus of the RO-Crate may be a description of a _Contextual Entity_ for exam
         {"@id": "photo1.jpg"},
         {"@id": "photo2.jpg"}
     ]
-
 }
 
-    {
-        "@id": "https://en.wikipedia.org/wiki/Mary_Reibey",
-        "@type": "Person",
-        "name": "Mary Reibey",
-        "description": "Mary Reibey née Haydock (12 May 1777 – 30 May 1855) was an English-born merchant, shipowner and trader ..."
-    }
-
-
+{
+    "@id": "https://en.wikipedia.org/wiki/Mary_Reibey",
+    "@type": "Person",
+    "name": "Mary Reibey",
+    "description": "Mary Reibey née Haydock (12 May 1777 – 30 May 1855) was an English-born merchant, shipowner and trader ..."
 }
 ```
 
-## Crates which describe _Contetual Entities_ 
+## Crates which describe _Contextual Entities_
 
-RO-Crates may describe _Contextual Entities_ which are not linked to a_Root Dataset_ via `hasPart` relationships.
+RO-Crates may describe _Contextual Entities_ which are not linked to a_Root Dataset_ via `mentions` relationships.
 
 For example RO-Crates can be used as containers for schema.org-style vocabularies.
 
 ```
-
 {
       "@id": "./",
       "@type": "Dataset",
@@ -109,7 +101,7 @@ For example RO-Crates can be used as containers for schema.org-style vocabularie
       "description": "This is an experimental language data ontology based on OLAC terms for use in the ATAP and LDaCA projects",
       "hasPart": [],
       "name": "Language Data Ontology",
-      "mentions": ["txc:Annotation", t"xc:CollectionEvent"]
+      "mentions": ["txc:Annotation", "txc:CollectionEvent"]
     },
     {
       "@id": "txc:Annotation",
@@ -140,11 +132,10 @@ For example RO-Crates can be used as containers for schema.org-style vocabularie
 ```
 
 
-
 The following example shows both a `mainEntity` which is a _Data Entity_ and also a _Contextual Entity_ which is a test suite (`#test1`)
 
 ```
- {
+        {
             "@id": "./",
             "@type": "Dataset",
             "name": "sort-and-change-case",
@@ -162,7 +153,8 @@ The following example shows both a `mainEntity` which is a _Data Entity_ and als
                     "@id": "test/test1/sort-and-change-case-test.yml"
                 }
             ]
-        } {
+        }
+		{
             "@id": "#test1",
             "name": "test1",
             "@type": "TestSuite",
@@ -200,8 +192,6 @@ The following example shows both a `mainEntity` which is a _Data Entity_ and als
             "url": {"@id": "https://github.com/galaxyproject/planemo"},
             "version": ">=0.70"
         }
-
-
 ```
 
 {% include references.liquid %}

--- a/docs/1.2-DRAFT/provenance.md
+++ b/docs/1.2-DRAFT/provenance.md
@@ -1,6 +1,6 @@
 ---
 title: Provenance of entities
-nav_order: 8
+nav_order: 9
 parent: RO-Crate 1.2-DRAFT 
 ---
 <!--

--- a/docs/1.2-DRAFT/root-data-entity.md
+++ b/docs/1.2-DRAFT/root-data-entity.md
@@ -119,7 +119,7 @@ The _Root Data Entity_ MUST have the following properties:
 *  `name`: SHOULD identify the dataset to humans well enough to disambiguate it from other RO-Crates
 *  `description`: SHOULD further elaborate on the name to provide a summary of the context in which the dataset is important.
 *  `datePublished`: MUST be a string in [ISO 8601 date format][DateTime] and SHOULD be specified to at least the precision of a day, MAY be a timestamp down to the millisecond. 
-*  `license`: SHOULD link to a _Contextual Entity_ in the _RO-Crate Metadata File_ with a name and description (see section on [licensing](contextual-entities.md#licensing-access-control-and-copyright)). MAY, if necessary be a textual description of how the RO-Crate may be used. 
+*  `license`: SHOULD link to a _Contextual Entity_ or _Data Entity_ in the _RO-Crate Metadata File_ with a name and description (see section on [licensing](contextual-entities.md#licensing-access-control-and-copyright)). MAY, if necessary be a textual description of how the RO-Crate may be used. 
 {: .note }
 > These requirements are stricter than those published 
 > for [Google Dataset Search](https://developers.google.com/search/docs/data-types/dataset) which 

--- a/docs/1.2-DRAFT/workflows.md
+++ b/docs/1.2-DRAFT/workflows.md
@@ -4,7 +4,7 @@ excerpt: |
   Scientific workflows and Scripts that were used (or can be used) to 
   analyze or generate files contained in an RO-Crate can be embedded
   in an RO-Crate and described in detail.
-nav_order: 9
+nav_order: 10
 parent: RO-Crate 1.2-DRAFT
 ---
 <!--


### PR DESCRIPTION
I have drafted a new section which attempts to codify the discussions around mentions and mainEntity (I left out `about` as it is too hard to differentiate from `mentions` - this is complicated enough already)

I think this needs to be a short new section because while it belongs int he discussion of metadata on a root dataset it also needs to come after the sections on Data and Contextual entities.