### PR TITLE
contentUrl for direct download, add section on Converting to Attached RO-Crate

### DIFF
--- a/docs/1.2-DRAFT/appendix/relative-uris.md
+++ b/docs/1.2-DRAFT/appendix/relative-uris.md
@@ -126,7 +126,40 @@ If the new Detached RO-Crate is not meant as a snapshot of the corresponding Att
 
 ## Converting from Detached to Attached RO-Crate
 
-_TODO_
+Converting a Detached Crate to an Attached Crate can mean multiple things depending on intentions, and may imply an elaborate process.
+
+First, check if the Root Dataset already have a [distribution download](../data-entities.md#directories-on-the-web-dataset-distributions) listed, in which case that can be retrieved as the corresponding Attached Crate.
+
+To archive a snapshot of an Detached Crate's metadata, keeping all data entities [web-based](../data-entities.md#web-based-data-entities):
+* Crate a new folder as the _RO-Crate Root_, save the _RO-Crate Metadata Document_ as the _RO-Crate Metadata File_ according to [Attached RO-Crate](../structure.md#attached-ro-crate) structure
+* Copy the absolute `@id` to become an `identifier` according to recommendations for [Root Data Entity identifier](../root-data-entity.md#root-data-entity-identifier)
+* Change the `@id` of the root dataset to `./` and update all references to it, including from the [Metadata Descriptor](../root-data-entity.md#ro-crate-metadata-descriptor)  
+
+If the new Attached Crate is intended as a _fork_ that will evolve independently of the Detached Crate, then:
+* Delete the `identifier`, add the previous `@id` as `isBasedOn`
+* Delete/update `datePublished` and `publisher`
+* Add yourself as `author` or `contributor` to the Root Dataset
+* Add records of [changes to the Crate](../provenance.md#recording-changes-to-ro-crates)
+
+
+To additionally save Web-based Data entities to become part of the Detached Crate, a possible algorithm is:
+
+* For each data entity which `@type` include `Dataset`:
+  + If it has a [distribution download](../data-entities.md#directories-on-the-web-dataset-distributions), retrieve and unpack that according to its `encodingFormat`, using its new folder name as the new local path name.
+  + If not, create a corresponding folder in the _RO-Crate Root_, possibly generating the local path name based on `name` or path elements of `@id`  URI
+  + Replace the `@id` of the dataset and all its references with the _relative URI_ based on the path from the RO-Crate Root, [encoding file paths](../data-entities.md#encoding-file-paths) as necessary.
+  + Recurse this algorithm to process each data entity from this dataset's `hasPart`
+* For each data entity which `@type` include `File`:
+  + Decide based on `@id` URI elements, `contentSize` `encodingFormat` and (possibly implied) `licence` if this file is acceptable to archive
+  + Retrieve the file and check the `contentSize` matches, if specified
+  + Store the file with a file path generated in a way consistent with the `Dataset`s, ideally added to the folder of the first `Dataset` that directly has this data entity as its `hasPart`
+  + Add the previous `@id` downloaded from as `url` according to [Embedded data entnties that are also on the Web](../data-entities.md#embedded-data-entities-that-are-also-on-the-web)
+  + Replace the `@id` of the `File` with the _relative URI_ based on the path from the RO-Crate Root, [encoding file paths](../data-entities.md#encoding-file-paths) as necessary.
+  
+As this procedure can be error-prone (e.g. a Web-based entity may not be accessible or may require authentication), the implementation should consider the new Attached Crate as a _fork_ and update `identifier` and `isDefinedBy` as specified above.
+
+{: .tip }
+> If you are archiving an [attached RO-Crate](../structure.md#attached-ro-crate) that is already on the Web, then first [establish the absolute URI](#establishing-absolute-uri-for-ro-crate-root) for the root, and retrieve all [payload](../structure.md#payload-files-and-directories-attached-ro-crates) files that are considered URI path-wise to be part the RO-Crate Root, creating corresponding local paths. In this scenario the above algorithm can be simplified and the rewriting of identifiers can be avoided if they are already relative URIs. 
 
 
 ## Handling relative URI references when using JSON-LD/RDF tools

--- a/docs/1.2-DRAFT/appendix/relative-uris.md
+++ b/docs/1.2-DRAFT/appendix/relative-uris.md
@@ -153,7 +153,7 @@ To additionally save Web-based Data entities to become part of the Detached Crat
   + Decide based on `@id` URI elements, `contentSize` `encodingFormat` and (possibly implied) `licence` if this file is acceptable to archive
   + Retrieve the file and check the `contentSize` matches, if specified
   + Store the file with a file path generated in a way consistent with the `Dataset`s, ideally added to the folder of the first `Dataset` that directly has this data entity as its `hasPart`
-  + Add the previous `@id` downloaded from as `url` according to [Embedded data entnties that are also on the Web](../data-entities.md#embedded-data-entities-that-are-also-on-the-web)
+  + Add the previous `@id` downloaded from as `contentUrl` according to [Embedded data entnties that are also on the Web](../data-entities.md#embedded-data-entities-that-are-also-on-the-web)
   + Replace the `@id` of the `File` with the _relative URI_ based on the path from the RO-Crate Root, [encoding file paths](../data-entities.md#encoding-file-paths) as necessary.
   
 As this procedure can be error-prone (e.g. a Web-based entity may not be accessible or may require authentication), the implementation should consider the new Attached Crate as a _fork_ and update `identifier` and `isDefinedBy` as specified above.

--- a/docs/1.2-DRAFT/data-entities.md
+++ b/docs/1.2-DRAFT/data-entities.md
@@ -316,7 +316,8 @@ File Data Entities may already have a corresponding web presence, for instance a
 These can be included for File Data Entities as additional metadata, regardless of whether the File is included in the _RO-Crate Root_ directory or exists on the Web, by using the properties:
 
 * [identifier] for formal identifier strings such as DOIs
-* [url] with a string URL corresponding to a *download* link (if not available, a download landing page) for this file
+* [contentUrl] with a string URL corresponding to a *download* link. Following the link (allowing for HTTP redirects) SHOULD directly download the file.
+* [url] with a string URL for a download/landing page for this particular file (e.g. direct download is not available)
 * [subjectOf] to a [CreativeWork] (or [WebPage]) that mentions this file or its content (but also other resources)
 * [mainEntityOfPage] to a [CreativeWork]  (or [WebPage]) that primarily describes this file (or its content) 
 
@@ -326,7 +327,7 @@ These can be included for File Data Entities as additional metadata, regardless 
     "@type": "File",
     "name": "Survey responses",
     "encodingFormat": "text/csv",
-    "url": "http://example.com/downloads/2019/survey-responses-2019.csv",
+    "contentUrl": "http://example.com/downloads/2019/survey-responses-2019.csv",
     "subjectOf": {"@id": "http://example.com/reports/2019/annual-survey.html"}
   },
   {


### PR DESCRIPTION
New section _Converting from Detached to Attached Crate_ with a suggested algorithm and warnings it may be elaborate. It notes that if the crate is an Attached Crate on the Web then it is easier due to relative paths.

The "Files that are also on the web" section adds `contentUrl` for the purpose of direct download, while `url` can be used for landing pages only - as proposed in https://github.com/ResearchObject/ro-crate/pull/189#issuecomment-1227697348

This completes #189 as this section was marked as `TODO`.

Tagging @jmfernandez @ptsefton @simleo which had views on retrieval in #189.