### PR TITLE
Updated ARC Profile

### DIFF
--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -324,7 +324,6 @@ A profile of RO-Crate for [Annotated Research Contexts](https://nfdi4plants.org/
 An ARC consists of [ISA](https://isa-specs.readthedocs.io/en/latest/isamodel.html) metadata describing the experimental setup and computational workflows given in CWL.
 The current [profile](https://github.com/nfdi4plants/ARC-specification/blob/main/ARC%20specification.md#appendix-conversion-of-arcs-to-ro-crates) requires the crate to follow the ISA Investigation profile on the top level.
 In the future, the ARC profile will be extended to not only cover the ISA part of an ARC, but also computational workflows, following the existing profiles for this kind of data.
-At the moment, the ISA profile only contains the top-level `Investigation` metadata.
 
 How such an RO-Crate can be generated from an ARC is described in the [arc-to-rocrate](https://github.com/nfdi4plants/arc-to-rocrate) repository, which also contains scripts to perform the conversion.
 
@@ -332,12 +331,15 @@ How such an RO-Crate can be generated from an ARC is described in the [arc-to-ro
 
 A profile of RO-Crate for experimental data in plant sciences that is described by metadata following the [ISA model](https://isa-specs.readthedocs.io/en/latest/isamodel.html).
 Such datasets consist of three types of data entities: `Investigation`, `Study` and `Assay`.
-The [profile](https://github.com/nfdi4plants/arc-to-rocrate/blob/main/profiles/investigation.md) adds requirements of the crate such that the folders match the Investigation, Study and Assay objects of the [ISA model](https://isa-specs.readthedocs.io/en/latest/isamodel.html).
+The [profile](https://github.com/nfdi4plants/arc-to-rocrate/blob/main/profiles/investigation.md) adds requirements of the crate such that the data folders match the Investigation, Study and Assay objects of the [ISA model](https://isa-specs.readthedocs.io/en/latest/isamodel.html).
 
-At the moment, the profile describes the top-level `Investigation` object, while the `Study` and `Assay` definitions are pending.
-The top-level metadata consists of the following types, which represent the `Investigation`, `Person` and `Publication` types of the ISA model. More details can be found in the [arc-to-rocrate](https://github.com/nfdi4plants/arc-to-rocrate) repository.
+The profile here describes the top-level `Investigation` object (a dataset) and contained datasets following the `Study` and `Assay` profiles.
+Profiles for other included types can be found in the [full version](https://github.com/nfdi4plants/isa-ro-crate-profile).
 
 ### ISA Investigation Profile
+
+An `Investigation` object describes the top-level meatadata of a scientific investigation, e.g. descriptions of the context, the title, authors and publications (see [ISA model](https://isa-specs.readthedocs.io/en/latest/isamodel.html) for details).
+It SHOULD contain further datasets that follow the `Study` profile.
 
 - [`Dataset`](http://schema.org/dataset)
   - [`identifier`](http://schema.org/identifier): [`Text`](https://schema.org/Text) or [`URL`](https://schema.org/URL) (required)
@@ -354,7 +356,50 @@ The top-level metadata consists of the following types, which represent the `Inv
   - [`disambiguatingDescription`](http://schema.org/disambiguatingDescription): [`Text`](https://schema.org/Text) (optional)
   - [`hasPart`](http://schema.org/hasPart): [`Dataset`](http://schema.org/dataset) (optional)
 
-- [`Person`](http://schema.org/Person)
+### ISA Study Profile
+
+A `Study` contains information on the subject under study, its characteristics and any treatments applied(see [ISA model](https://isa-specs.readthedocs.io/en/latest/isamodel.html) for details).
+It contexualizes further datasets that follow the `Assay` profile.
+
+- [`Dataset`](http://schema.org/dataset)
+  - [`identifier`](http://schema.org/identifier): [`Text`](https://schema.org/Text) or [`URL`](https://schema.org/URL) (required)
+  - [`headline`](http://schema.org/headline): [`Text`](https://schema.org/Text) (required)
+  - [`alternateType`](https://schema.org/alternateName): [`Text`](https://schema.org/Text) (required)
+  - [`creator`](http://schema.org/creator): [`Person`](https://schema.org/Person) (required)
+
+  - [`hasPart`](https://schema.org/hasPart): [`Dataset`](https://schema.org/Dataset) or [`File`](https://schema.org/MediaObject) (recommended)
+  - [`about`](https://schema.org/about): [`LabProcess`](https://bioschemas.org/LabProcess) (recommended)
+  - [`description`](https://schema.org/description): [`Text`](https://schema.org/Text) (recommended)
+  - [`dateCreated`](https://schema.org/dateCreated): [`Date`](https://schema.org/Date) or [`DateTime`](https://schema.org/DateTime) (recommended)
+  - [`dateModified`](https://schema.org/dateModified): [`Date`](https://schema.org/Date) or [`DateTime`](https://schema.org/DateTime) (recommended)
+
+  - [`datePublished`](https://schema.org/datePublished): [`Date`](https://schema.org/Date) or [`DateTime`](https://schema.org/DateTime) (optional)
+  - [`citation`](https://schema.org/citation): [`ScholarlyArticle`](https://schema.org/ScholarlyArticle) (optional)
+  - [`comment`](https://schema.org/comment): [`Comment`](https://schema.org/Comment) (optional)
+
+### ISA Assay Profile
+
+An `Assay` contains information about a test performed either on material taken from a subject or on a whole initial subject(see [ISA model](https://isa-specs.readthedocs.io/en/latest/isamodel.html) for details).
+
+- [`Dataset`](http://schema.org/dataset)
+  - [`additionalType`](https://schema.org/additionalType): [`Text`](https://schema.org/Text) or [`URL`](https://schema.org/URL) (required)
+  - [`creator`](https://schema.org/creator): [`Person`](https://schema.org/Person) (required)
+  - [`identifier`](https://schema.org/identifier): [`Text`](https://schema.org/Text) or [`URL`](https://schema.org/URL) (required)
+  - [`headline`](https://schema.org/headline): [`Text`](https://schema.org/Text) (required)
+  - [`about`](https://schema.org/about): [`LabProcess`](https://bioschemas.org/LabProcess) (required)
+  - [`measurementMethod`](https://schema.org/measurementMethod): [`URL`](https://schema.org/URL) or [`DefinedTerm`](https://schema.org/DefinedTerm) (required)
+  - [`measurementTechnique`](https://schema.org/measurementTechnique): [`URL`](https://schema.org/URL) or [`DefinedTerm`](https://schema.org/DefinedTerm) (required)
+
+  - [`hasPart`](https://schema.org/hasPart): [`File`](https://schema.org/MediaObject) (recommended)
+  - [`description`](https://schema.org/description): [`Text`](https://schema.org/Text) (recommended)
+  - [`variableMeasured`](https://schema.org/variableMeasured): [`Text`](https://schema.org/Text) or [`PropertyValue`](https://schema.org/PropertyValue) (recommended)
+  - [`dateModified`](https://schema.org/dateModified): [`Date`](https://schema.org/Date) or [`DateTime`](https://schema.org/DateTime) (recommended)
+
+  - [`dateCreated`](https://schema.org/dateCreated): [`Date`](https://schema.org/Date) or [`DateTime`](https://schema.org/DateTime) (optional)
+  - [`citation`](https://schema.org/citation): [`ScholarlyArticle`](https://schema.org/ScholarlyArticle) (optional)
+  - [`comment`](https://schema.org/comment): [`Comment`](https://schema.org/Comment) (optional)
+
+<!-- - [`Person`](http://schema.org/Person)
   - [`givenName`](http://schema.org/givenName): [`Text`](https://schema.org/Text) (required)
   - [`familyName`](http://schema.org/familyName): [`Text`](https://schema.org/Text) (required)
   
@@ -376,7 +421,7 @@ The top-level metadata consists of the following types, which represent the `Inv
   - [`url`](http://schema.org/url): [`URL`](https://schema.org/URL) (recommended)
    
   - [`creativeWorkStatus`](http://schema.org/creativeWorkStatus): [`DefinedTerm`](https://schema.org/DefinedTerm) (optional)
-  - [`disambiguatingDescription`](http://schema.org/disambiguatingDescription): [`Text`](https://schema.org/Text) (optional)
+  - [`disambiguatingDescription`](http://schema.org/disambiguatingDescription): [`Text`](https://schema.org/Text) (optional) -->
 
 ## Electronic Lab Notebook (ELN)
 


### PR DESCRIPTION
This PR updates the ARC and ISA profiles such that they now also specify the ISA types further down in the hierarchy like Assays, Studies or Protocols. They are based on the new/adapted bioschemas types LabProcess and LabProtocol. Previously, the profile has only been specified for the top level Investigation object.