### PR TITLE
Add geosparql vocabulary terms

### DIFF
--- a/docs/1.2-DRAFT/context.jsonld
+++ b/docs/1.2-DRAFT/context.jsonld
@@ -2892,6 +2892,8 @@
           "ResourceDescriptor": "http://www.w3.org/ns/dx/prof/ResourceDescriptor",
           "ResourceRole": "http://www.w3.org/ns/dx/prof/ResourceRole",
           "Profile": "http://www.w3.org/ns/dx/prof/Profile",
+          "Geometry": "http://www.opengis.net/ont/geosparql#Geometry",
+          "asWKT": "http://www.opengis.net/ont/geosparql#asWKT",
           "@label": "http://www.w3.org/2000/01/rdf-schema#label",
           "pcdm": "http://pcdm.org/models#",
           "bibo": "http://purl.org/ontology/bibo/",
@@ -2913,6 +2915,7 @@
           "roterms": "http://purl.org/ro/roterms#",
           "relation": "http://www.iana.org/assignments/relation/",
           "wf4ever": "http://purl.org/ro/wf4ever#",
-          "vann": "http://purl.org/vocab/vann/"
+          "vann": "http://purl.org/vocab/vann/",
+          "geosparql": "http://www.opengis.net/ont/geosparql#"
      }
 }

--- a/docs/1.2-DRAFT/metadata.md
+++ b/docs/1.2-DRAFT/metadata.md
@@ -143,6 +143,11 @@ These terms are being proposed by [Bioschemas profile ComputationalWorkflow 1.0-
 * `input` mapped to <https://bioschemas.org/ComputationalWorkflow#input>
 * `output` mapped to <https://bioschemas.org/ComputationalWorkflow#output>
 
+To support geometry in [Places](contextual-entities.md#places), these terms from the [GeoSPARQL ontology]:
+
+* `Geometry` mapped to <http://www.opengis.net/ont/geosparql#Geometry>
+* `asWKT` mapped to <http://www.opengis.net/ont/geosparql#asWKT>
+
 {: .note }
 > In this specification the proposed Bioschemas terms use the temporary <https://bioschemas.org/> namespace; future releases of RO-Crate may reflect mapping to the <http://schema.org/> namespace.
 

--- a/docs/1.2-DRAFT/ro-crate-metadata.json
+++ b/docs/1.2-DRAFT/ro-crate-metadata.json
@@ -686,10 +686,18 @@
       "description": "The WKT serialization (ISO13249) of a Geometry.",
       "name": "Geometry",
       "termCode": "asWKT",
+      "citation": { "@id": "https://portal.ogc.org/files/?artifact_id=25355" },
       "sameAs": "https://opengeospatial.github.io/ogc-geosparql/geosparql11/#asWKT",
       "inDefinedTermSet": {
         "@id": "http://www.opengis.net/ont/geosparql#"
       }
+    },
+    {
+      "@id": "https://portal.ogc.org/files/?artifact_id=25355",
+      "@type": "CreativeWork",
+      "name": "OpenGIS Implementation Specification for Geographic information – Simple feature access – Part 1: Common architecture",
+      "version": "1.2.1",
+      "url": "https://www.ogc.org/standard/sfa/"
     },
     {
       "@id": "http://www.opengis.net/ont/geosparql#",

--- a/docs/1.2-DRAFT/ro-crate-metadata.json
+++ b/docs/1.2-DRAFT/ro-crate-metadata.json
@@ -683,7 +683,7 @@
     {
       "@id": "http://www.opengis.net/ont/geosparql#asWKT",
       "@type": "DefinedTerm",
-      "description": "The WKT serialization (ISO13249) of a Geometry.",
+      "description": "The WKT (Well-Known Text) serialization (ISO13249) of a Geometry.",
       "name": "Geometry",
       "termCode": "asWKT",
       "citation": { "@id": "https://portal.ogc.org/files/?artifact_id=25355" },

--- a/docs/1.2-DRAFT/ro-crate-metadata.json
+++ b/docs/1.2-DRAFT/ro-crate-metadata.json
@@ -298,6 +298,12 @@
         },
         {
           "@id": "http://schema.org/Property"
+        },
+        {
+          "@id": "http://www.opengis.net/ont/geosparql#Geometry"
+        },
+        {
+          "@id": "http://www.opengis.net/ont/geosparql#asWKT"
         }
       ],
       "identifier": {"@id": "https://doi.org/DOI"},      
@@ -344,6 +350,9 @@
         },
         {
           "@id": "#vocabulary-rdfs"
+        },
+        {
+          "@id": "#vocabulary-geosparql"
         },
         {
           "@id": "#specification"
@@ -659,6 +668,36 @@
       "description": "Defines terms used in the profile specification",
       "name": "Vocabulary",
       "sameAs": "https://www.w3.org/TR/2019/NOTE-dx-prof-20191218/#Role:vocabulary"
+    },
+    {
+      "@id": "http://www.opengis.net/ont/geosparql#Geometry",
+      "@type": "DefinedTerm",
+      "description": "A coherent set of direct positions in space. The positions are held within a Spatial Reference System (SRS).",
+      "name": "Geometry",
+      "termCode": "Geometry",
+      "sameAs": "https://opengeospatial.github.io/ogc-geosparql/geosparql11/#Geometry",
+      "inDefinedTermSet": {
+        "@id": "http://www.opengis.net/ont/geosparql#"
+      }
+    },
+    {
+      "@id": "http://www.opengis.net/ont/geosparql#asWKT",
+      "@type": "DefinedTerm",
+      "description": "The WKT serialization (ISO13249) of a Geometry.",
+      "name": "Geometry",
+      "termCode": "asWKT",
+      "sameAs": "https://opengeospatial.github.io/ogc-geosparql/geosparql11/#asWKT",
+      "inDefinedTermSet": {
+        "@id": "http://www.opengis.net/ont/geosparql#"
+      }
+    },
+    {
+      "@id": "http://www.opengis.net/ont/geosparql#",
+      "@type": "DefinedTermSet",
+      "name": "GeoSPARQL ontology",
+      "version": "1.1",
+      "sameAs": "https://opengeospatial.github.io/ogc-geosparql/geosparql11/",
+      "url": "https://opengeospatial.github.io/ogc-geosparql/geosparql11/spec.html"
     },
     {
       "@id": "http://www.w3.org/ns/json-ld#Context",
@@ -1873,7 +1912,18 @@
       "hasRole": {
         "@id": "http://www.w3.org/ns/dx/prof/role/vocabulary"
       }
+    },
+    {
+      "@id": "#vocabulary-geosparql",
+      "@type": "ResourceDescriptor",
+      "hasArtifact": {
+        "@id": "http://www.opengis.net/ont/geosparql#"
+      },
+      "hasRole": {
+        "@id": "http://www.w3.org/ns/dx/prof/role/vocabulary"
+      }
     }
+
 
   ]
 }

--- a/docs/1.2-DRAFT/ro-crate-preview.html
+++ b/docs/1.2-DRAFT/ro-crate-preview.html
@@ -1103,7 +1103,7 @@
     {
       "@id": "http://www.opengis.net/ont/geosparql#asWKT",
       "@type": "DefinedTerm",
-      "description": "The WKT serialization (ISO13249) of a Geometry.",
+      "description": "The WKT (Well-Known Text) serialization (ISO13249) of a Geometry.",
       "name": "Geometry",
       "termCode": "asWKT",
       "citation": {
@@ -7456,7 +7456,7 @@ While providing the formal specification for RO-Crate, this document also aims t
             <td style='text-align:left'><span>DefinedTerm</span></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">description<span>&nbsp;</span><a href="http://schema.org/description">[?]</a></th>
-            <td style='text-align:left'><span>The WKT serialization (ISO13249) of a Geometry.</span></td>
+            <td style='text-align:left'><span>The WKT (Well-Known Text) serialization (ISO13249) of a Geometry.</span></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">termCode<span>&nbsp;</span><a href="http://schema.org/termCode">[?]</a></th>
             <td style='text-align:left'><span>asWKT</span></td>

--- a/docs/1.2-DRAFT/ro-crate-preview.html
+++ b/docs/1.2-DRAFT/ro-crate-preview.html
@@ -305,6 +305,12 @@
         },
         {
           "@id": "http://schema.org/Property"
+        },
+        {
+          "@id": "http://www.opengis.net/ont/geosparql#Geometry"
+        },
+        {
+          "@id": "http://www.opengis.net/ont/geosparql#asWKT"
         }
       ],
       "identifier": {
@@ -355,12 +361,862 @@
           "@id": "#vocabulary-rdfs"
         },
         {
+          "@id": "#vocabulary-geosparql"
+        },
+        {
           "@id": "#specification"
         },
         {
           "@id": "#example-rainfall"
         }
-      ]
+      ],
+      "@reverse": {
+        "conformsTo": [
+          {
+            "@id": "ro-crate-metadata.json"
+          },
+          {
+            "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/examples/rainfall-1.2.0/"
+          }
+        ],
+        "about": [
+          {
+            "@id": "ro-crate-metadata.json"
+          }
+        ]
+      }
+    },
+    {
+      "@id": "http://datasciencehub.net/",
+      "@type": "Journal",
+      "issn": "2451-8492",
+      "name": "Data Science",
+      "url": "http://datasciencehub.net/",
+      "@reverse": {
+        "isPartOf": [
+          {
+            "@id": "https://doi.org/10.3233/DS-210053"
+          }
+        ]
+      }
+    },
+    {
+      "@id": "http://pcdm.org/models#",
+      "@type": "DefinedTermSet",
+      "name": "Portland Common Data Model",
+      "sameAs": "https://pcdm.org/2016/04/18/models",
+      "version": "2016/04/18",
+      "@reverse": {
+        "inDefinedTermSet": [
+          {
+            "@id": "http://pcdm.org/models#Collection"
+          },
+          {
+            "@id": "http://pcdm.org/models#File"
+          },
+          {
+            "@id": "http://pcdm.org/models#Object"
+          },
+          {
+            "@id": "http://pcdm.org/models#hasFile"
+          },
+          {
+            "@id": "http://pcdm.org/models#hasMember"
+          }
+        ]
+      }
+    },
+    {
+      "@id": "http://pcdm.org/models#Collection",
+      "@type": [
+        "DefinedTerm",
+        "Class"
+      ],
+      "inDefinedTermSet": {
+        "@id": "http://pcdm.org/models#"
+      },
+      "name": "Repository collection",
+      "termCode": "RepositoryCollection",
+      "@reverse": {
+        "hasPart": [
+          {
+            "@id": "https://w3id.org/ro/crate/1.2-DRAFT"
+          }
+        ]
+      }
+    },
+    {
+      "@id": "http://pcdm.org/models#File",
+      "@type": [
+        "DefinedTerm",
+        "Class"
+      ],
+      "inDefinedTermSet": {
+        "@id": "http://pcdm.org/models#"
+      },
+      "name": "Repository file",
+      "termCode": "RepositoryFile",
+      "@reverse": {
+        "hasPart": [
+          {
+            "@id": "https://w3id.org/ro/crate/1.2-DRAFT"
+          }
+        ]
+      }
+    },
+    {
+      "@id": "http://pcdm.org/models#Object",
+      "@type": [
+        "DefinedTerm",
+        "Class"
+      ],
+      "inDefinedTermSet": {
+        "@id": "http://pcdm.org/models#"
+      },
+      "name": "Repository object",
+      "termCode": "RepositoryObject",
+      "@reverse": {
+        "hasPart": [
+          {
+            "@id": "https://w3id.org/ro/crate/1.2-DRAFT"
+          }
+        ]
+      }
+    },
+    {
+      "@id": "http://pcdm.org/models#hasFile",
+      "@type": [
+        "DefinedTerm",
+        "Property"
+      ],
+      "inDefinedTermSet": {
+        "@id": "http://pcdm.org/models#"
+      },
+      "name": "has file",
+      "termCode": "hasFile",
+      "@reverse": {
+        "hasPart": [
+          {
+            "@id": "https://w3id.org/ro/crate/1.2-DRAFT"
+          }
+        ]
+      }
+    },
+    {
+      "@id": "http://pcdm.org/models#hasMember",
+      "@type": [
+        "DefinedTerm",
+        "Property"
+      ],
+      "inDefinedTermSet": {
+        "@id": "http://pcdm.org/models#"
+      },
+      "name": "has member",
+      "termCode": "hasMember",
+      "@reverse": {
+        "hasPart": [
+          {
+            "@id": "https://w3id.org/ro/crate/1.2-DRAFT"
+          }
+        ]
+      }
+    },
+    {
+      "@id": "http://purl.org/vocab/vann/preferredNamespacePrefix",
+      "@type": "DefinedTerm",
+      "name": "preferred namespace prefix",
+      "description": "The preferred namespace prefix to use when using terms from this vocabulary in an document.",
+      "url": "https://vocab.org/vann/#preferredNamespacePrefix"
+    },
+    {
+      "@id": "http://purl.org/vocab/vann/preferredNamespaceUri",
+      "@type": "DefinedTerm",
+      "name": "preferred namespace URI",
+      "description": "The preferred namespace URI to use when using terms from this vocabulary in an document",
+      "url": "https://vocab.org/vann/#preferredNamespaceUri"
+    },
+    {
+      "@id": "http://schema.org/version/15.0/",
+      "@type": [
+        "DefinedTermSet",
+        "Standard"
+      ],
+      "name": "Schema.org vocabulary (http prefix)",
+      "encoding": {
+        "@id": "https://schema.org/version/15.0/schemaorg-current-http.jsonld"
+      },
+      "vann:preferredNamespaceUri": "http://schema.org/",
+      "version": "15.0",
+      "url": "https://schema.org/docs/developers.html",
+      "@reverse": {
+        "isProfileOf": [
+          {
+            "@id": "https://w3id.org/ro/crate/1.2-DRAFT"
+          }
+        ],
+        "inDefinedTermSet": [
+          {
+            "@id": "http://schema.org/Class"
+          },
+          {
+            "@id": "http://schema.org/Property"
+          }
+        ],
+        "isBasedOn": [
+          {
+            "@id": "https://w3id.org/ro/crate/1.2-DRAFT/context"
+          }
+        ],
+        "hasArtifact": [
+          {
+            "@id": "#vocabulary-schema"
+          }
+        ]
+      }
+    },
+    {
+      "@id": "https://schema.org/version/15.0/schemaorg-current-http.jsonld",
+      "@type": "CreativeWork",
+      "encodingFormat": "application/ld+json",
+      "conformsTo": {
+        "@id": "https://www.w3.org/TR/rdf-schema/"
+      },
+      "@reverse": {
+        "encoding": [
+          {
+            "@id": "http://schema.org/version/15.0/"
+          }
+        ]
+      }
+    },
+    {
+      "@id": "http://www.iana.org/assignments/relation/cite-as",
+      "@type": [
+        "DefinedTerm",
+        "Property"
+      ],
+      "inDefinedTermSet": {
+        "@id": "https://www.iana.org/assignments/link-relations/"
+      },
+      "name": "Cite as",
+      "termCode": "cite-as",
+      "url": "https://doi.org/10.17487/RFC8574",
+      "@reverse": {
+        "hasPart": [
+          {
+            "@id": "https://w3id.org/ro/crate/1.2-DRAFT"
+          }
+        ]
+      }
+    },
+    {
+      "@id": "https://www.w3.org/TR/rdf-schema/",
+      "@type": "Standard",
+      "name": "RDF Schema (rdfs)",
+      "hasPart": {
+        "@id": "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+      },
+      "@reverse": {
+        "conformsTo": [
+          {
+            "@id": "https://schema.org/version/15.0/schemaorg-current-http.jsonld"
+          }
+        ]
+      }
+    },
+    {
+      "@id": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+      "@type": "DefinedTermSet",
+      "url": "https://www.w3.org/TR/rdf-schema/",
+      "vann:preferredNamespacePrefix": "rdfs",
+      "vann:preferredNamespaceUri": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+      "@reverse": {
+        "hasPart": [
+          {
+            "@id": "https://www.w3.org/TR/rdf-schema/"
+          }
+        ],
+        "inDefinedTermSet": [
+          {
+            "@id": "http://www.w3.org/1999/02/22-rdf-syntax-ns#Class"
+          },
+          {
+            "@id": "http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"
+          }
+        ],
+        "hasArtifact": [
+          {
+            "@id": "#vocabulary-rdfs"
+          }
+        ]
+      }
+    },
+    {
+      "@id": "http://www.w3.org/1999/02/22-rdf-syntax-ns#Class",
+      "@type": [
+        "DefinedTerm",
+        "Class"
+      ],
+      "inDefinedTermSet": {
+        "@id": "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+      },
+      "name": "Class (rdfs)",
+      "description": "Class definition as part of a Profile Crate",
+      "url": "https://www.w3.org/TR/rdf-schema/#ch_class",
+      "@reverse": {
+        "hasPart": [
+          {
+            "@id": "https://w3id.org/ro/crate/1.2-DRAFT"
+          }
+        ]
+      }
+    },
+    {
+      "@id": "http://www.w3.org/1999/02/22-rdf-syntax-ns#Property",
+      "@type": [
+        "DefinedTerm",
+        "Class"
+      ],
+      "inDefinedTermSet": {
+        "@id": "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+      },
+      "name": "Property (rdfs)",
+      "description": "Property definition as part of a Profile Crate",
+      "url": "https://www.w3.org/TR/rdf-schema/#ch_property",
+      "@reverse": {
+        "hasPart": [
+          {
+            "@id": "https://w3id.org/ro/crate/1.2-DRAFT"
+          }
+        ]
+      }
+    },
+    {
+      "@id": "http://schema.org/Class",
+      "@type": [
+        "DefinedTerm",
+        "Class"
+      ],
+      "inDefinedTermSet": {
+        "@id": "http://schema.org/version/15.0/"
+      },
+      "name": "Class (schema.org)",
+      "description": "Class reference, defined outside the Profile Crate as indicated by @id url or inDefinedTermSet",
+      "@reverse": {
+        "hasPart": [
+          {
+            "@id": "https://w3id.org/ro/crate/1.2-DRAFT"
+          }
+        ]
+      }
+    },
+    {
+      "@id": "http://schema.org/Property",
+      "@type": [
+        "DefinedTerm",
+        "Class"
+      ],
+      "inDefinedTermSet": {
+        "@id": "http://schema.org/version/15.0/"
+      },
+      "name": "Property (schema.org)",
+      "description": "Property reference, defined outside the Profile Crate as indicated by @id url or inDefinedTermSet",
+      "@reverse": {
+        "hasPart": [
+          {
+            "@id": "https://w3id.org/ro/crate/1.2-DRAFT"
+          }
+        ]
+      }
+    },
+    {
+      "@id": "http://www.w3.org/ns/dx/prof",
+      "@type": "DefinedTermSet",
+      "name": "Profiles Vocabulary",
+      "sameAs": "http://www.w3.org/ns/dx/prof/1.0",
+      "url": "https://www.w3.org/TR/2019/NOTE-dx-prof-20191218/",
+      "version": "1.0",
+      "@reverse": {
+        "inDefinedTermSet": [
+          {
+            "@id": "http://www.w3.org/ns/dx/prof#Profile"
+          },
+          {
+            "@id": "http://www.w3.org/ns/dx/prof#ResourceDescriptor"
+          },
+          {
+            "@id": "http://www.w3.org/ns/dx/prof#ResourceRole"
+          },
+          {
+            "@id": "http://www.w3.org/ns/dx/prof#hasArtifact"
+          },
+          {
+            "@id": "http://www.w3.org/ns/dx/prof#hasResource"
+          },
+          {
+            "@id": "http://www.w3.org/ns/dx/prof#hasRole"
+          }
+        ],
+        "hasArtifact": [
+          {
+            "@id": "#vocabulary-prof"
+          }
+        ]
+      }
+    },
+    {
+      "@id": "http://www.w3.org/ns/dx/prof#Profile",
+      "@type": [
+        "DefinedTerm",
+        "Class"
+      ],
+      "inDefinedTermSet": {
+        "@id": "http://www.w3.org/ns/dx/prof"
+      },
+      "name": "Profile",
+      "sameAs": "https://www.w3.org/TR/2019/NOTE-dx-prof-20191218/#Class:Profile",
+      "termCode": "Profile",
+      "@reverse": {
+        "hasPart": [
+          {
+            "@id": "https://w3id.org/ro/crate/1.2-DRAFT"
+          }
+        ]
+      }
+    },
+    {
+      "@id": "http://www.w3.org/ns/dx/prof#ResourceDescriptor",
+      "@type": [
+        "DefinedTerm",
+        "Class"
+      ],
+      "inDefinedTermSet": {
+        "@id": "http://www.w3.org/ns/dx/prof"
+      },
+      "name": "Resource descriptor",
+      "sameAs": "https://www.w3.org/TR/2019/NOTE-dx-prof-20191218/#Class:ResourceDescriptor",
+      "termCode": "ResourceDescriptor",
+      "@reverse": {
+        "hasPart": [
+          {
+            "@id": "https://w3id.org/ro/crate/1.2-DRAFT"
+          }
+        ]
+      }
+    },
+    {
+      "@id": "http://www.w3.org/ns/dx/prof#ResourceRole",
+      "@type": [
+        "DefinedTerm",
+        "Class"
+      ],
+      "inDefinedTermSet": {
+        "@id": "http://www.w3.org/ns/dx/prof"
+      },
+      "name": "Resource role",
+      "sameAs": "https://www.w3.org/TR/2019/NOTE-dx-prof-20191218/#Class:ResourceRole",
+      "termCode": "ResourceRole",
+      "@reverse": {
+        "hasPart": [
+          {
+            "@id": "https://w3id.org/ro/crate/1.2-DRAFT"
+          }
+        ]
+      }
+    },
+    {
+      "@id": "http://www.w3.org/ns/dx/prof#hasArtifact",
+      "@type": [
+        "DefinedTerm",
+        "Property"
+      ],
+      "inDefinedTermSet": {
+        "@id": "http://www.w3.org/ns/dx/prof"
+      },
+      "name": "has artifact",
+      "sameAs": "https://www.w3.org/TR/2019/NOTE-dx-prof-20191218/#Property:hasArtifact",
+      "termCode": "hasArtifact",
+      "@reverse": {
+        "hasPart": [
+          {
+            "@id": "https://w3id.org/ro/crate/1.2-DRAFT"
+          }
+        ]
+      }
+    },
+    {
+      "@id": "http://www.w3.org/ns/dx/prof#hasResource",
+      "@type": [
+        "DefinedTerm",
+        "Property"
+      ],
+      "inDefinedTermSet": {
+        "@id": "http://www.w3.org/ns/dx/prof"
+      },
+      "name": "has resource",
+      "sameAs": "https://www.w3.org/TR/2019/NOTE-dx-prof-20191218/#Property:hasResource",
+      "termCode": "hasResource",
+      "@reverse": {
+        "hasPart": [
+          {
+            "@id": "https://w3id.org/ro/crate/1.2-DRAFT"
+          }
+        ]
+      }
+    },
+    {
+      "@id": "http://www.w3.org/ns/dx/prof#hasRole",
+      "@type": [
+        "DefinedTerm",
+        "Property"
+      ],
+      "inDefinedTermSet": {
+        "@id": "http://www.w3.org/ns/dx/prof"
+      },
+      "name": "has role",
+      "sameAs": "https://www.w3.org/TR/2019/NOTE-dx-prof-20191218/#Property:hasRole",
+      "termCode": "hasRole",
+      "@reverse": {
+        "hasPart": [
+          {
+            "@id": "https://w3id.org/ro/crate/1.2-DRAFT"
+          }
+        ]
+      }
+    },
+    {
+      "@id": "http://www.w3.org/ns/dx/prof#role/",
+      "@type": "DefinedTermSet",
+      "hasDefinedTerm": [
+        {
+          "@id": "http://www.w3.org/ns/dx/prof/role/constraints"
+        },
+        {
+          "@id": "http://www.w3.org/ns/dx/prof/role/example"
+        },
+        {
+          "@id": "http://www.w3.org/ns/dx/prof/role/guidance"
+        },
+        {
+          "@id": "http://www.w3.org/ns/dx/prof/role/mapping"
+        },
+        {
+          "@id": "http://www.w3.org/ns/dx/prof/role/schema"
+        },
+        {
+          "@id": "http://www.w3.org/ns/dx/prof/role/specification"
+        },
+        {
+          "@id": "http://www.w3.org/ns/dx/prof/role/validation"
+        },
+        {
+          "@id": "http://www.w3.org/ns/dx/prof/role/vocabulary"
+        }
+      ],
+      "name": "Resource Roles vocabulary",
+      "url": "https://www.w3.org/TR/2019/NOTE-dx-prof-20191218/#resource-roles-vocab"
+    },
+    {
+      "@id": "http://www.w3.org/ns/dx/prof/role/constraints",
+      "@type": [
+        "DefinedTerm",
+        "ResourceRole"
+      ],
+      "description": "Descriptions of obligations, limitations or extensions that the profile defines",
+      "name": "Constraints",
+      "sameAs": "https://www.w3.org/TR/2019/NOTE-dx-prof-20191218/#Role:constraints",
+      "@reverse": {
+        "hasDefinedTerm": [
+          {
+            "@id": "http://www.w3.org/ns/dx/prof#role/"
+          }
+        ]
+      }
+    },
+    {
+      "@id": "http://www.w3.org/ns/dx/prof/role/example",
+      "@type": [
+        "DefinedTerm",
+        "ResourceRole"
+      ],
+      "description": "Sample instance data conforming to the profile",
+      "name": "Example",
+      "sameAs": "https://www.w3.org/TR/2019/NOTE-dx-prof-20191218/#Role:example",
+      "@reverse": {
+        "hasDefinedTerm": [
+          {
+            "@id": "http://www.w3.org/ns/dx/prof#role/"
+          }
+        ],
+        "hasRole": [
+          {
+            "@id": "#example-rainfall"
+          }
+        ]
+      }
+    },
+    {
+      "@id": "http://www.w3.org/ns/dx/prof/role/guidance",
+      "@type": [
+        "DefinedTerm",
+        "ResourceRole"
+      ],
+      "description": "Documents, in human-readable form, how to use the profile",
+      "name": "Guidance",
+      "sameAs": "https://www.w3.org/TR/2019/NOTE-dx-prof-20191218/#Role:guidance",
+      "@reverse": {
+        "hasDefinedTerm": [
+          {
+            "@id": "http://www.w3.org/ns/dx/prof#role/"
+          }
+        ]
+      }
+    },
+    {
+      "@id": "http://www.w3.org/ns/dx/prof/role/mapping",
+      "@type": [
+        "DefinedTerm",
+        "ResourceRole"
+      ],
+      "description": "Describes conversions between two specifications",
+      "name": "Mapping",
+      "sameAs": "https://www.w3.org/TR/2019/NOTE-dx-prof-20191218/#Role:mapping",
+      "@reverse": {
+        "hasDefinedTerm": [
+          {
+            "@id": "http://www.w3.org/ns/dx/prof#role/"
+          }
+        ]
+      }
+    },
+    {
+      "@id": "http://www.w3.org/ns/dx/prof/role/schema",
+      "@type": [
+        "DefinedTerm",
+        "ResourceRole"
+      ],
+      "description": "Machine-readable structural descriptions of data defined by the profile",
+      "name": "Schema",
+      "sameAs": "https://www.w3.org/TR/2019/NOTE-dx-prof-20191218/#Role:schema",
+      "@reverse": {
+        "hasDefinedTerm": [
+          {
+            "@id": "http://www.w3.org/ns/dx/prof#role/"
+          }
+        ]
+      }
+    },
+    {
+      "@id": "http://www.w3.org/ns/dx/prof/role/specification",
+      "@type": [
+        "DefinedTerm",
+        "ResourceRole"
+      ],
+      "description": "Defining the profile in human-readable form",
+      "name": "Specification",
+      "sameAs": "https://www.w3.org/TR/2019/NOTE-dx-prof-20191218/#Role:specification",
+      "@reverse": {
+        "hasDefinedTerm": [
+          {
+            "@id": "http://www.w3.org/ns/dx/prof#role/"
+          }
+        ],
+        "hasRole": [
+          {
+            "@id": "#specification"
+          }
+        ]
+      }
+    },
+    {
+      "@id": "http://www.w3.org/ns/dx/prof/role/validation",
+      "@type": [
+        "DefinedTerm",
+        "ResourceRole"
+      ],
+      "description": "Supplies instructions about how to verify conformance of data to the profile",
+      "name": "Validation",
+      "sameAs": "https://www.w3.org/TR/2019/NOTE-dx-prof-20191218/#Role:validation",
+      "@reverse": {
+        "hasDefinedTerm": [
+          {
+            "@id": "http://www.w3.org/ns/dx/prof#role/"
+          }
+        ]
+      }
+    },
+    {
+      "@id": "http://www.w3.org/ns/dx/prof/role/vocabulary",
+      "@type": [
+        "DefinedTerm",
+        "ResourceRole"
+      ],
+      "description": "Defines terms used in the profile specification",
+      "name": "Vocabulary",
+      "sameAs": "https://www.w3.org/TR/2019/NOTE-dx-prof-20191218/#Role:vocabulary",
+      "@reverse": {
+        "hasDefinedTerm": [
+          {
+            "@id": "http://www.w3.org/ns/dx/prof#role/"
+          }
+        ],
+        "hasRole": [
+          {
+            "@id": "#vocabulary-pcdm"
+          },
+          {
+            "@id": "#vocabulary-prof"
+          },
+          {
+            "@id": "#vocabulary-prof-roles"
+          },
+          {
+            "@id": "#vocabulary-schema"
+          },
+          {
+            "@id": "#vocabulary-rdfs"
+          },
+          {
+            "@id": "#vocabulary-geosparql"
+          }
+        ]
+      }
+    },
+    {
+      "@id": "http://www.opengis.net/ont/geosparql#Geometry",
+      "@type": "DefinedTerm",
+      "description": "A coherent set of direct positions in space. The positions are held within a Spatial Reference System (SRS).",
+      "name": "Geometry",
+      "termCode": "Geometry",
+      "sameAs": "https://opengeospatial.github.io/ogc-geosparql/geosparql11/#Geometry",
+      "inDefinedTermSet": {
+        "@id": "http://www.opengis.net/ont/geosparql#"
+      },
+      "@reverse": {
+        "hasPart": [
+          {
+            "@id": "https://w3id.org/ro/crate/1.2-DRAFT"
+          }
+        ]
+      }
+    },
+    {
+      "@id": "http://www.opengis.net/ont/geosparql#asWKT",
+      "@type": "DefinedTerm",
+      "description": "The WKT serialization (ISO13249) of a Geometry.",
+      "name": "Geometry",
+      "termCode": "asWKT",
+      "sameAs": "https://opengeospatial.github.io/ogc-geosparql/geosparql11/#asWKT",
+      "inDefinedTermSet": {
+        "@id": "http://www.opengis.net/ont/geosparql#"
+      },
+      "@reverse": {
+        "hasPart": [
+          {
+            "@id": "https://w3id.org/ro/crate/1.2-DRAFT"
+          }
+        ]
+      }
+    },
+    {
+      "@id": "http://www.opengis.net/ont/geosparql#",
+      "@type": "DefinedTermSet",
+      "name": "GeoSPARQL ontology",
+      "version": "1.1",
+      "sameAs": "https://opengeospatial.github.io/ogc-geosparql/geosparql11/",
+      "url": "https://opengeospatial.github.io/ogc-geosparql/geosparql11/spec.html",
+      "@reverse": {
+        "inDefinedTermSet": [
+          {
+            "@id": "http://www.opengis.net/ont/geosparql#Geometry"
+          },
+          {
+            "@id": "http://www.opengis.net/ont/geosparql#asWKT"
+          }
+        ],
+        "hasArtifact": [
+          {
+            "@id": "#vocabulary-geosparql"
+          }
+        ]
+      }
+    },
+    {
+      "@id": "http://www.w3.org/ns/json-ld#Context",
+      "@type": "DefinedTerm",
+      "name": "JSON-LD Context",
+      "url": "https://www.w3.org/TR/json-ld/",
+      "@reverse": {
+        "conformsTo": [
+          {
+            "@id": "https://w3id.org/ro/crate/1.2-DRAFT/context"
+          }
+        ]
+      }
+    },
+    {
+      "@id": "http://www.w3.org/ns/json-ld#flattened",
+      "@type": "Profile",
+      "name": "Flattened JSON-LD",
+      "isProfileOf": {
+        "@id": "http://www.w3.org/TR/2014/REC-json-ld-20140116/"
+      },
+      "version": "1.0",
+      "url": "https://www.w3.org/TR/json-ld1/#flattened-document-form",
+      "@reverse": {
+        "isProfileOf": [
+          {
+            "@id": "https://w3id.org/ro/crate/1.2-DRAFT"
+          }
+        ]
+      }
+    },
+    {
+      "@id": "http://www.w3.org/TR/2014/REC-json-ld-20140116/",
+      "@type": "Standard",
+      "name": "JSON-LD 1.0",
+      "description": "A JSON-based Serialization for Linked Data",
+      "version": "1.0",
+      "sameAs": {
+        "@id": "https://www.nationalarchives.gov.uk/PRONOM/fmt/880"
+      },
+      "@reverse": {
+        "isProfileOf": [
+          {
+            "@id": "https://w3id.org/ro/crate/1.2-DRAFT"
+          },
+          {
+            "@id": "http://www.w3.org/ns/json-ld#flattened"
+          }
+        ]
+      }
+    },
+    {
+      "@id": "https://bioschemas.org/profiles/ComputationalWorkflow/1.0-RELEASE",
+      "@type": "Profile",
+      "description": "Bioschemas specification for describing a Computational Workflow",
+      "name": "ComputationalWorkflow profile",
+      "version": "1.0-RELEASE",
+      "@reverse": {
+        "isBasedOn": [
+          {
+            "@id": "https://w3id.org/ro/crate/1.2-DRAFT/context"
+          }
+        ]
+      }
+    },
+    {
+      "@id": "https://bioschemas.org/profiles/FormalParameter/1.0-RELEASE",
+      "description": "Bioschemas specification for describing a formal parameter in the Life Sciences",
+      "name": "FormalParameter Profile",
+      "version": "1.0-RELEASE",
+      "@reverse": {
+        "isBasedOn": [
+          {
+            "@id": "https://w3id.org/ro/crate/1.2-DRAFT/context"
+          }
+        ]
+      }
     },
     {
       "@id": "https://creativecommons.org/publicdomain/zero/1.0/",
@@ -369,353 +1225,46 @@
         "@id": "http://spdx.org/licenses/CC0-1.0"
       },
       "name": "Creative Commons Zero v1.0 Universal",
-      "version": "1.0"
-    },
-    {
-      "@id": "https://orcid.org/0000-0001-8131-2150",
-      "@type": "Person",
-      "name": "Eoghan Ó Carragáin"
-    },
-    {
-      "@id": "https://orcid.org/0000-0002-3545-944X",
-      "@type": "Person",
-      "name": "Peter Sefton"
-    },
-    {
-      "@id": "https://orcid.org/0000-0001-9842-9718",
-      "@type": "Person",
-      "name": "Stian Soiland-Reyes"
-    },
-    {
-      "@id": "https://orcid.org/0000-0002-9260-0753",
-      "@type": "Person",
-      "name": "Oscar Corcho"
-    },
-    {
-      "@id": "https://orcid.org/0000-0003-0454-7145",
-      "@type": "Person",
-      "name": "Daniel Garijo"
-    },
-    {
-      "@id": "https://orcid.org/0000-0003-4289-4922",
-      "@type": "Person",
-      "name": "Raul Palma"
-    },
-    {
-      "@id": "https://orcid.org/0000-0001-6565-5145",
-      "@type": "Person",
-      "name": "Frederik Coppens"
-    },
-    {
-      "@id": "https://orcid.org/0000-0003-1219-2137",
-      "@type": "Person",
-      "name": "Carole Goble"
-    },
-    {
-      "@id": "https://orcid.org/0000-0002-4806-5140",
-      "@type": "Person",
-      "name": "José María Fernández"
-    },
-    {
-      "@id": "https://orcid.org/0000-0002-7370-4805",
-      "@type": "Person",
-      "name": "Kyle Chard"
-    },
-    {
-      "@id": "https://orcid.org/0000-0002-5491-6431",
-      "@type": "Person",
-      "name": "Jose Manuel Gomez-Perez"
-    },
-    {
-      "@id": "https://orcid.org/0000-0002-2961-9670",
-      "@type": "Person",
-      "name": "Michael R Crusoe"
-    },
-    {
-      "@id": "https://orcid.org/0000-0002-6190-122X",
-      "@type": "Person",
-      "name": "Ignacio Eguinoa"
-    },
-    {
-      "@id": "https://orcid.org/0000-0002-2036-8350",
-      "@type": "Person",
-      "name": "Nick Juty"
-    },
-    {
-      "@id": "https://orcid.org/0000-0001-8420-5254",
-      "@type": "Person",
-      "name": "Kristi Holmes"
-    },
-    {
-      "@id": "https://orcid.org/0000-0002-3588-6257",
-      "@type": "Person",
-      "name": "Jason A. Clark"
-    },
-    {
-      "@id": "https://orcid.org/0000-0002-0309-604X",
-      "@type": "Person",
-      "name": "Salvador Capella-Gutierrez"
-    },
-    {
-      "@id": "https://orcid.org/0000-0002-5711-4872",
-      "@type": "Person",
-      "name": "Alasdair J. G. Gray"
-    },
-    {
-      "@id": "https://orcid.org/0000-0003-2130-0865",
-      "@type": "Person",
-      "name": "Stuart Owen"
-    },
-    {
-      "@id": "https://orcid.org/0000-0003-3156-2105",
-      "@type": "Person",
-      "name": "Alan R Williams"
-    },
-    {
-      "@id": "https://orcid.org/0000-0003-1130-2154",
-      "@type": "Person",
-      "name": "Giacomo Tartari"
-    },
-    {
-      "@id": "https://orcid.org/0000-0002-0048-3300",
-      "@type": "Person",
-      "name": "Finn Bacall"
-    },
-    {
-      "@id": "https://orcid.org/0000-0002-1756-2128",
-      "@type": "Person",
-      "name": "Thomas Thelen"
-    },
-    {
-      "@id": "https://orcid.org/0000-0002-7552-1009",
-      "@type": "Person",
-      "name": "Hervé Ménager"
-    },
-    {
-      "@id": "https://orcid.org/0000-0003-4929-1219",
-      "@type": "Person",
-      "name": "Laura Rodríguez-Navas"
-    },
-    {
-      "@id": "https://orcid.org/0000-0003-1541-5631",
-      "@type": "Person",
-      "name": "Paul Walk"
-    },
-    {
-      "@id": "https://orcid.org/0000-0002-0337-8610",
-      "@type": "Person",
-      "name": "brandon whitehead"
-    },
-    {
-      "@id": "https://orcid.org/0000-0001-6960-357X",
-      "@type": "Person",
-      "name": "Mark Wilkinson"
-    },
-    {
-      "@id": "https://orcid.org/0000-0003-0183-6910",
-      "@type": "Person",
-      "name": "Paul Groth"
-    },
-    {
-      "@id": "https://orcid.org/0000-0003-0223-1059",
-      "@type": "Person",
-      "name": "Erich Bremer"
-    },
-    {
-      "@id": "https://orcid.org/0000-0003-3986-0510",
-      "@type": "Person",
-      "alternateName": "LJ Garcia Castro",
-      "name": "Leyla Jael Castro"
-    },
-    {
-      "@id": "https://orcid.org/0000-0001-6022-9825",
-      "@type": "Person",
-      "name": "Karl Sebby"
-    },
-    {
-      "@id": "https://orcid.org/0000-0002-3468-0652",
-      "@type": "Person",
-      "name": "Alexander Kanitz"
-    },
-    {
-      "@id": "https://orcid.org/0000-0003-1991-0533",
-      "@type": "Person",
-      "name": "Ana Trisovic"
-    },
-    {
-      "@id": "https://orcid.org/0000-0003-3910-0474",
-      "@type": "Person",
-      "name": "Gavin Kennedy"
-    },
-    {
-      "@id": "https://orcid.org/0000-0003-3486-8193",
-      "@type": "Person",
-      "name": "Mark Graves"
-    },
-    {
-      "@id": "https://orcid.org/0000-0001-8172-8981",
-      "@type": "Person",
-      "name": "Jasper Koehorst"
-    },
-    {
-      "@id": "https://orcid.org/0000-0001-8271-5429",
-      "@type": "Person",
-      "name": "Simone Leo"
-    },
-    {
-      "@id": "https://orcid.org/0000-0002-9648-6484",
-      "@type": "Person",
-      "name": "Marc Portier"
-    },
-    {
-      "@id": "https://orcid.org/0000-0002-5432-2748",
-      "@type": "Person",
-      "name": "Paul Brack"
-    },
-    {
-      "@id": "https://orcid.org/0000-0003-1743-8300",
-      "@type": "Person",
-      "name": "Milan Ojsteršek"
-    },
-    {
-      "@id": "https://orcid.org/0000-0003-0522-5674",
-      "@type": "Person",
-      "name": "Bert Droesbeke"
-    },
-    {
-      "@id": "https://orcid.org/0000-0002-2142-1731",
-      "@type": "Person",
-      "name": "Chenxu Niu"
-    },
-    {
-      "@id": "https://orcid.org/0000-0002-9986-7223",
-      "@type": "Person",
-      "name": "Kosuke Tanabe"
-    },
-    {
-      "@id": "https://orcid.org/0000-0002-4929-7875",
-      "@type": "Person",
-      "name": "Tomasz Miksa"
-    },
-    {
-      "@id": "https://orcid.org/0000-0001-5383-6993",
-      "@type": "Person",
-      "name": "Marco La Rosa"
-    },
-    {
-      "@id": "https://orcid.org/0000-0001-6387-5988",
-      "@type": "Person",
-      "name": "Cedric Decruw"
-    },
-    {
-      "@id": "https://orcid.org/0000-0003-3883-4169",
-      "@type": "Person",
-      "name": "Andreas Czerniak"
-    },
-    {
-      "@id": "https://orcid.org/0000-0002-5761-7533",
-      "@type": "Person",
-      "name": "Jeremy Jay"
-    },
-    {
-      "@id": "https://orcid.org/0000-0002-0792-8157",
-      "@type": "Person",
-      "name": "Sergio Serra"
-    },
-    {
-      "@id": "https://orcid.org/0000-0001-8772-7904",
-      "@type": "Person",
-      "name": "Ronald Siebes"
-    },
-    {
-      "@id": "https://orcid.org/0000-0003-4196-3658",
-      "@type": "Person",
-      "name": "Shaun de Witt"
-    },
-    {
-      "@id": "https://orcid.org/0000-0002-2318-4477",
-      "@type": "Person",
-      "name": "Shady El Damaty"
-    },
-    {
-      "@id": "https://orcid.org/0000-0002-1248-3594",
-      "@type": "Person",
-      "name": "Douglas Lowe"
-    },
-    {
-      "@id": "https://orcid.org/0000-0003-1498-6205",
-      "@type": "Person",
-      "name": "Xuanqi Li"
-    },
-    {
-      "@id": "https://orcid.org/0000-0001-9888-7954",
-      "@type": "Person",
-      "name": "Sveinung Gundersen"
-    },
-    {
-      "@id": "https://orcid.org/0000-0001-9156-9478",
-      "@type": "Person",
-      "name": "Muhammad Radifar"
-    },
-    {
-      "@id": "https://orcid.org/0000-0002-0003-2024",
-      "@type": "Person",
-      "name": "Rudolf Wittner"
-    },
-    {
-      "@id": "https://orcid.org/0000-0002-4565-9760",
-      "@type": "Person",
-      "name": "Oliver Woolland"
-    },
-    {
-      "@id": "https://orcid.org/0000-0002-8940-4946",
-      "@type": "Person",
-      "name": "Paul De Geest"
-    },
-    {
-      "@id": "https://orcid.org/0000-0002-2257-9127",
-      "@type": "Person",
-      "name": "Douglas Fils"
-    },
-    {
-      "@id": "https://orcid.org/0000-0002-5526-7138",
-      "@type": "Person",
-      "name": "Florian Wetzels"
-    },
-    {
-      "@id": "https://orcid.org/0000-0003-0606-2512",
-      "@type": "Person",
-      "name": "Raül Sirvent"
-    },
-    {
-      "@id": "https://orcid.org/0000-0001-9228-2882",
-      "@type": "Person",
-      "name": "Abigail Miller"
-    },
-    {
-      "@id": "https://orcid.org/0000-0003-0617-9219",
-      "@type": "Person",
-      "name": "Jake Emerson"
-    },
-    {
-      "@id": "https://orcid.org/0000-0002-0679-4361",
-      "@type": "Person",
-      "name": "Davide Fucci"
-    },
-    {
-      "@id": "https://orcid.org/0000-0001-8250-4074",
-      "@type": "Person",
-      "name": "Bruno P. Kinoshita"
-    },
-    {
-      "@id": "https://orcid.org/0000-0003-1361-7301",
-      "@type": "Person",
-      "name": "Maciek Bąk"
-    },
-    {
-      "@id": "https://orcid.org/0000-0003-3234-6762",
-      "@type": "Person",
-      "name": "Jens Hollunder"
+      "version": "1.0",
+      "@reverse": {
+        "license": [
+          {
+            "@id": "ro-crate-metadata.json"
+          },
+          {
+            "@id": "https://w3id.org/ro/crate/1.2-DRAFT/context"
+          },
+          {
+            "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/examples/rainfall-1.2.0/"
+          }
+        ]
+      }
+    },
+    {
+      "@id": "https://creativecommons.org/licenses/by/4.0/",
+      "@type": "CreativeWork",
+      "identifier": {
+        "@id": "http://spdx.org/licenses/CC-BY-4.0"
+      },
+      "name": "Creative Commons Attribution 4.0 International",
+      "version": "4.0"
+    },
+    {
+      "@id": "https://doi.org/DOI",
+      "@type": "PropertyValue",
+      "propertyID": "https://registry.identifiers.org/registry/doi",
+      "value": "doi:DOI",
+      "url": "https://doi.org/DOI",
+      "@reverse": {
+        "identifier": [
+          {
+            "@id": "https://w3id.org/ro/crate/1.2-DRAFT"
+          },
+          {
+            "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/"
+          }
+        ]
+      }
     },
     {
       "@id": "https://doi.org/10.3233/DS-210053",
@@ -777,7 +1326,1863 @@
       "mainEntityOfPage": {
         "@id": "https://w3id.org/ro/doi/10.5281/zenodo.5146227"
       },
-      "name": "Packaging research artefacts with RO-Crate"
+      "name": "Packaging research artefacts with RO-Crate",
+      "@reverse": {
+        "citation": [
+          {
+            "@id": "https://w3id.org/ro/crate/1.2-DRAFT"
+          }
+        ]
+      }
+    },
+    {
+      "@id": "https://github.com/ResearchObject/ro-crate/releases/download/TAG/ro-crate-TAG.html",
+      "@type": "CreativeWork",
+      "encodingFormat": [
+        "text/html",
+        {
+          "@id": "https://www.nationalarchives.gov.uk/PRONOM/fmt/471"
+        }
+      ],
+      "isBasedOn": [
+        {
+          "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/"
+        },
+        {
+          "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/about.html"
+        },
+        {
+          "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/introduction.html"
+        },
+        {
+          "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/terminology.html"
+        },
+        {
+          "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/structure.html"
+        },
+        {
+          "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/metadata.html"
+        },
+        {
+          "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/root-data-entity.html"
+        },
+        {
+          "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/data-entities.html"
+        },
+        {
+          "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/crate-focus.html"
+        },
+        {
+          "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/contextual-entities.html"
+        },
+        {
+          "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/provenance.html"
+        },
+        {
+          "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/profiles.html"
+        },
+        {
+          "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/workflows.html"
+        },
+        {
+          "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/appendix/"
+        },
+        {
+          "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/appendix/changelog.html"
+        },
+        {
+          "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/appendix/implementation-notes.html"
+        },
+        {
+          "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/appendix/jsonld.html"
+        },
+        {
+          "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/appendix/relative-uris.html"
+        }
+      ],
+      "name": "RO-Crate Metadata Specification 1.2-DRAFT (single-page HTML)",
+      "sameAs": {
+        "@id": "https://zenodo.org/record/ZENODO/files/ro-crate-TAG.html"
+      },
+      "version": "TAG",
+      "@reverse": {
+        "hasPart": [
+          {
+            "@id": "https://w3id.org/ro/crate/1.2-DRAFT"
+          }
+        ],
+        "encoding": [
+          {
+            "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/"
+          }
+        ],
+        "hasArtifact": [
+          {
+            "@id": "#specification"
+          }
+        ]
+      }
+    },
+    {
+      "@id": "https://github.com/ResearchObject/ro-crate/releases/download/TAG/ro-crate-TAG.pdf",
+      "@type": "CreativeWork",
+      "encodingFormat": [
+        "application/pdf",
+        {
+          "@id": "https://www.nationalarchives.gov.uk/PRONOM/fmt/18"
+        }
+      ],
+      "isBasedOn": [
+        {
+          "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/"
+        },
+        {
+          "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/about.html"
+        },
+        {
+          "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/introduction.html"
+        },
+        {
+          "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/terminology.html"
+        },
+        {
+          "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/structure.html"
+        },
+        {
+          "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/metadata.html"
+        },
+        {
+          "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/root-data-entity.html"
+        },
+        {
+          "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/data-entities.html"
+        },
+        {
+          "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/crate-focus.html"
+        },
+        {
+          "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/contextual-entities.html"
+        },
+        {
+          "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/provenance.html"
+        },
+        {
+          "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/profiles.html"
+        },
+        {
+          "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/workflows.html"
+        },
+        {
+          "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/appendix/"
+        },
+        {
+          "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/appendix/changelog.html"
+        },
+        {
+          "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/appendix/implementation-notes.html"
+        },
+        {
+          "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/appendix/jsonld.html"
+        },
+        {
+          "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/appendix/relative-uris.html"
+        }
+      ],
+      "name": "RO-Crate Metadata Specification 1.2-DRAFT (PDF)",
+      "sameAs": {
+        "@id": "https://zenodo.org/record/ZENODO/files/ro-crate-1.2-DRAFT.pdf"
+      },
+      "version": "TAG",
+      "@reverse": {
+        "hasPart": [
+          {
+            "@id": "https://w3id.org/ro/crate/1.2-DRAFT"
+          }
+        ],
+        "encoding": [
+          {
+            "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/"
+          }
+        ]
+      }
+    },
+    {
+      "@id": "https://orcid.org/0000-0001-5383-6993",
+      "@type": "Person",
+      "name": "Marco La Rosa",
+      "@reverse": {
+        "author": [
+          {
+            "@id": "https://w3id.org/ro/crate/1.2-DRAFT"
+          },
+          {
+            "@id": "https://doi.org/10.3233/DS-210053"
+          }
+        ],
+        "member": [
+          {
+            "@id": "https://www.researchobject.org/ro-crate/community"
+          }
+        ]
+      }
+    },
+    {
+      "@id": "https://orcid.org/0000-0001-6022-9825",
+      "@type": "Person",
+      "name": "Karl Sebby",
+      "@reverse": {
+        "author": [
+          {
+            "@id": "https://w3id.org/ro/crate/1.2-DRAFT"
+          }
+        ],
+        "member": [
+          {
+            "@id": "https://www.researchobject.org/ro-crate/community"
+          }
+        ]
+      }
+    },
+    {
+      "@id": "https://orcid.org/0000-0001-6387-5988",
+      "@type": "Person",
+      "name": "Cedric Decruw",
+      "@reverse": {
+        "author": [
+          {
+            "@id": "https://w3id.org/ro/crate/1.2-DRAFT"
+          }
+        ],
+        "member": [
+          {
+            "@id": "https://www.researchobject.org/ro-crate/community"
+          }
+        ]
+      }
+    },
+    {
+      "@id": "https://orcid.org/0000-0001-6565-5145",
+      "@type": "Person",
+      "name": "Frederik Coppens",
+      "@reverse": {
+        "author": [
+          {
+            "@id": "https://w3id.org/ro/crate/1.2-DRAFT"
+          },
+          {
+            "@id": "https://doi.org/10.3233/DS-210053"
+          }
+        ],
+        "member": [
+          {
+            "@id": "https://www.researchobject.org/ro-crate/community"
+          }
+        ]
+      }
+    },
+    {
+      "@id": "https://orcid.org/0000-0001-6960-357X",
+      "@type": "Person",
+      "name": "Mark Wilkinson",
+      "@reverse": {
+        "author": [
+          {
+            "@id": "https://w3id.org/ro/crate/1.2-DRAFT"
+          }
+        ],
+        "member": [
+          {
+            "@id": "https://www.researchobject.org/ro-crate/community"
+          }
+        ]
+      }
+    },
+    {
+      "@id": "https://orcid.org/0000-0001-8131-2150",
+      "@type": "Person",
+      "name": "Eoghan Ó Carragáin",
+      "@reverse": {
+        "author": [
+          {
+            "@id": "https://w3id.org/ro/crate/1.2-DRAFT"
+          },
+          {
+            "@id": "https://doi.org/10.3233/DS-210053"
+          }
+        ],
+        "member": [
+          {
+            "@id": "https://www.researchobject.org/ro-crate/community"
+          }
+        ]
+      }
+    },
+    {
+      "@id": "https://orcid.org/0000-0001-8172-8981",
+      "@type": "Person",
+      "name": "Jasper Koehorst",
+      "@reverse": {
+        "author": [
+          {
+            "@id": "https://w3id.org/ro/crate/1.2-DRAFT"
+          }
+        ],
+        "member": [
+          {
+            "@id": "https://www.researchobject.org/ro-crate/community"
+          }
+        ]
+      }
+    },
+    {
+      "@id": "https://orcid.org/0000-0001-8250-4074",
+      "@type": "Person",
+      "name": "Bruno P. Kinoshita",
+      "@reverse": {
+        "author": [
+          {
+            "@id": "https://w3id.org/ro/crate/1.2-DRAFT"
+          }
+        ],
+        "member": [
+          {
+            "@id": "https://www.researchobject.org/ro-crate/community"
+          }
+        ]
+      }
+    },
+    {
+      "@id": "https://orcid.org/0000-0001-8271-5429",
+      "@type": "Person",
+      "name": "Simone Leo",
+      "@reverse": {
+        "author": [
+          {
+            "@id": "https://w3id.org/ro/crate/1.2-DRAFT"
+          },
+          {
+            "@id": "https://doi.org/10.3233/DS-210053"
+          }
+        ],
+        "member": [
+          {
+            "@id": "https://www.researchobject.org/ro-crate/community"
+          }
+        ]
+      }
+    },
+    {
+      "@id": "https://orcid.org/0000-0001-8420-5254",
+      "@type": "Person",
+      "name": "Kristi Holmes",
+      "@reverse": {
+        "author": [
+          {
+            "@id": "https://w3id.org/ro/crate/1.2-DRAFT"
+          }
+        ],
+        "member": [
+          {
+            "@id": "https://www.researchobject.org/ro-crate/community"
+          }
+        ]
+      }
+    },
+    {
+      "@id": "https://orcid.org/0000-0001-8772-7904",
+      "@type": "Person",
+      "name": "Ronald Siebes",
+      "@reverse": {
+        "author": [
+          {
+            "@id": "https://w3id.org/ro/crate/1.2-DRAFT"
+          }
+        ],
+        "member": [
+          {
+            "@id": "https://www.researchobject.org/ro-crate/community"
+          }
+        ]
+      }
+    },
+    {
+      "@id": "https://orcid.org/0000-0001-9156-9478",
+      "@type": "Person",
+      "name": "Muhammad Radifar",
+      "@reverse": {
+        "author": [
+          {
+            "@id": "https://w3id.org/ro/crate/1.2-DRAFT"
+          }
+        ],
+        "member": [
+          {
+            "@id": "https://www.researchobject.org/ro-crate/community"
+          }
+        ]
+      }
+    },
+    {
+      "@id": "https://orcid.org/0000-0001-9228-2882",
+      "@type": "Person",
+      "name": "Abigail Miller",
+      "@reverse": {
+        "author": [
+          {
+            "@id": "https://w3id.org/ro/crate/1.2-DRAFT"
+          }
+        ],
+        "member": [
+          {
+            "@id": "https://www.researchobject.org/ro-crate/community"
+          }
+        ]
+      }
+    },
+    {
+      "@id": "https://orcid.org/0000-0001-9842-9718",
+      "@type": "Person",
+      "name": "Stian Soiland-Reyes",
+      "@reverse": {
+        "author": [
+          {
+            "@id": "https://w3id.org/ro/crate/1.2-DRAFT"
+          },
+          {
+            "@id": "https://doi.org/10.3233/DS-210053"
+          }
+        ],
+        "member": [
+          {
+            "@id": "https://www.researchobject.org/ro-crate/community"
+          }
+        ]
+      }
+    },
+    {
+      "@id": "https://orcid.org/0000-0001-9888-7954",
+      "@type": "Person",
+      "name": "Sveinung Gundersen",
+      "@reverse": {
+        "author": [
+          {
+            "@id": "https://w3id.org/ro/crate/1.2-DRAFT"
+          }
+        ],
+        "member": [
+          {
+            "@id": "https://www.researchobject.org/ro-crate/community"
+          }
+        ]
+      }
+    },
+    {
+      "@id": "https://orcid.org/0000-0002-0003-2024",
+      "@type": "Person",
+      "name": "Rudolf Wittner",
+      "@reverse": {
+        "author": [
+          {
+            "@id": "https://w3id.org/ro/crate/1.2-DRAFT"
+          }
+        ],
+        "member": [
+          {
+            "@id": "https://www.researchobject.org/ro-crate/community"
+          }
+        ]
+      }
+    },
+    {
+      "@id": "https://orcid.org/0000-0002-0048-3300",
+      "@type": "Person",
+      "name": "Finn Bacall",
+      "@reverse": {
+        "author": [
+          {
+            "@id": "https://w3id.org/ro/crate/1.2-DRAFT"
+          }
+        ],
+        "member": [
+          {
+            "@id": "https://www.researchobject.org/ro-crate/community"
+          }
+        ]
+      }
+    },
+    {
+      "@id": "https://orcid.org/0000-0002-0309-604X",
+      "@type": "Person",
+      "name": "Salvador Capella-Gutierrez",
+      "@reverse": {
+        "author": [
+          {
+            "@id": "https://w3id.org/ro/crate/1.2-DRAFT"
+          }
+        ],
+        "member": [
+          {
+            "@id": "https://www.researchobject.org/ro-crate/community"
+          }
+        ]
+      }
+    },
+    {
+      "@id": "https://orcid.org/0000-0002-0337-8610",
+      "@type": "Person",
+      "name": "brandon whitehead",
+      "@reverse": {
+        "author": [
+          {
+            "@id": "https://w3id.org/ro/crate/1.2-DRAFT"
+          }
+        ],
+        "member": [
+          {
+            "@id": "https://www.researchobject.org/ro-crate/community"
+          }
+        ]
+      }
+    },
+    {
+      "@id": "https://orcid.org/0000-0002-0679-4361",
+      "@type": "Person",
+      "name": "Davide Fucci",
+      "@reverse": {
+        "author": [
+          {
+            "@id": "https://w3id.org/ro/crate/1.2-DRAFT"
+          }
+        ],
+        "member": [
+          {
+            "@id": "https://www.researchobject.org/ro-crate/community"
+          }
+        ]
+      }
+    },
+    {
+      "@id": "https://orcid.org/0000-0002-0792-8157",
+      "@type": "Person",
+      "name": "Sergio Serra",
+      "@reverse": {
+        "author": [
+          {
+            "@id": "https://w3id.org/ro/crate/1.2-DRAFT"
+          }
+        ],
+        "member": [
+          {
+            "@id": "https://www.researchobject.org/ro-crate/community"
+          }
+        ]
+      }
+    },
+    {
+      "@id": "https://orcid.org/0000-0002-1248-3594",
+      "@type": "Person",
+      "name": "Douglas Lowe",
+      "@reverse": {
+        "author": [
+          {
+            "@id": "https://w3id.org/ro/crate/1.2-DRAFT"
+          }
+        ],
+        "member": [
+          {
+            "@id": "https://www.researchobject.org/ro-crate/community"
+          }
+        ]
+      }
+    },
+    {
+      "@id": "https://orcid.org/0000-0002-1756-2128",
+      "@type": "Person",
+      "name": "Thomas Thelen",
+      "@reverse": {
+        "author": [
+          {
+            "@id": "https://w3id.org/ro/crate/1.2-DRAFT"
+          }
+        ],
+        "member": [
+          {
+            "@id": "https://www.researchobject.org/ro-crate/community"
+          }
+        ]
+      }
+    },
+    {
+      "@id": "https://orcid.org/0000-0002-2036-8350",
+      "@type": "Person",
+      "name": "Nick Juty",
+      "@reverse": {
+        "author": [
+          {
+            "@id": "https://w3id.org/ro/crate/1.2-DRAFT"
+          }
+        ],
+        "member": [
+          {
+            "@id": "https://www.researchobject.org/ro-crate/community"
+          }
+        ]
+      }
+    },
+    {
+      "@id": "https://orcid.org/0000-0002-2142-1731",
+      "@type": "Person",
+      "name": "Chenxu Niu",
+      "@reverse": {
+        "author": [
+          {
+            "@id": "https://w3id.org/ro/crate/1.2-DRAFT"
+          }
+        ],
+        "member": [
+          {
+            "@id": "https://www.researchobject.org/ro-crate/community"
+          }
+        ]
+      }
+    },
+    {
+      "@id": "https://orcid.org/0000-0002-2257-9127",
+      "@type": "Person",
+      "name": "Douglas Fils",
+      "@reverse": {
+        "author": [
+          {
+            "@id": "https://w3id.org/ro/crate/1.2-DRAFT"
+          }
+        ],
+        "member": [
+          {
+            "@id": "https://www.researchobject.org/ro-crate/community"
+          }
+        ]
+      }
+    },
+    {
+      "@id": "https://orcid.org/0000-0002-2318-4477",
+      "@type": "Person",
+      "name": "Shady El Damaty",
+      "@reverse": {
+        "author": [
+          {
+            "@id": "https://w3id.org/ro/crate/1.2-DRAFT"
+          }
+        ],
+        "member": [
+          {
+            "@id": "https://www.researchobject.org/ro-crate/community"
+          }
+        ]
+      }
+    },
+    {
+      "@id": "https://orcid.org/0000-0002-2961-9670",
+      "@type": "Person",
+      "name": "Michael R Crusoe",
+      "@reverse": {
+        "author": [
+          {
+            "@id": "https://w3id.org/ro/crate/1.2-DRAFT"
+          }
+        ],
+        "member": [
+          {
+            "@id": "https://www.researchobject.org/ro-crate/community"
+          }
+        ]
+      }
+    },
+    {
+      "@id": "https://orcid.org/0000-0002-3079-6586",
+      "@type": "Person",
+      "name": "Björn Grüning",
+      "@reverse": {
+        "author": [
+          {
+            "@id": "https://doi.org/10.3233/DS-210053"
+          }
+        ]
+      }
+    },
+    {
+      "@id": "https://orcid.org/0000-0002-3468-0652",
+      "@type": "Person",
+      "name": "Alexander Kanitz",
+      "@reverse": {
+        "author": [
+          {
+            "@id": "https://w3id.org/ro/crate/1.2-DRAFT"
+          }
+        ],
+        "member": [
+          {
+            "@id": "https://www.researchobject.org/ro-crate/community"
+          }
+        ]
+      }
+    },
+    {
+      "@id": "https://orcid.org/0000-0002-3545-944X",
+      "@type": "Person",
+      "name": "Peter Sefton",
+      "@reverse": {
+        "author": [
+          {
+            "@id": "https://w3id.org/ro/crate/1.2-DRAFT"
+          },
+          {
+            "@id": "https://doi.org/10.3233/DS-210053"
+          }
+        ],
+        "member": [
+          {
+            "@id": "https://www.researchobject.org/ro-crate/community"
+          }
+        ]
+      }
+    },
+    {
+      "@id": "https://orcid.org/0000-0002-3588-6257",
+      "@type": "Person",
+      "name": "Jason A. Clark",
+      "@reverse": {
+        "author": [
+          {
+            "@id": "https://w3id.org/ro/crate/1.2-DRAFT"
+          }
+        ],
+        "member": [
+          {
+            "@id": "https://www.researchobject.org/ro-crate/community"
+          }
+        ]
+      }
+    },
+    {
+      "@id": "https://orcid.org/0000-0002-4565-9760",
+      "@type": "Person",
+      "name": "Oliver Woolland",
+      "@reverse": {
+        "author": [
+          {
+            "@id": "https://w3id.org/ro/crate/1.2-DRAFT"
+          }
+        ],
+        "member": [
+          {
+            "@id": "https://www.researchobject.org/ro-crate/community"
+          }
+        ]
+      }
+    },
+    {
+      "@id": "https://orcid.org/0000-0002-4806-5140",
+      "@type": "Person",
+      "name": "José María Fernández",
+      "@reverse": {
+        "author": [
+          {
+            "@id": "https://w3id.org/ro/crate/1.2-DRAFT"
+          },
+          {
+            "@id": "https://doi.org/10.3233/DS-210053"
+          }
+        ],
+        "member": [
+          {
+            "@id": "https://www.researchobject.org/ro-crate/community"
+          }
+        ]
+      }
+    },
+    {
+      "@id": "https://orcid.org/0000-0002-4929-7875",
+      "@type": "Person",
+      "name": "Tomasz Miksa",
+      "@reverse": {
+        "author": [
+          {
+            "@id": "https://w3id.org/ro/crate/1.2-DRAFT"
+          }
+        ],
+        "member": [
+          {
+            "@id": "https://www.researchobject.org/ro-crate/community"
+          }
+        ]
+      }
+    },
+    {
+      "@id": "https://orcid.org/0000-0002-5432-2748",
+      "@type": "Person",
+      "name": "Paul Brack",
+      "@reverse": {
+        "author": [
+          {
+            "@id": "https://w3id.org/ro/crate/1.2-DRAFT"
+          }
+        ],
+        "member": [
+          {
+            "@id": "https://www.researchobject.org/ro-crate/community"
+          }
+        ]
+      }
+    },
+    {
+      "@id": "https://orcid.org/0000-0002-5491-6431",
+      "@type": "Person",
+      "name": "Jose Manuel Gomez-Perez",
+      "@reverse": {
+        "author": [
+          {
+            "@id": "https://w3id.org/ro/crate/1.2-DRAFT"
+          }
+        ],
+        "member": [
+          {
+            "@id": "https://www.researchobject.org/ro-crate/community"
+          }
+        ]
+      }
+    },
+    {
+      "@id": "https://orcid.org/0000-0002-5526-7138",
+      "@type": "Person",
+      "name": "Florian Wetzels",
+      "@reverse": {
+        "author": [
+          {
+            "@id": "https://w3id.org/ro/crate/1.2-DRAFT"
+          }
+        ],
+        "member": [
+          {
+            "@id": "https://www.researchobject.org/ro-crate/community"
+          }
+        ]
+      }
+    },
+    {
+      "@id": "https://orcid.org/0000-0002-5711-4872",
+      "@type": "Person",
+      "name": "Alasdair J. G. Gray",
+      "@reverse": {
+        "author": [
+          {
+            "@id": "https://w3id.org/ro/crate/1.2-DRAFT"
+          }
+        ],
+        "member": [
+          {
+            "@id": "https://www.researchobject.org/ro-crate/community"
+          }
+        ]
+      }
+    },
+    {
+      "@id": "https://orcid.org/0000-0002-5761-7533",
+      "@type": "Person",
+      "name": "Jeremy Jay",
+      "@reverse": {
+        "author": [
+          {
+            "@id": "https://w3id.org/ro/crate/1.2-DRAFT"
+          }
+        ],
+        "member": [
+          {
+            "@id": "https://www.researchobject.org/ro-crate/community"
+          }
+        ]
+      }
+    },
+    {
+      "@id": "https://orcid.org/0000-0002-6190-122X",
+      "@type": "Person",
+      "name": "Ignacio Eguinoa",
+      "@reverse": {
+        "author": [
+          {
+            "@id": "https://w3id.org/ro/crate/1.2-DRAFT"
+          }
+        ],
+        "member": [
+          {
+            "@id": "https://www.researchobject.org/ro-crate/community"
+          }
+        ]
+      }
+    },
+    {
+      "@id": "https://orcid.org/0000-0002-7370-4805",
+      "@type": "Person",
+      "name": "Kyle Chard",
+      "@reverse": {
+        "author": [
+          {
+            "@id": "https://w3id.org/ro/crate/1.2-DRAFT"
+          }
+        ],
+        "member": [
+          {
+            "@id": "https://www.researchobject.org/ro-crate/community"
+          }
+        ]
+      }
+    },
+    {
+      "@id": "https://orcid.org/0000-0002-7552-1009",
+      "@type": "Person",
+      "name": "Hervé Ménager",
+      "@reverse": {
+        "author": [
+          {
+            "@id": "https://w3id.org/ro/crate/1.2-DRAFT"
+          }
+        ],
+        "member": [
+          {
+            "@id": "https://www.researchobject.org/ro-crate/community"
+          }
+        ]
+      }
+    },
+    {
+      "@id": "https://orcid.org/0000-0002-8940-4946",
+      "@type": "Person",
+      "name": "Paul De Geest",
+      "@reverse": {
+        "author": [
+          {
+            "@id": "https://w3id.org/ro/crate/1.2-DRAFT"
+          }
+        ],
+        "member": [
+          {
+            "@id": "https://www.researchobject.org/ro-crate/community"
+          }
+        ]
+      }
+    },
+    {
+      "@id": "https://orcid.org/0000-0002-9260-0753",
+      "@type": "Person",
+      "name": "Oscar Corcho",
+      "@reverse": {
+        "author": [
+          {
+            "@id": "https://w3id.org/ro/crate/1.2-DRAFT"
+          }
+        ],
+        "member": [
+          {
+            "@id": "https://www.researchobject.org/ro-crate/community"
+          }
+        ]
+      }
+    },
+    {
+      "@id": "https://orcid.org/0000-0002-9648-6484",
+      "@type": "Person",
+      "name": "Marc Portier",
+      "@reverse": {
+        "author": [
+          {
+            "@id": "https://w3id.org/ro/crate/1.2-DRAFT"
+          },
+          {
+            "@id": "https://doi.org/10.3233/DS-210053"
+          }
+        ],
+        "member": [
+          {
+            "@id": "https://www.researchobject.org/ro-crate/community"
+          }
+        ]
+      }
+    },
+    {
+      "@id": "https://orcid.org/0000-0002-9986-7223",
+      "@type": "Person",
+      "name": "Kosuke Tanabe",
+      "@reverse": {
+        "author": [
+          {
+            "@id": "https://w3id.org/ro/crate/1.2-DRAFT"
+          }
+        ],
+        "member": [
+          {
+            "@id": "https://www.researchobject.org/ro-crate/community"
+          }
+        ]
+      }
+    },
+    {
+      "@id": "https://orcid.org/0000-0003-0183-6910",
+      "@type": "Person",
+      "name": "Paul Groth",
+      "@reverse": {
+        "author": [
+          {
+            "@id": "https://w3id.org/ro/crate/1.2-DRAFT"
+          },
+          {
+            "@id": "https://doi.org/10.3233/DS-210053"
+          }
+        ],
+        "member": [
+          {
+            "@id": "https://www.researchobject.org/ro-crate/community"
+          }
+        ]
+      }
+    },
+    {
+      "@id": "https://orcid.org/0000-0003-0223-1059",
+      "@type": "Person",
+      "name": "Erich Bremer",
+      "@reverse": {
+        "author": [
+          {
+            "@id": "https://w3id.org/ro/crate/1.2-DRAFT"
+          }
+        ],
+        "member": [
+          {
+            "@id": "https://www.researchobject.org/ro-crate/community"
+          }
+        ]
+      }
+    },
+    {
+      "@id": "https://orcid.org/0000-0003-0454-7145",
+      "@type": "Person",
+      "name": "Daniel Garijo",
+      "@reverse": {
+        "author": [
+          {
+            "@id": "https://w3id.org/ro/crate/1.2-DRAFT"
+          },
+          {
+            "@id": "https://doi.org/10.3233/DS-210053"
+          }
+        ],
+        "member": [
+          {
+            "@id": "https://www.researchobject.org/ro-crate/community"
+          }
+        ]
+      }
+    },
+    {
+      "@id": "https://orcid.org/0000-0003-0522-5674",
+      "@type": "Person",
+      "name": "Bert Droesbeke",
+      "@reverse": {
+        "author": [
+          {
+            "@id": "https://w3id.org/ro/crate/1.2-DRAFT"
+          }
+        ],
+        "member": [
+          {
+            "@id": "https://www.researchobject.org/ro-crate/community"
+          }
+        ]
+      }
+    },
+    {
+      "@id": "https://orcid.org/0000-0003-0606-2512",
+      "@type": "Person",
+      "name": "Raül Sirvent",
+      "@reverse": {
+        "author": [
+          {
+            "@id": "https://w3id.org/ro/crate/1.2-DRAFT"
+          }
+        ],
+        "member": [
+          {
+            "@id": "https://www.researchobject.org/ro-crate/community"
+          }
+        ]
+      }
+    },
+    {
+      "@id": "https://orcid.org/0000-0003-0617-9219",
+      "@type": "Person",
+      "name": "Jake Emerson",
+      "@reverse": {
+        "author": [
+          {
+            "@id": "https://w3id.org/ro/crate/1.2-DRAFT"
+          }
+        ],
+        "member": [
+          {
+            "@id": "https://www.researchobject.org/ro-crate/community"
+          }
+        ]
+      }
+    },
+    {
+      "@id": "https://orcid.org/0000-0003-1130-2154",
+      "@type": "Person",
+      "name": "Giacomo Tartari",
+      "@reverse": {
+        "author": [
+          {
+            "@id": "https://w3id.org/ro/crate/1.2-DRAFT"
+          }
+        ],
+        "member": [
+          {
+            "@id": "https://www.researchobject.org/ro-crate/community"
+          }
+        ]
+      }
+    },
+    {
+      "@id": "https://orcid.org/0000-0003-1219-2137",
+      "@type": "Person",
+      "name": "Carole Goble",
+      "@reverse": {
+        "author": [
+          {
+            "@id": "https://w3id.org/ro/crate/1.2-DRAFT"
+          },
+          {
+            "@id": "https://doi.org/10.3233/DS-210053"
+          }
+        ],
+        "member": [
+          {
+            "@id": "https://www.researchobject.org/ro-crate/community"
+          }
+        ]
+      }
+    },
+    {
+      "@id": "https://orcid.org/0000-0003-1304-1939",
+      "@type": "Person",
+      "name": "Mercè Crosas",
+      "@reverse": {
+        "author": [
+          {
+            "@id": "https://doi.org/10.3233/DS-210053"
+          }
+        ]
+      }
+    },
+    {
+      "@id": "https://orcid.org/0000-0003-1361-7301",
+      "@type": "Person",
+      "name": "Maciek Bąk",
+      "@reverse": {
+        "author": [
+          {
+            "@id": "https://w3id.org/ro/crate/1.2-DRAFT"
+          }
+        ],
+        "member": [
+          {
+            "@id": "https://www.researchobject.org/ro-crate/community"
+          }
+        ]
+      }
+    },
+    {
+      "@id": "https://orcid.org/0000-0003-1498-6205",
+      "@type": "Person",
+      "name": "Xuanqi Li",
+      "@reverse": {
+        "author": [
+          {
+            "@id": "https://w3id.org/ro/crate/1.2-DRAFT"
+          }
+        ],
+        "member": [
+          {
+            "@id": "https://www.researchobject.org/ro-crate/community"
+          }
+        ]
+      }
+    },
+    {
+      "@id": "https://orcid.org/0000-0003-1541-5631",
+      "@type": "Person",
+      "name": "Paul Walk",
+      "@reverse": {
+        "author": [
+          {
+            "@id": "https://w3id.org/ro/crate/1.2-DRAFT"
+          }
+        ],
+        "member": [
+          {
+            "@id": "https://www.researchobject.org/ro-crate/community"
+          }
+        ]
+      }
+    },
+    {
+      "@id": "https://orcid.org/0000-0003-1743-8300",
+      "@type": "Person",
+      "name": "Milan Ojsteršek",
+      "@reverse": {
+        "author": [
+          {
+            "@id": "https://w3id.org/ro/crate/1.2-DRAFT"
+          }
+        ],
+        "member": [
+          {
+            "@id": "https://www.researchobject.org/ro-crate/community"
+          }
+        ]
+      }
+    },
+    {
+      "@id": "https://orcid.org/0000-0003-1991-0533",
+      "@type": "Person",
+      "name": "Ana Trisovic",
+      "@reverse": {
+        "author": [
+          {
+            "@id": "https://w3id.org/ro/crate/1.2-DRAFT"
+          },
+          {
+            "@id": "https://doi.org/10.3233/DS-210053"
+          }
+        ],
+        "member": [
+          {
+            "@id": "https://www.researchobject.org/ro-crate/community"
+          }
+        ]
+      }
+    },
+    {
+      "@id": "https://orcid.org/0000-0003-2130-0865",
+      "@type": "Person",
+      "name": "Stuart Owen",
+      "@reverse": {
+        "author": [
+          {
+            "@id": "https://w3id.org/ro/crate/1.2-DRAFT"
+          }
+        ],
+        "member": [
+          {
+            "@id": "https://www.researchobject.org/ro-crate/community"
+          }
+        ]
+      }
+    },
+    {
+      "@id": "https://orcid.org/0000-0003-3156-2105",
+      "@type": "Person",
+      "name": "Alan R Williams",
+      "@reverse": {
+        "author": [
+          {
+            "@id": "https://w3id.org/ro/crate/1.2-DRAFT"
+          }
+        ],
+        "member": [
+          {
+            "@id": "https://www.researchobject.org/ro-crate/community"
+          }
+        ]
+      }
+    },
+    {
+      "@id": "https://orcid.org/0000-0003-3234-6762",
+      "@type": "Person",
+      "name": "Jens Hollunder",
+      "@reverse": {
+        "author": [
+          {
+            "@id": "https://w3id.org/ro/crate/1.2-DRAFT"
+          }
+        ],
+        "member": [
+          {
+            "@id": "https://www.researchobject.org/ro-crate/community"
+          }
+        ]
+      }
+    },
+    {
+      "@id": "https://orcid.org/0000-0003-3486-8193",
+      "@type": "Person",
+      "name": "Mark Graves",
+      "@reverse": {
+        "author": [
+          {
+            "@id": "https://w3id.org/ro/crate/1.2-DRAFT"
+          }
+        ],
+        "member": [
+          {
+            "@id": "https://www.researchobject.org/ro-crate/community"
+          }
+        ]
+      }
+    },
+    {
+      "@id": "https://orcid.org/0000-0003-3883-4169",
+      "@type": "Person",
+      "name": "Andreas Czerniak",
+      "@reverse": {
+        "author": [
+          {
+            "@id": "https://w3id.org/ro/crate/1.2-DRAFT"
+          }
+        ],
+        "member": [
+          {
+            "@id": "https://www.researchobject.org/ro-crate/community"
+          }
+        ]
+      }
+    },
+    {
+      "@id": "https://orcid.org/0000-0003-3910-0474",
+      "@type": "Person",
+      "name": "Gavin Kennedy",
+      "@reverse": {
+        "author": [
+          {
+            "@id": "https://w3id.org/ro/crate/1.2-DRAFT"
+          }
+        ],
+        "member": [
+          {
+            "@id": "https://www.researchobject.org/ro-crate/community"
+          }
+        ]
+      }
+    },
+    {
+      "@id": "https://orcid.org/0000-0003-3986-0510",
+      "@type": "Person",
+      "alternateName": "LJ Garcia Castro",
+      "name": "Leyla Jael Castro",
+      "@reverse": {
+        "author": [
+          {
+            "@id": "https://w3id.org/ro/crate/1.2-DRAFT"
+          },
+          {
+            "@id": "https://doi.org/10.3233/DS-210053"
+          }
+        ],
+        "member": [
+          {
+            "@id": "https://www.researchobject.org/ro-crate/community"
+          }
+        ]
+      }
+    },
+    {
+      "@id": "https://orcid.org/0000-0003-4196-3658",
+      "@type": "Person",
+      "name": "Shaun de Witt",
+      "@reverse": {
+        "author": [
+          {
+            "@id": "https://w3id.org/ro/crate/1.2-DRAFT"
+          }
+        ],
+        "member": [
+          {
+            "@id": "https://www.researchobject.org/ro-crate/community"
+          }
+        ]
+      }
+    },
+    {
+      "@id": "https://orcid.org/0000-0003-4289-4922",
+      "@type": "Person",
+      "name": "Raul Palma",
+      "@reverse": {
+        "author": [
+          {
+            "@id": "https://w3id.org/ro/crate/1.2-DRAFT"
+          }
+        ],
+        "member": [
+          {
+            "@id": "https://www.researchobject.org/ro-crate/community"
+          }
+        ]
+      }
+    },
+    {
+      "@id": "https://orcid.org/0000-0003-4929-1219",
+      "@type": "Person",
+      "name": "Laura Rodríguez-Navas",
+      "@reverse": {
+        "author": [
+          {
+            "@id": "https://w3id.org/ro/crate/1.2-DRAFT"
+          }
+        ],
+        "member": [
+          {
+            "@id": "https://www.researchobject.org/ro-crate/community"
+          }
+        ]
+      }
+    },
+    {
+      "@id": "http://spdx.org/licenses/CC0-1.0",
+      "@type": "PropertyValue",
+      "propertyID": "http://spdx.org/rdf/terms#licenseId",
+      "name": "spdx",
+      "value": "CC0-1.0",
+      "@reverse": {
+        "identifier": [
+          {
+            "@id": "https://creativecommons.org/publicdomain/zero/1.0/"
+          }
+        ]
+      }
+    },
+    {
+      "@id": "http://spdx.org/licenses/CC-BY-4.0",
+      "@type": "PropertyValue",
+      "propertyID": "http://spdx.org/rdf/terms#licenseId",
+      "name": "spdx",
+      "value": "CC-BY-4.0",
+      "@reverse": {
+        "identifier": [
+          {
+            "@id": "https://creativecommons.org/licenses/by/4.0/"
+          }
+        ]
+      }
+    },
+    {
+      "@id": "http://spdx.org/licenses/Apache-2.0",
+      "@type": "PropertyValue",
+      "propertyID": "http://spdx.org/rdf/terms#licenseId",
+      "name": "spdx",
+      "value": "Apache-2.0",
+      "@reverse": {
+        "identifier": [
+          {
+            "@id": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        ]
+      }
+    },
+    {
+      "@id": "https://w3id.org/ro/crate/",
+      "@type": "WebSite",
+      "maintainer": {
+        "@id": "https://www.researchobject.org/ro-crate/community"
+      },
+      "name": "Research Object Crate (RO-Crate) website",
+      "publisher": {
+        "@id": "https://www.researchobject.org/"
+      },
+      "url": "https://www.researchobject.org/ro-crate/",
+      "@reverse": {
+        "isPartOf": [
+          {
+            "@id": "https://w3id.org/ro/crate/1.2-DRAFT"
+          }
+        ]
+      }
+    },
+    {
+      "@id": "https://w3id.org/ro/crate/1.1",
+      "@type": "Dataset",
+      "name": "RO-Crate specification 1.1",
+      "version": "1.1.2",
+      "@reverse": {
+        "isBasedOn": [
+          {
+            "@id": "https://w3id.org/ro/crate/1.2-DRAFT"
+          }
+        ]
+      }
+    },
+    {
+      "@id": "https://w3id.org/ro/crate/1.2-DRAFT/context",
+      "@type": "File",
+      "conformsTo": {
+        "@id": "http://www.w3.org/ns/json-ld#Context"
+      },
+      "encodingFormat": "application/ld+json",
+      "isBasedOn": [
+        {
+          "@id": "http://schema.org/version/15.0/"
+        },
+        {
+          "@id": "https://pcdm.org/2016/04/18/models"
+        },
+        {
+          "@id": "https://bioschemas.org/profiles/ComputationalWorkflow/1.0-RELEASE"
+        },
+        {
+          "@id": "https://bioschemas.org/profiles/FormalParameter/1.0-RELEASE"
+        }
+      ],
+      "license": {
+        "@id": "https://creativecommons.org/publicdomain/zero/1.0/"
+      },
+      "name": "RO-Crate JSON-LD Context",
+      "sameAs": [
+        {
+          "@id": "https://zenodo.org/record/ZENODO/files/ro-crate-context-TAG.jsonld"
+        },
+        {
+          "@id": "https://github.com/ResearchObject/ro-crate/releases/download/TAG/ro-crate-context-TAG.jsonld"
+        },
+        {
+          "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/context.jsonld"
+        }
+      ],
+      "version": "TAG",
+      "@reverse": {
+        "hasPart": [
+          {
+            "@id": "https://w3id.org/ro/crate/1.2-DRAFT"
+          }
+        ]
+      }
+    },
+    {
+      "@id": "https://w3id.org/ro/doi/10.5281/zenodo.5146227",
+      "@type": "Dataset",
+      "name": "Packaging research artefacts with RO-Crate (RO-Crate)",
+      "@reverse": {
+        "mainEntityOfPage": [
+          {
+            "@id": "https://doi.org/10.3233/DS-210053"
+          }
+        ]
+      }
+    },
+    {
+      "@id": "https://www.apache.org/licenses/LICENSE-2.0",
+      "@type": "CreativeWork",
+      "name": "Apache License 2.0",
+      "version": "2.0",
+      "identifier": {
+        "@id": "http://spdx.org/licenses/Apache-2.0"
+      },
+      "@reverse": {
+        "license": [
+          {
+            "@id": "https://w3id.org/ro/crate/1.2-DRAFT"
+          }
+        ]
+      }
+    },
+    {
+      "@id": "https://www.iana.org/assignments/link-relations/",
+      "@type": "DefinedTermSet",
+      "name": "IANA Link Relations",
+      "@reverse": {
+        "inDefinedTermSet": [
+          {
+            "@id": "http://www.iana.org/assignments/relation/cite-as"
+          }
+        ]
+      }
+    },
+    {
+      "@id": "https://www.nationalarchives.gov.uk/PRONOM/fmt/18",
+      "@type": "WebPage",
+      "alternateName": "PDF 1.4",
+      "name": "Acrobat PDF 1.4 - Portable Document Format",
+      "@reverse": {
+        "encodingFormat": [
+          {
+            "@id": "https://github.com/ResearchObject/ro-crate/releases/download/TAG/ro-crate-TAG.pdf"
+          }
+        ]
+      }
+    },
+    {
+      "@id": "https://www.nationalarchives.gov.uk/PRONOM/fmt/471",
+      "@type": "WebPage",
+      "alternateName": "HTML5",
+      "name": "Hypertext Markup Language 5",
+      "@reverse": {
+        "encodingFormat": [
+          {
+            "@id": "https://github.com/ResearchObject/ro-crate/releases/download/TAG/ro-crate-TAG.html"
+          },
+          {
+            "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/"
+          }
+        ]
+      }
+    },
+    {
+      "@id": "https://www.researchobject.org/",
+      "@type": "Organization",
+      "name": "ResearchObject.org",
+      "url": "https://www.researchobject.org/",
+      "@reverse": {
+        "publisher": [
+          {
+            "@id": "https://w3id.org/ro/crate/1.2-DRAFT"
+          },
+          {
+            "@id": "https://w3id.org/ro/crate/"
+          }
+        ],
+        "parentOrganization": [
+          {
+            "@id": "https://www.researchobject.org/ro-crate/community"
+          }
+        ]
+      }
+    },
+    {
+      "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/about.html",
+      "@type": "WebPage",
+      "name": "About this document",
+      "@reverse": {
+        "isBasedOn": [
+          {
+            "@id": "https://github.com/ResearchObject/ro-crate/releases/download/TAG/ro-crate-TAG.html"
+          },
+          {
+            "@id": "https://github.com/ResearchObject/ro-crate/releases/download/TAG/ro-crate-TAG.pdf"
+          }
+        ]
+      }
+    },
+    {
+      "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/appendix/changelog.html",
+      "@type": "WebPage",
+      "name": "Changelog",
+      "@reverse": {
+        "isBasedOn": [
+          {
+            "@id": "https://github.com/ResearchObject/ro-crate/releases/download/TAG/ro-crate-TAG.html"
+          },
+          {
+            "@id": "https://github.com/ResearchObject/ro-crate/releases/download/TAG/ro-crate-TAG.pdf"
+          }
+        ],
+        "hasPart": [
+          {
+            "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/appendix/"
+          },
+          {
+            "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/"
+          }
+        ]
+      }
+    },
+    {
+      "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/appendix/implementation-notes.html",
+      "@type": "WebPage",
+      "name": "Implementation notes",
+      "@reverse": {
+        "isBasedOn": [
+          {
+            "@id": "https://github.com/ResearchObject/ro-crate/releases/download/TAG/ro-crate-TAG.html"
+          },
+          {
+            "@id": "https://github.com/ResearchObject/ro-crate/releases/download/TAG/ro-crate-TAG.pdf"
+          }
+        ],
+        "hasPart": [
+          {
+            "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/appendix/"
+          },
+          {
+            "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/"
+          }
+        ]
+      }
+    },
+    {
+      "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/appendix/",
+      "@type": "WebPage",
+      "name": "Appendix",
+      "hasPart": [
+        {
+          "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/appendix/changelog.html"
+        },
+        {
+          "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/appendix/implementation-notes.html"
+        },
+        {
+          "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/appendix/jsonld.html"
+        },
+        {
+          "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/appendix/relative-uris.html"
+        }
+      ],
+      "@reverse": {
+        "isBasedOn": [
+          {
+            "@id": "https://github.com/ResearchObject/ro-crate/releases/download/TAG/ro-crate-TAG.html"
+          },
+          {
+            "@id": "https://github.com/ResearchObject/ro-crate/releases/download/TAG/ro-crate-TAG.pdf"
+          }
+        ],
+        "hasPart": [
+          {
+            "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/"
+          }
+        ]
+      }
+    },
+    {
+      "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/appendix/jsonld.html",
+      "@type": "WebPage",
+      "name": "RO-Crate JSON-LD",
+      "@reverse": {
+        "isBasedOn": [
+          {
+            "@id": "https://github.com/ResearchObject/ro-crate/releases/download/TAG/ro-crate-TAG.html"
+          },
+          {
+            "@id": "https://github.com/ResearchObject/ro-crate/releases/download/TAG/ro-crate-TAG.pdf"
+          }
+        ],
+        "hasPart": [
+          {
+            "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/appendix/"
+          },
+          {
+            "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/"
+          }
+        ]
+      }
+    },
+    {
+      "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/appendix/relative-uris.html",
+      "@type": "WebPage",
+      "name": "Handling relative URI references",
+      "@reverse": {
+        "isBasedOn": [
+          {
+            "@id": "https://github.com/ResearchObject/ro-crate/releases/download/TAG/ro-crate-TAG.html"
+          },
+          {
+            "@id": "https://github.com/ResearchObject/ro-crate/releases/download/TAG/ro-crate-TAG.pdf"
+          }
+        ],
+        "hasPart": [
+          {
+            "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/appendix/"
+          },
+          {
+            "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/"
+          }
+        ]
+      }
+    },
+    {
+      "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/contextual-entities.html",
+      "@type": "WebPage",
+      "name": "Contextual Entities",
+      "@reverse": {
+        "isBasedOn": [
+          {
+            "@id": "https://github.com/ResearchObject/ro-crate/releases/download/TAG/ro-crate-TAG.html"
+          },
+          {
+            "@id": "https://github.com/ResearchObject/ro-crate/releases/download/TAG/ro-crate-TAG.pdf"
+          }
+        ],
+        "hasPart": [
+          {
+            "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/"
+          }
+        ]
+      }
+    },
+    {
+      "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/crate-focus.html",
+      "@type": "WebPage",
+      "name": "The focus of an RO-Crate",
+      "@reverse": {
+        "isBasedOn": [
+          {
+            "@id": "https://github.com/ResearchObject/ro-crate/releases/download/TAG/ro-crate-TAG.html"
+          },
+          {
+            "@id": "https://github.com/ResearchObject/ro-crate/releases/download/TAG/ro-crate-TAG.pdf"
+          }
+        ],
+        "hasPart": [
+          {
+            "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/"
+          }
+        ]
+      }
+    },
+    {
+      "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/data-entities.html",
+      "@type": "WebPage",
+      "name": "Data Entities",
+      "@reverse": {
+        "isBasedOn": [
+          {
+            "@id": "https://github.com/ResearchObject/ro-crate/releases/download/TAG/ro-crate-TAG.html"
+          },
+          {
+            "@id": "https://github.com/ResearchObject/ro-crate/releases/download/TAG/ro-crate-TAG.pdf"
+          }
+        ],
+        "hasPart": [
+          {
+            "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/"
+          }
+        ]
+      }
+    },
+    {
+      "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/examples/rainfall-1.2.0/",
+      "@type": "Dataset",
+      "conformsTo": {
+        "@id": "https://w3id.org/ro/crate/1.2-DRAFT"
+      },
+      "name": "Example dataset for RO-Crate specification",
+      "license": {
+        "@id": "https://creativecommons.org/publicdomain/zero/1.0/"
+      },
+      "subjectOf": [
+        {
+          "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/examples/rainfall-1.2.0/ro-crate-metadata.json"
+        },
+        {
+          "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/examples/rainfall-1.2.0/ro-crate-preview.html"
+        }
+      ],
+      "@reverse": {
+        "hasPart": [
+          {
+            "@id": "https://w3id.org/ro/crate/1.2-DRAFT"
+          }
+        ],
+        "hasArtifact": [
+          {
+            "@id": "#example-rainfall"
+          }
+        ]
+      }
     },
     {
       "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/",
@@ -856,474 +3261,181 @@
         {
           "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/appendix/relative-uris.html"
         }
-      ]
-    },
-    {
-      "@id": "https://w3id.org/ro/crate/1.2-DRAFT/context",
-      "@type": "File",
-      "conformsTo": {
-        "@id": "http://www.w3.org/ns/json-ld#Context"
-      },
-      "encodingFormat": "application/ld+json",
-      "isBasedOn": [
-        {
-          "@id": "http://schema.org/version/15.0/"
-        },
-        {
-          "@id": "https://pcdm.org/2016/04/18/models"
-        },
-        {
-          "@id": "https://bioschemas.org/profiles/ComputationalWorkflow/1.0-RELEASE"
-        },
-        {
-          "@id": "https://bioschemas.org/profiles/FormalParameter/1.0-RELEASE"
-        }
       ],
-      "license": {
-        "@id": "https://creativecommons.org/publicdomain/zero/1.0/"
-      },
-      "name": "RO-Crate JSON-LD Context",
-      "sameAs": [
-        {
-          "@id": "https://zenodo.org/record/ZENODO/files/ro-crate-context-TAG.jsonld"
-        },
-        {
-          "@id": "https://github.com/ResearchObject/ro-crate/releases/download/TAG/ro-crate-context-TAG.jsonld"
-        },
-        {
-          "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/context.jsonld"
-        }
-      ],
-      "version": "TAG"
-    },
-    {
-      "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/examples/rainfall-1.2.0/",
-      "@type": "Dataset",
-      "conformsTo": {
-        "@id": "https://w3id.org/ro/crate/1.2-DRAFT"
-      },
-      "name": "Example dataset for RO-Crate specification",
-      "license": {
-        "@id": "https://creativecommons.org/publicdomain/zero/1.0/"
-      },
-      "subjectOf": [
-        {
-          "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/examples/rainfall-1.2.0/ro-crate-metadata.json"
-        },
-        {
-          "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/examples/rainfall-1.2.0/ro-crate-preview.html"
-        }
-      ]
-    },
-    {
-      "@id": "https://github.com/ResearchObject/ro-crate/releases/download/TAG/ro-crate-TAG.html",
-      "@type": "CreativeWork",
-      "encodingFormat": [
-        "text/html",
-        {
-          "@id": "https://www.nationalarchives.gov.uk/PRONOM/fmt/471"
-        }
-      ],
-      "isBasedOn": [
-        {
-          "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/"
-        },
-        {
-          "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/about.html"
-        },
-        {
-          "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/introduction.html"
-        },
-        {
-          "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/terminology.html"
-        },
-        {
-          "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/structure.html"
-        },
-        {
-          "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/metadata.html"
-        },
-        {
-          "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/root-data-entity.html"
-        },
-        {
-          "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/data-entities.html"
-        },
-        {
-          "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/crate-focus.html"
-        },
-        {
-          "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/contextual-entities.html"
-        },
-        {
-          "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/provenance.html"
-        },
-        {
-          "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/profiles.html"
-        },
-        {
-          "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/workflows.html"
-        },
-        {
-          "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/appendix/"
-        },
-        {
-          "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/appendix/changelog.html"
-        },
-        {
-          "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/appendix/implementation-notes.html"
-        },
-        {
-          "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/appendix/jsonld.html"
-        },
-        {
-          "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/appendix/relative-uris.html"
-        }
-      ],
-      "name": "RO-Crate Metadata Specification 1.2-DRAFT (single-page HTML)",
-      "sameAs": {
-        "@id": "https://zenodo.org/record/ZENODO/files/ro-crate-TAG.html"
-      },
-      "version": "TAG"
-    },
-    {
-      "@id": "https://github.com/ResearchObject/ro-crate/releases/download/TAG/ro-crate-TAG.pdf",
-      "@type": "CreativeWork",
-      "encodingFormat": [
-        "application/pdf",
-        {
-          "@id": "https://www.nationalarchives.gov.uk/PRONOM/fmt/18"
-        }
-      ],
-      "isBasedOn": [
-        {
-          "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/"
-        },
-        {
-          "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/about.html"
-        },
-        {
-          "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/introduction.html"
-        },
-        {
-          "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/terminology.html"
-        },
-        {
-          "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/structure.html"
-        },
-        {
-          "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/metadata.html"
-        },
-        {
-          "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/root-data-entity.html"
-        },
-        {
-          "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/data-entities.html"
-        },
-        {
-          "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/crate-focus.html"
-        },
-        {
-          "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/contextual-entities.html"
-        },
-        {
-          "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/provenance.html"
-        },
-        {
-          "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/profiles.html"
-        },
-        {
-          "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/workflows.html"
-        },
-        {
-          "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/appendix/"
-        },
-        {
-          "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/appendix/changelog.html"
-        },
-        {
-          "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/appendix/implementation-notes.html"
-        },
-        {
-          "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/appendix/jsonld.html"
-        },
-        {
-          "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/appendix/relative-uris.html"
-        }
-      ],
-      "name": "RO-Crate Metadata Specification 1.2-DRAFT (PDF)",
-      "sameAs": {
-        "@id": "https://zenodo.org/record/ZENODO/files/ro-crate-1.2-DRAFT.pdf"
-      },
-      "version": "TAG"
-    },
-    {
-      "@id": "http://www.w3.org/ns/dx/prof#ResourceDescriptor",
-      "@type": [
-        "DefinedTerm",
-        "Class"
-      ],
-      "inDefinedTermSet": {
-        "@id": "http://www.w3.org/ns/dx/prof"
-      },
-      "name": "Resource descriptor",
-      "sameAs": "https://www.w3.org/TR/2019/NOTE-dx-prof-20191218/#Class:ResourceDescriptor",
-      "termCode": "ResourceDescriptor"
-    },
-    {
-      "@id": "http://www.w3.org/ns/dx/prof#ResourceRole",
-      "@type": [
-        "DefinedTerm",
-        "Class"
-      ],
-      "inDefinedTermSet": {
-        "@id": "http://www.w3.org/ns/dx/prof"
-      },
-      "name": "Resource role",
-      "sameAs": "https://www.w3.org/TR/2019/NOTE-dx-prof-20191218/#Class:ResourceRole",
-      "termCode": "ResourceRole"
-    },
-    {
-      "@id": "http://www.w3.org/ns/dx/prof#Profile",
-      "@type": [
-        "DefinedTerm",
-        "Class"
-      ],
-      "inDefinedTermSet": {
-        "@id": "http://www.w3.org/ns/dx/prof"
-      },
-      "name": "Profile",
-      "sameAs": "https://www.w3.org/TR/2019/NOTE-dx-prof-20191218/#Class:Profile",
-      "termCode": "Profile"
-    },
-    {
-      "@id": "http://www.w3.org/ns/dx/prof#hasArtifact",
-      "@type": [
-        "DefinedTerm",
-        "Property"
-      ],
-      "inDefinedTermSet": {
-        "@id": "http://www.w3.org/ns/dx/prof"
-      },
-      "name": "has artifact",
-      "sameAs": "https://www.w3.org/TR/2019/NOTE-dx-prof-20191218/#Property:hasArtifact",
-      "termCode": "hasArtifact"
-    },
-    {
-      "@id": "http://www.w3.org/ns/dx/prof#hasResource",
-      "@type": [
-        "DefinedTerm",
-        "Property"
-      ],
-      "inDefinedTermSet": {
-        "@id": "http://www.w3.org/ns/dx/prof"
-      },
-      "name": "has resource",
-      "sameAs": "https://www.w3.org/TR/2019/NOTE-dx-prof-20191218/#Property:hasResource",
-      "termCode": "hasResource"
-    },
-    {
-      "@id": "http://www.w3.org/ns/dx/prof#hasRole",
-      "@type": [
-        "DefinedTerm",
-        "Property"
-      ],
-      "inDefinedTermSet": {
-        "@id": "http://www.w3.org/ns/dx/prof"
-      },
-      "name": "has role",
-      "sameAs": "https://www.w3.org/TR/2019/NOTE-dx-prof-20191218/#Property:hasRole",
-      "termCode": "hasRole"
-    },
-    {
-      "@id": "http://www.iana.org/assignments/relation/cite-as",
-      "@type": [
-        "DefinedTerm",
-        "Property"
-      ],
-      "inDefinedTermSet": {
-        "@id": "https://www.iana.org/assignments/link-relations/"
-      },
-      "name": "Cite as",
-      "termCode": "cite-as",
-      "url": "https://doi.org/10.17487/RFC8574"
-    },
-    {
-      "@id": "http://pcdm.org/models#Object",
-      "@type": [
-        "DefinedTerm",
-        "Class"
-      ],
-      "inDefinedTermSet": {
-        "@id": "http://pcdm.org/models#"
-      },
-      "name": "Repository object",
-      "termCode": "RepositoryObject"
-    },
-    {
-      "@id": "http://pcdm.org/models#Collection",
-      "@type": [
-        "DefinedTerm",
-        "Class"
-      ],
-      "inDefinedTermSet": {
-        "@id": "http://pcdm.org/models#"
-      },
-      "name": "Repository collection",
-      "termCode": "RepositoryCollection"
-    },
-    {
-      "@id": "http://pcdm.org/models#File",
-      "@type": [
-        "DefinedTerm",
-        "Class"
-      ],
-      "inDefinedTermSet": {
-        "@id": "http://pcdm.org/models#"
-      },
-      "name": "Repository file",
-      "termCode": "RepositoryFile"
-    },
-    {
-      "@id": "http://pcdm.org/models#hasMember",
-      "@type": [
-        "DefinedTerm",
-        "Property"
-      ],
-      "inDefinedTermSet": {
-        "@id": "http://pcdm.org/models#"
-      },
-      "name": "has member",
-      "termCode": "hasMember"
-    },
-    {
-      "@id": "http://pcdm.org/models#hasFile",
-      "@type": [
-        "DefinedTerm",
-        "Property"
-      ],
-      "inDefinedTermSet": {
-        "@id": "http://pcdm.org/models#"
-      },
-      "name": "has file",
-      "termCode": "hasFile"
-    },
-    {
-      "@id": "http://www.w3.org/1999/02/22-rdf-syntax-ns#Class",
-      "@type": [
-        "DefinedTerm",
-        "Class"
-      ],
-      "inDefinedTermSet": {
-        "@id": "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-      },
-      "name": "Class (rdfs)",
-      "description": "Class definition as part of a Profile Crate",
-      "url": "https://www.w3.org/TR/rdf-schema/#ch_class"
-    },
-    {
-      "@id": "http://www.w3.org/1999/02/22-rdf-syntax-ns#Property",
-      "@type": [
-        "DefinedTerm",
-        "Class"
-      ],
-      "inDefinedTermSet": {
-        "@id": "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-      },
-      "name": "Property (rdfs)",
-      "description": "Property definition as part of a Profile Crate",
-      "url": "https://www.w3.org/TR/rdf-schema/#ch_property"
-    },
-    {
-      "@id": "http://schema.org/Class",
-      "@type": [
-        "DefinedTerm",
-        "Class"
-      ],
-      "inDefinedTermSet": {
-        "@id": "http://schema.org/version/15.0/"
-      },
-      "name": "Class (schema.org)",
-      "description": "Class reference, defined outside the Profile Crate as indicated by @id url or inDefinedTermSet"
-    },
-    {
-      "@id": "http://schema.org/Property",
-      "@type": [
-        "DefinedTerm",
-        "Class"
-      ],
-      "inDefinedTermSet": {
-        "@id": "http://schema.org/version/15.0/"
-      },
-      "name": "Property (schema.org)",
-      "description": "Property reference, defined outside the Profile Crate as indicated by @id url or inDefinedTermSet"
-    },
-    {
-      "@id": "https://doi.org/DOI",
-      "@type": "PropertyValue",
-      "propertyID": "https://registry.identifiers.org/registry/doi",
-      "value": "doi:DOI",
-      "url": "https://doi.org/DOI"
-    },
-    {
-      "@id": "https://w3id.org/ro/crate/1.1",
-      "@type": "Dataset",
-      "name": "RO-Crate specification 1.1",
-      "version": "1.1.2"
-    },
-    {
-      "@id": "https://w3id.org/ro/crate/",
-      "@type": "WebSite",
-      "maintainer": {
-        "@id": "https://www.researchobject.org/ro-crate/community"
-      },
-      "name": "Research Object Crate (RO-Crate) website",
-      "publisher": {
-        "@id": "https://www.researchobject.org/"
-      },
-      "url": "https://www.researchobject.org/ro-crate/"
-    },
-    {
-      "@id": "http://www.w3.org/TR/2014/REC-json-ld-20140116/",
-      "@type": "Standard",
-      "name": "JSON-LD 1.0",
-      "description": "A JSON-based Serialization for Linked Data",
-      "version": "1.0",
-      "sameAs": {
-        "@id": "https://www.nationalarchives.gov.uk/PRONOM/fmt/880"
+      "@reverse": {
+        "hasPart": [
+          {
+            "@id": "https://w3id.org/ro/crate/1.2-DRAFT"
+          }
+        ],
+        "isBasedOn": [
+          {
+            "@id": "https://github.com/ResearchObject/ro-crate/releases/download/TAG/ro-crate-TAG.html"
+          },
+          {
+            "@id": "https://github.com/ResearchObject/ro-crate/releases/download/TAG/ro-crate-TAG.pdf"
+          }
+        ]
       }
     },
     {
-      "@id": "http://www.w3.org/ns/json-ld#flattened",
-      "@type": "Profile",
-      "name": "Flattened JSON-LD",
-      "isProfileOf": {
-        "@id": "http://www.w3.org/TR/2014/REC-json-ld-20140116/"
-      },
-      "version": "1.0",
-      "url": "https://www.w3.org/TR/json-ld1/#flattened-document-form"
+      "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/introduction.html",
+      "@type": "WebPage",
+      "name": "Introduction",
+      "@reverse": {
+        "isBasedOn": [
+          {
+            "@id": "https://github.com/ResearchObject/ro-crate/releases/download/TAG/ro-crate-TAG.html"
+          },
+          {
+            "@id": "https://github.com/ResearchObject/ro-crate/releases/download/TAG/ro-crate-TAG.pdf"
+          }
+        ],
+        "hasPart": [
+          {
+            "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/"
+          }
+        ]
+      }
     },
     {
-      "@id": "http://schema.org/version/15.0/",
-      "@type": [
-        "DefinedTermSet",
-        "Standard"
-      ],
-      "name": "Schema.org vocabulary (http prefix)",
-      "encoding": {
-        "@id": "https://schema.org/version/15.0/schemaorg-current-http.jsonld"
-      },
-      "vann:preferredNamespaceUri": "http://schema.org/",
-      "version": "15.0",
-      "url": "https://schema.org/docs/developers.html"
+      "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/metadata.html",
+      "@type": "WebPage",
+      "name": "Metadata of the RO-Crate",
+      "@reverse": {
+        "isBasedOn": [
+          {
+            "@id": "https://github.com/ResearchObject/ro-crate/releases/download/TAG/ro-crate-TAG.html"
+          },
+          {
+            "@id": "https://github.com/ResearchObject/ro-crate/releases/download/TAG/ro-crate-TAG.pdf"
+          }
+        ],
+        "hasPart": [
+          {
+            "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/"
+          }
+        ]
+      }
     },
     {
-      "@id": "https://www.apache.org/licenses/LICENSE-2.0",
-      "@type": "CreativeWork",
-      "name": "Apache License 2.0",
-      "version": "2.0",
-      "identifier": {
-        "@id": "http://spdx.org/licenses/Apache-2.0"
+      "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/profiles.html",
+      "@type": "WebPage",
+      "name": "Profiles",
+      "@reverse": {
+        "isBasedOn": [
+          {
+            "@id": "https://github.com/ResearchObject/ro-crate/releases/download/TAG/ro-crate-TAG.html"
+          },
+          {
+            "@id": "https://github.com/ResearchObject/ro-crate/releases/download/TAG/ro-crate-TAG.pdf"
+          }
+        ],
+        "hasPart": [
+          {
+            "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/"
+          }
+        ]
+      }
+    },
+    {
+      "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/provenance.html",
+      "@type": "WebPage",
+      "name": "Provenance of entities",
+      "@reverse": {
+        "isBasedOn": [
+          {
+            "@id": "https://github.com/ResearchObject/ro-crate/releases/download/TAG/ro-crate-TAG.html"
+          },
+          {
+            "@id": "https://github.com/ResearchObject/ro-crate/releases/download/TAG/ro-crate-TAG.pdf"
+          }
+        ],
+        "hasPart": [
+          {
+            "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/"
+          }
+        ]
+      }
+    },
+    {
+      "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/root-data-entity.html",
+      "@type": "WebPage",
+      "name": "Root Data Entity",
+      "@reverse": {
+        "isBasedOn": [
+          {
+            "@id": "https://github.com/ResearchObject/ro-crate/releases/download/TAG/ro-crate-TAG.html"
+          },
+          {
+            "@id": "https://github.com/ResearchObject/ro-crate/releases/download/TAG/ro-crate-TAG.pdf"
+          }
+        ],
+        "hasPart": [
+          {
+            "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/"
+          }
+        ]
+      }
+    },
+    {
+      "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/structure.html",
+      "@type": "WebPage",
+      "name": "RO-Crate Structure",
+      "@reverse": {
+        "isBasedOn": [
+          {
+            "@id": "https://github.com/ResearchObject/ro-crate/releases/download/TAG/ro-crate-TAG.html"
+          },
+          {
+            "@id": "https://github.com/ResearchObject/ro-crate/releases/download/TAG/ro-crate-TAG.pdf"
+          }
+        ],
+        "hasPart": [
+          {
+            "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/"
+          }
+        ]
+      }
+    },
+    {
+      "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/terminology.html",
+      "@type": "WebPage",
+      "name": "Terminology",
+      "@reverse": {
+        "isBasedOn": [
+          {
+            "@id": "https://github.com/ResearchObject/ro-crate/releases/download/TAG/ro-crate-TAG.html"
+          },
+          {
+            "@id": "https://github.com/ResearchObject/ro-crate/releases/download/TAG/ro-crate-TAG.pdf"
+          }
+        ],
+        "hasPart": [
+          {
+            "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/"
+          }
+        ]
+      }
+    },
+    {
+      "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/workflows.html",
+      "@type": "WebPage",
+      "name": "Workflows and scripts",
+      "@reverse": {
+        "isBasedOn": [
+          {
+            "@id": "https://github.com/ResearchObject/ro-crate/releases/download/TAG/ro-crate-TAG.html"
+          },
+          {
+            "@id": "https://github.com/ResearchObject/ro-crate/releases/download/TAG/ro-crate-TAG.pdf"
+          }
+        ],
+        "hasPart": [
+          {
+            "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/"
+          }
+        ]
       }
     },
     {
@@ -1543,72 +3655,21 @@
         "@id": "https://www.researchobject.org/"
       },
       "sdDatePublished": "2022-01-19T10:54:41Z",
-      "url": "https://www.researchobject.org/ro-crate/community"
-    },
-    {
-      "@id": "https://www.researchobject.org/",
-      "@type": "Organization",
-      "name": "ResearchObject.org",
-      "url": "https://www.researchobject.org/"
-    },
-    {
-      "@id": "#vocabulary-schema",
-      "@type": "ResourceDescriptor",
-      "hasArtifact": {
-        "@id": "http://schema.org/version/15.0/"
-      },
-      "hasRole": {
-        "@id": "http://www.w3.org/ns/dx/prof/role/vocabulary"
-      }
-    },
-    {
-      "@id": "#vocabulary-pcdm",
-      "@type": "ResourceDescriptor",
-      "hasArtifact": {
-        "@id": "http://pcdm.org/models"
-      },
-      "hasRole": {
-        "@id": "http://www.w3.org/ns/dx/prof/role/vocabulary"
-      }
-    },
-    {
-      "@id": "#vocabulary-prof",
-      "@type": "ResourceDescriptor",
-      "hasArtifact": {
-        "@id": "http://www.w3.org/ns/dx/prof"
-      },
-      "hasRole": {
-        "@id": "http://www.w3.org/ns/dx/prof/role/vocabulary"
-      }
-    },
-    {
-      "@id": "#vocabulary-prof-roles",
-      "@type": "ResourceDescriptor",
-      "hasArtifact": {
-        "@id": "http://pcdm.org/models"
-      },
-      "hasRole": {
-        "@id": "http://www.w3.org/ns/dx/prof/role/vocabulary"
-      }
-    },
-    {
-      "@id": "#vocabulary-rdfs",
-      "@type": "ResourceDescriptor",
-      "hasArtifact": {
-        "@id": "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-      },
-      "hasRole": {
-        "@id": "http://www.w3.org/ns/dx/prof/role/vocabulary"
-      }
-    },
-    {
-      "@id": "#specification",
-      "@type": "ResourceDescriptor",
-      "hasArtifact": {
-        "@id": "https://github.com/ResearchObject/ro-crate/releases/download/TAG/ro-crate-TAG.html"
-      },
-      "hasRole": {
-        "@id": "http://www.w3.org/ns/dx/prof/role/specification"
+      "url": "https://www.researchobject.org/ro-crate/community",
+      "@reverse": {
+        "maintainer": [
+          {
+            "@id": "https://w3id.org/ro/crate/1.2-DRAFT"
+          },
+          {
+            "@id": "https://w3id.org/ro/crate/"
+          }
+        ],
+        "author": [
+          {
+            "@id": "https://doi.org/10.3233/DS-210053"
+          }
+        ]
       }
     },
     {
@@ -1619,352 +3680,133 @@
       },
       "hasRole": {
         "@id": "http://www.w3.org/ns/dx/prof/role/example"
-      }
-    },
-    {
-      "@id": "http://datasciencehub.net/",
-      "@type": "Journal",
-      "issn": "2451-8492",
-      "name": "Data Science",
-      "url": "http://datasciencehub.net/"
-    },
-    {
-      "@id": "http://pcdm.org/models#",
-      "@type": "DefinedTermSet",
-      "name": "Portland Common Data Model",
-      "sameAs": "https://pcdm.org/2016/04/18/models",
-      "version": "2016/04/18"
-    },
-    {
-      "@id": "http://purl.org/vocab/vann/preferredNamespacePrefix",
-      "@type": "DefinedTerm",
-      "name": "preferred namespace prefix",
-      "description": "The preferred namespace prefix to use when using terms from this vocabulary in an document.",
-      "url": "https://vocab.org/vann/#preferredNamespacePrefix"
-    },
-    {
-      "@id": "http://purl.org/vocab/vann/preferredNamespaceUri",
-      "@type": "DefinedTerm",
-      "name": "preferred namespace URI",
-      "description": "The preferred namespace URI to use when using terms from this vocabulary in an document",
-      "url": "https://vocab.org/vann/#preferredNamespaceUri"
-    },
-    {
-      "@id": "https://schema.org/version/15.0/schemaorg-current-http.jsonld",
-      "@type": "CreativeWork",
-      "encodingFormat": "application/ld+json",
-      "conformsTo": {
-        "@id": "https://www.w3.org/TR/rdf-schema/"
-      }
-    },
-    {
-      "@id": "https://www.w3.org/TR/rdf-schema/",
-      "@type": "Standard",
-      "name": "RDF Schema (rdfs)",
-      "hasPart": {
-        "@id": "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-      }
-    },
-    {
-      "@id": "https://www.iana.org/assignments/link-relations/",
-      "@type": "DefinedTermSet",
-      "name": "IANA Link Relations"
-    },
-    {
-      "@id": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
-      "@type": "DefinedTermSet",
-      "url": "https://www.w3.org/TR/rdf-schema/",
-      "vann:preferredNamespacePrefix": "rdfs",
-      "vann:preferredNamespaceUri": "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-    },
-    {
-      "@id": "http://www.w3.org/ns/dx/prof",
-      "@type": "DefinedTermSet",
-      "name": "Profiles Vocabulary",
-      "sameAs": "http://www.w3.org/ns/dx/prof/1.0",
-      "url": "https://www.w3.org/TR/2019/NOTE-dx-prof-20191218/",
-      "version": "1.0"
-    },
-    {
-      "@id": "http://www.w3.org/ns/dx/prof#role/",
-      "@type": "DefinedTermSet",
-      "hasDefinedTerm": [
-        {
-          "@id": "http://www.w3.org/ns/dx/prof/role/constraints"
-        },
-        {
-          "@id": "http://www.w3.org/ns/dx/prof/role/example"
-        },
-        {
-          "@id": "http://www.w3.org/ns/dx/prof/role/guidance"
-        },
-        {
-          "@id": "http://www.w3.org/ns/dx/prof/role/mapping"
-        },
-        {
-          "@id": "http://www.w3.org/ns/dx/prof/role/schema"
-        },
-        {
-          "@id": "http://www.w3.org/ns/dx/prof/role/specification"
-        },
-        {
-          "@id": "http://www.w3.org/ns/dx/prof/role/validation"
-        },
-        {
-          "@id": "http://www.w3.org/ns/dx/prof/role/vocabulary"
-        }
-      ],
-      "name": "Resource Roles vocabulary",
-      "url": "https://www.w3.org/TR/2019/NOTE-dx-prof-20191218/#resource-roles-vocab"
-    },
-    {
-      "@id": "http://www.w3.org/ns/dx/prof/role/constraints",
-      "@type": [
-        "DefinedTerm",
-        "ResourceRole"
-      ],
-      "description": "Descriptions of obligations, limitations or extensions that the profile defines",
-      "name": "Constraints",
-      "sameAs": "https://www.w3.org/TR/2019/NOTE-dx-prof-20191218/#Role:constraints"
-    },
-    {
-      "@id": "http://www.w3.org/ns/dx/prof/role/example",
-      "@type": [
-        "DefinedTerm",
-        "ResourceRole"
-      ],
-      "description": "Sample instance data conforming to the profile",
-      "name": "Example",
-      "sameAs": "https://www.w3.org/TR/2019/NOTE-dx-prof-20191218/#Role:example"
-    },
-    {
-      "@id": "http://www.w3.org/ns/dx/prof/role/guidance",
-      "@type": [
-        "DefinedTerm",
-        "ResourceRole"
-      ],
-      "description": "Documents, in human-readable form, how to use the profile",
-      "name": "Guidance",
-      "sameAs": "https://www.w3.org/TR/2019/NOTE-dx-prof-20191218/#Role:guidance"
-    },
-    {
-      "@id": "http://www.w3.org/ns/dx/prof/role/mapping",
-      "@type": [
-        "DefinedTerm",
-        "ResourceRole"
-      ],
-      "description": "Describes conversions between two specifications",
-      "name": "Mapping",
-      "sameAs": "https://www.w3.org/TR/2019/NOTE-dx-prof-20191218/#Role:mapping"
-    },
-    {
-      "@id": "http://www.w3.org/ns/dx/prof/role/schema",
-      "@type": [
-        "DefinedTerm",
-        "ResourceRole"
-      ],
-      "description": "Machine-readable structural descriptions of data defined by the profile",
-      "name": "Schema",
-      "sameAs": "https://www.w3.org/TR/2019/NOTE-dx-prof-20191218/#Role:schema"
-    },
-    {
-      "@id": "http://www.w3.org/ns/dx/prof/role/specification",
-      "@type": [
-        "DefinedTerm",
-        "ResourceRole"
-      ],
-      "description": "Defining the profile in human-readable form",
-      "name": "Specification",
-      "sameAs": "https://www.w3.org/TR/2019/NOTE-dx-prof-20191218/#Role:specification"
-    },
-    {
-      "@id": "http://www.w3.org/ns/dx/prof/role/validation",
-      "@type": [
-        "DefinedTerm",
-        "ResourceRole"
-      ],
-      "description": "Supplies instructions about how to verify conformance of data to the profile",
-      "name": "Validation",
-      "sameAs": "https://www.w3.org/TR/2019/NOTE-dx-prof-20191218/#Role:validation"
-    },
-    {
-      "@id": "http://www.w3.org/ns/dx/prof/role/vocabulary",
-      "@type": [
-        "DefinedTerm",
-        "ResourceRole"
-      ],
-      "description": "Defines terms used in the profile specification",
-      "name": "Vocabulary",
-      "sameAs": "https://www.w3.org/TR/2019/NOTE-dx-prof-20191218/#Role:vocabulary"
-    },
-    {
-      "@id": "http://www.w3.org/ns/json-ld#Context",
-      "@type": "DefinedTerm",
-      "name": "JSON-LD Context",
-      "url": "https://www.w3.org/TR/json-ld/"
-    },
-    {
-      "@id": "https://bioschemas.org/profiles/ComputationalWorkflow/1.0-RELEASE",
-      "@type": "Profile",
-      "description": "Bioschemas specification for describing a Computational Workflow",
-      "name": "ComputationalWorkflow profile",
-      "version": "1.0-RELEASE"
-    },
-    {
-      "@id": "https://bioschemas.org/profiles/FormalParameter/1.0-RELEASE",
-      "description": "Bioschemas specification for describing a formal parameter in the Life Sciences",
-      "name": "FormalParameter Profile",
-      "version": "1.0-RELEASE",
-      "@type": "Thing"
-    },
-    {
-      "@id": "http://spdx.org/licenses/CC0-1.0",
-      "@type": "PropertyValue",
-      "propertyID": "http://spdx.org/rdf/terms#licenseId",
-      "name": "spdx",
-      "value": "CC0-1.0"
-    },
-    {
-      "@id": "https://creativecommons.org/licenses/by/4.0/",
-      "@type": "CreativeWork",
-      "identifier": {
-        "@id": "http://spdx.org/licenses/CC-BY-4.0"
       },
-      "name": "Creative Commons Attribution 4.0 International",
-      "version": "4.0"
+      "@reverse": {
+        "hasResource": [
+          {
+            "@id": "https://w3id.org/ro/crate/1.2-DRAFT"
+          }
+        ]
+      }
     },
     {
-      "@id": "https://orcid.org/0000-0003-1304-1939",
-      "@type": "Person",
-      "name": "Mercè Crosas"
+      "@id": "#specification",
+      "@type": "ResourceDescriptor",
+      "hasArtifact": {
+        "@id": "https://github.com/ResearchObject/ro-crate/releases/download/TAG/ro-crate-TAG.html"
+      },
+      "hasRole": {
+        "@id": "http://www.w3.org/ns/dx/prof/role/specification"
+      },
+      "@reverse": {
+        "hasResource": [
+          {
+            "@id": "https://w3id.org/ro/crate/1.2-DRAFT"
+          }
+        ]
+      }
     },
     {
-      "@id": "https://orcid.org/0000-0002-3079-6586",
-      "@type": "Person",
-      "name": "Björn Grüning"
+      "@id": "#vocabulary-pcdm",
+      "@type": "ResourceDescriptor",
+      "hasArtifact": {
+        "@id": "http://pcdm.org/models"
+      },
+      "hasRole": {
+        "@id": "http://www.w3.org/ns/dx/prof/role/vocabulary"
+      },
+      "@reverse": {
+        "hasResource": [
+          {
+            "@id": "https://w3id.org/ro/crate/1.2-DRAFT"
+          }
+        ]
+      }
     },
     {
-      "@id": "https://w3id.org/ro/doi/10.5281/zenodo.5146227",
-      "@type": "Dataset",
-      "name": "Packaging research artefacts with RO-Crate (RO-Crate)"
+      "@id": "#vocabulary-prof",
+      "@type": "ResourceDescriptor",
+      "hasArtifact": {
+        "@id": "http://www.w3.org/ns/dx/prof"
+      },
+      "hasRole": {
+        "@id": "http://www.w3.org/ns/dx/prof/role/vocabulary"
+      },
+      "@reverse": {
+        "hasResource": [
+          {
+            "@id": "https://w3id.org/ro/crate/1.2-DRAFT"
+          }
+        ]
+      }
     },
     {
-      "@id": "https://www.nationalarchives.gov.uk/PRONOM/fmt/471",
-      "@type": "WebPage",
-      "alternateName": "HTML5",
-      "name": "Hypertext Markup Language 5"
+      "@id": "#vocabulary-prof-roles",
+      "@type": "ResourceDescriptor",
+      "hasArtifact": {
+        "@id": "http://pcdm.org/models"
+      },
+      "hasRole": {
+        "@id": "http://www.w3.org/ns/dx/prof/role/vocabulary"
+      },
+      "@reverse": {
+        "hasResource": [
+          {
+            "@id": "https://w3id.org/ro/crate/1.2-DRAFT"
+          }
+        ]
+      }
     },
     {
-      "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/about.html",
-      "@type": "WebPage",
-      "name": "About this document"
+      "@id": "#vocabulary-schema",
+      "@type": "ResourceDescriptor",
+      "hasArtifact": {
+        "@id": "http://schema.org/version/15.0/"
+      },
+      "hasRole": {
+        "@id": "http://www.w3.org/ns/dx/prof/role/vocabulary"
+      },
+      "@reverse": {
+        "hasResource": [
+          {
+            "@id": "https://w3id.org/ro/crate/1.2-DRAFT"
+          }
+        ]
+      }
     },
     {
-      "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/introduction.html",
-      "@type": "WebPage",
-      "name": "Introduction"
+      "@id": "#vocabulary-rdfs",
+      "@type": "ResourceDescriptor",
+      "hasArtifact": {
+        "@id": "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+      },
+      "hasRole": {
+        "@id": "http://www.w3.org/ns/dx/prof/role/vocabulary"
+      },
+      "@reverse": {
+        "hasResource": [
+          {
+            "@id": "https://w3id.org/ro/crate/1.2-DRAFT"
+          }
+        ]
+      }
     },
     {
-      "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/terminology.html",
-      "@type": "WebPage",
-      "name": "Terminology"
-    },
-    {
-      "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/structure.html",
-      "@type": "WebPage",
-      "name": "RO-Crate Structure"
-    },
-    {
-      "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/metadata.html",
-      "@type": "WebPage",
-      "name": "Metadata of the RO-Crate"
-    },
-    {
-      "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/root-data-entity.html",
-      "@type": "WebPage",
-      "name": "Root Data Entity"
-    },
-    {
-      "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/data-entities.html",
-      "@type": "WebPage",
-      "name": "Data Entities"
-    },
-    {
-      "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/crate-focus.html",
-      "@type": "WebPage",
-      "name": "The focus of an RO-Crate"
-    },
-    {
-      "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/contextual-entities.html",
-      "@type": "WebPage",
-      "name": "Contextual Entities"
-    },
-    {
-      "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/provenance.html",
-      "@type": "WebPage",
-      "name": "Provenance of entities"
-    },
-    {
-      "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/profiles.html",
-      "@type": "WebPage",
-      "name": "Profiles"
-    },
-    {
-      "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/workflows.html",
-      "@type": "WebPage",
-      "name": "Workflows and scripts"
-    },
-    {
-      "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/appendix/",
-      "@type": "WebPage",
-      "name": "Appendix",
-      "hasPart": [
-        {
-          "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/appendix/changelog.html"
-        },
-        {
-          "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/appendix/implementation-notes.html"
-        },
-        {
-          "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/appendix/jsonld.html"
-        },
-        {
-          "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/appendix/relative-uris.html"
-        }
-      ]
-    },
-    {
-      "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/appendix/changelog.html",
-      "@type": "WebPage",
-      "name": "Changelog"
-    },
-    {
-      "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/appendix/implementation-notes.html",
-      "@type": "WebPage",
-      "name": "Implementation notes"
-    },
-    {
-      "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/appendix/jsonld.html",
-      "@type": "WebPage",
-      "name": "RO-Crate JSON-LD"
-    },
-    {
-      "@id": "https://www.researchobject.org/ro-crate/1.2-DRAFT/appendix/relative-uris.html",
-      "@type": "WebPage",
-      "name": "Handling relative URI references"
-    },
-    {
-      "@id": "https://www.nationalarchives.gov.uk/PRONOM/fmt/18",
-      "@type": "WebPage",
-      "alternateName": "PDF 1.4",
-      "name": "Acrobat PDF 1.4 - Portable Document Format"
-    },
-    {
-      "@id": "http://spdx.org/licenses/Apache-2.0",
-      "@type": "PropertyValue",
-      "propertyID": "http://spdx.org/rdf/terms#licenseId",
-      "name": "spdx",
-      "value": "Apache-2.0"
+      "@id": "#vocabulary-geosparql",
+      "@type": "ResourceDescriptor",
+      "hasArtifact": {
+        "@id": "http://www.opengis.net/ont/geosparql#"
+      },
+      "hasRole": {
+        "@id": "http://www.w3.org/ns/dx/prof/role/vocabulary"
+      },
+      "@reverse": {
+        "hasResource": [
+          {
+            "@id": "https://w3id.org/ro/crate/1.2-DRAFT"
+          }
+        ]
+      }
     }
   ]
 }
@@ -1972,7 +3814,7 @@
 
     
 <!-- script src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script -->
-<script src="https://unpkg.com/ro-crate-html@0.1/dist/ro-crate-dynamic.min.js"></script>
+<script src="https://unpkg.com/ro-crate-html-js/dist/ro-crate-dynamic.js"></script>
 
 <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.2.1/css/bootstrap.min.css" integrity="sha384-GJzZqFGwb1QTTN6wy59ffF1BuGJpLSa9DkKMp0DgiMDm4iYMj70gZWKYbI706tWS" crossorigin="anonymous">
 
@@ -2255,6 +4097,10 @@ While providing the formal specification for RO-Crate, this document also aims t
                         <li><a href="#http%3A//schema.org/Class">Class (schema.org)</a></li>
                         
                         <li><a href="#http%3A//schema.org/Property">Property (schema.org)</a></li>
+                        
+                        <li><a href="#http%3A//www.opengis.net/ont/geosparql%23Geometry">Geometry</a></li>
+                        
+                        <li><a href="#http%3A//www.opengis.net/ont/geosparql%23asWKT">Geometry</a></li>
                         </ul></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">identifier<span>&nbsp;</span><a href="http://schema.org/identifier">[?]</a></th>
@@ -2295,6 +4141,8 @@ While providing the formal specification for RO-Crate, this document also aims t
                         <li><a href="#%23vocabulary-prof-roles">#vocabulary-prof-roles</a></li>
                         
                         <li><a href="#%23vocabulary-rdfs">#vocabulary-rdfs</a></li>
+                        
+                        <li><a href="#%23vocabulary-geosparql">#vocabulary-geosparql</a></li>
                         
                         <li><a href="#%23specification">#specification</a></li>
                         
@@ -5533,6 +7381,84 @@ While providing the formal specification for RO-Crate, this document also aims t
         </div>
         <hr/><br/><br/>
            <div>
+            <h3><a href="http://www.opengis.net/ont/geosparql#Geometry">Go to: </a> Geometry</h3>
+            
+            
+            
+            
+        <div id="http://www.opengis.net/ont/geosparql#Geometry">
+            
+            <table class="table metadata table-striped" >
+                <tbody><tr>
+            <th style="text-align:left;" class="prop">@id</th>
+            <td style='text-align:left'><a href="http://www.opengis.net/ont/geosparql#Geometry">http://www.opengis.net/ont/geosparql#Geometry</a></td>
+            </tr><tr>
+            <th style="text-align:left;" class="prop">name<span>&nbsp;</span><a href="http://schema.org/name">[?]</a></th>
+            <td style='text-align:left'><span>Geometry</span></td>
+            </tr><tr>
+            <th style="text-align:left;" class="prop">@type</th>
+            <td style='text-align:left'><span>DefinedTerm</span></td>
+            </tr><tr>
+            <th style="text-align:left;" class="prop">description<span>&nbsp;</span><a href="http://schema.org/description">[?]</a></th>
+            <td style='text-align:left'><span>A coherent set of direct positions in space. The positions are held within a Spatial Reference System (SRS).</span></td>
+            </tr><tr>
+            <th style="text-align:left;" class="prop">termCode<span>&nbsp;</span><a href="http://schema.org/termCode">[?]</a></th>
+            <td style='text-align:left'><span>Geometry</span></td>
+            </tr><tr>
+            <th style="text-align:left;" class="prop">sameAs<span>&nbsp;</span><a href="http://schema.org/sameAs">[?]</a></th>
+            <td style='text-align:left'><a href="https://opengeospatial.github.io/ogc-geosparql/geosparql11/#Geometry">https://opengeospatial.github.io/ogc-geosparql/geosparql11/#Geometry</a></td>
+            </tr><tr>
+            <th style="text-align:left;" class="prop">inDefinedTermSet<span>&nbsp;</span><a href="http://schema.org/inDefinedTermSet">[?]</a></th>
+            <td style='text-align:left'><a href="#http%3A//www.opengis.net/ont/geosparql%23">GeoSPARQL ontology</a></td>
+            </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
+            <th style="text-align:left;" class="prop">hasPart<span>&nbsp;</span><a href="http://schema.org/hasPart">[?]</a></th>
+            <td style='text-align:left'><a href="#https%3A//w3id.org/ro/crate/1.2-DRAFT">RO-Crate specification 1.2</a></td>
+            </tr></tbody>
+            </table>
+        </div>
+
+        </div>
+        <hr/><br/><br/>
+           <div>
+            <h3><a href="http://www.opengis.net/ont/geosparql#asWKT">Go to: </a> Geometry</h3>
+            
+            
+            
+            
+        <div id="http://www.opengis.net/ont/geosparql#asWKT">
+            
+            <table class="table metadata table-striped" >
+                <tbody><tr>
+            <th style="text-align:left;" class="prop">@id</th>
+            <td style='text-align:left'><a href="http://www.opengis.net/ont/geosparql#asWKT">http://www.opengis.net/ont/geosparql#asWKT</a></td>
+            </tr><tr>
+            <th style="text-align:left;" class="prop">name<span>&nbsp;</span><a href="http://schema.org/name">[?]</a></th>
+            <td style='text-align:left'><span>Geometry</span></td>
+            </tr><tr>
+            <th style="text-align:left;" class="prop">@type</th>
+            <td style='text-align:left'><span>DefinedTerm</span></td>
+            </tr><tr>
+            <th style="text-align:left;" class="prop">description<span>&nbsp;</span><a href="http://schema.org/description">[?]</a></th>
+            <td style='text-align:left'><span>The WKT serialization (ISO13249) of a Geometry.</span></td>
+            </tr><tr>
+            <th style="text-align:left;" class="prop">termCode<span>&nbsp;</span><a href="http://schema.org/termCode">[?]</a></th>
+            <td style='text-align:left'><span>asWKT</span></td>
+            </tr><tr>
+            <th style="text-align:left;" class="prop">sameAs<span>&nbsp;</span><a href="http://schema.org/sameAs">[?]</a></th>
+            <td style='text-align:left'><a href="https://opengeospatial.github.io/ogc-geosparql/geosparql11/#asWKT">https://opengeospatial.github.io/ogc-geosparql/geosparql11/#asWKT</a></td>
+            </tr><tr>
+            <th style="text-align:left;" class="prop">inDefinedTermSet<span>&nbsp;</span><a href="http://schema.org/inDefinedTermSet">[?]</a></th>
+            <td style='text-align:left'><a href="#http%3A//www.opengis.net/ont/geosparql%23">GeoSPARQL ontology</a></td>
+            </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
+            <th style="text-align:left;" class="prop">hasPart<span>&nbsp;</span><a href="http://schema.org/hasPart">[?]</a></th>
+            <td style='text-align:left'><a href="#https%3A//w3id.org/ro/crate/1.2-DRAFT">RO-Crate specification 1.2</a></td>
+            </tr></tbody>
+            </table>
+        </div>
+
+        </div>
+        <hr/><br/><br/>
+           <div>
             <h3><a href="https://doi.org/DOI">Go to: </a> https://doi.org/DOI</h3>
             
             
@@ -5701,7 +7627,7 @@ While providing the formal specification for RO-Crate, this document also aims t
             <th style="text-align:left;" class="prop">encoding<span>&nbsp;</span><a href="http://schema.org/encoding">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//schema.org/version/15.0/schemaorg-current-http.jsonld">https://schema.org/version/15.0/schemaorg-current-http.jsonld</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">vann:preferredNamespaceUri<span>&nbsp;</span><a href="http://purl.org/vocab/vann/preferredNamespaceUri">[?]</a></th>
+            <th style="text-align:left;" class="prop">vann:preferredNamespaceUri</th>
             <td style='text-align:left'><a href="http://schema.org/">http://schema.org/</a></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">version<span>&nbsp;</span><a href="http://schema.org/version">[?]</a></th>
@@ -6137,6 +8063,36 @@ While providing the formal specification for RO-Crate, this document also aims t
             </tr><tr>
             <th style="text-align:left;" class="prop">hasArtifact<span>&nbsp;</span><a href="http://www.w3.org/ns/dx/prof/hasArtifact">[?]</a></th>
             <td style='text-align:left'><a href="#http%3A//www.w3.org/1999/02/22-rdf-syntax-ns%23">http://www.w3.org/1999/02/22-rdf-syntax-ns#</a></td>
+            </tr><tr>
+            <th style="text-align:left;" class="prop">hasRole<span>&nbsp;</span><a href="http://www.w3.org/ns/dx/prof/hasRole">[?]</a></th>
+            <td style='text-align:left'><a href="#http%3A//www.w3.org/ns/dx/prof/role/vocabulary">Vocabulary</a></td>
+            </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
+            <th style="text-align:left;" class="prop">hasResource<span>&nbsp;</span><a href="http://www.w3.org/ns/dx/prof/hasResource">[?]</a></th>
+            <td style='text-align:left'><a href="#https%3A//w3id.org/ro/crate/1.2-DRAFT">RO-Crate specification 1.2</a></td>
+            </tr></tbody>
+            </table>
+        </div>
+
+        </div>
+        <hr/><br/><br/>
+           <div>
+            <h3> #vocabulary-geosparql</h3>
+            
+            
+            
+            
+        <div id="#vocabulary-geosparql">
+            
+            <table class="table metadata table-striped" >
+                <tbody><tr>
+            <th style="text-align:left;" class="prop">@id</th>
+            <td style='text-align:left'><span>#vocabulary-geosparql</span></td>
+            </tr><tr>
+            <th style="text-align:left;" class="prop">@type</th>
+            <td style='text-align:left'><span>ResourceDescriptor</span></td>
+            </tr><tr>
+            <th style="text-align:left;" class="prop">hasArtifact<span>&nbsp;</span><a href="http://www.w3.org/ns/dx/prof/hasArtifact">[?]</a></th>
+            <td style='text-align:left'><a href="#http%3A//www.opengis.net/ont/geosparql%23">GeoSPARQL ontology</a></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">hasRole<span>&nbsp;</span><a href="http://www.w3.org/ns/dx/prof/hasRole">[?]</a></th>
             <td style='text-align:left'><a href="#http%3A//www.w3.org/ns/dx/prof/role/vocabulary">Vocabulary</a></td>

--- a/docs/1.2-DRAFT/ro-crate-preview.html
+++ b/docs/1.2-DRAFT/ro-crate-preview.html
@@ -1106,6 +1106,9 @@
       "description": "The WKT serialization (ISO13249) of a Geometry.",
       "name": "Geometry",
       "termCode": "asWKT",
+      "citation": {
+        "@id": "https://portal.ogc.org/files/?artifact_id=25355"
+      },
       "sameAs": "https://opengeospatial.github.io/ogc-geosparql/geosparql11/#asWKT",
       "inDefinedTermSet": {
         "@id": "http://www.opengis.net/ont/geosparql#"
@@ -1114,6 +1117,20 @@
         "hasPart": [
           {
             "@id": "https://w3id.org/ro/crate/1.2-DRAFT"
+          }
+        ]
+      }
+    },
+    {
+      "@id": "https://portal.ogc.org/files/?artifact_id=25355",
+      "@type": "CreativeWork",
+      "name": "OpenGIS Implementation Specification for Geographic information – Simple feature access – Part 1: Common architecture",
+      "version": "1.2.1",
+      "url": "https://www.ogc.org/standard/sfa/",
+      "@reverse": {
+        "citation": [
+          {
+            "@id": "http://www.opengis.net/ont/geosparql#asWKT"
           }
         ]
       }
@@ -7443,6 +7460,9 @@ While providing the formal specification for RO-Crate, this document also aims t
             </tr><tr>
             <th style="text-align:left;" class="prop">termCode<span>&nbsp;</span><a href="http://schema.org/termCode">[?]</a></th>
             <td style='text-align:left'><span>asWKT</span></td>
+            </tr><tr>
+            <th style="text-align:left;" class="prop">citation<span>&nbsp;</span><a href="http://schema.org/citation">[?]</a></th>
+            <td style='text-align:left'><a href="#https%3A//portal.ogc.org/files/%3Fartifact_id%3D25355">OpenGIS Implementation Specification for Geographic information – Simple feature access – Part 1: Common architecture</a></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">sameAs<span>&nbsp;</span><a href="http://schema.org/sameAs">[?]</a></th>
             <td style='text-align:left'><a href="https://opengeospatial.github.io/ogc-geosparql/geosparql11/#asWKT">https://opengeospatial.github.io/ogc-geosparql/geosparql11/#asWKT</a></td>

--- a/docs/_includes/references.liquid
+++ b/docs/_includes/references.liquid
@@ -101,6 +101,7 @@ and is also rendered into the end of the PDF.
 [IANA link relations]: https://www.iana.org/assignments/link-relations/
 [RFC8574]: https://www.iana.org/go/rfc8574
 [citation styles]: https://citationstyles.org/
+[GeoSPARQL ontology]: https://opengeospatial.github.io/ogc-geosparql/geosparql11/
 
 [Action]: http://schema.org/Action
 [ActionStatusType]: http://schema.org/ActionStatusType
@@ -132,6 +133,8 @@ and is also rendered into the end of the PDF.
 [Thing]: http://schema.org/Thing
 [UpdateAction]: http://schema.org/UpdateAction
 [WebSite]: http://schema.org/WebSite
+[Geometry]: https://opengeospatial.github.io/ogc-geosparql/geosparql11/#Geometry
+[asWKT]: https://opengeospatial.github.io/ogc-geosparql/geosparql11/#asWKT
 
 [about]: http://schema.org/about
 [accountablePerson]: http://schema.org/accountablePerson

--- a/scripts/schema-context.py
+++ b/scripts/schema-context.py
@@ -154,6 +154,7 @@ ADDITIONAL = OrderedDict([
           ## from DC Terms, used in profiles and metadata file
           ("conformsTo", "http://purl.org/dc/terms/conformsTo"),
           ("Standard", "http://purl.org/dc/terms/Standard"),
+          ##
 
           ## The Profiles Vocabulary
           # https://www.w3.org/TR/2019/NOTE-dx-prof-20191218/
@@ -165,6 +166,11 @@ ADDITIONAL = OrderedDict([
           ("ResourceDescriptor", "http://www.w3.org/ns/dx/prof/ResourceDescriptor"),
           ("ResourceRole", "http://www.w3.org/ns/dx/prof/ResourceRole"),
           ("Profile", "http://www.w3.org/ns/dx/prof/Profile"),
+          ## END
+
+          ## GeoSparql terms
+          ("Geometry", "http://www.opengis.net/ont/geosparql#Geometry"),
+          ("asWKT", "http://www.opengis.net/ont/geosparql#asWKT"),
           ## END
 
           ## FIXME: Where is this used from?
@@ -193,6 +199,7 @@ ADDITIONAL = OrderedDict([
           ("relation", "http://www.iana.org/assignments/relation/"),
           ("wf4ever", "http://purl.org/ro/wf4ever#"),
           ("vann", "http://purl.org/vocab/vann/"),
+          ("geosparql", "http://www.opengis.net/ont/geosparql#"),
           # Disabled, see https://github.com/ResearchObject/ro-crate/pull/73
 #          ("@base", None) 
 ])


### PR DESCRIPTION
This fixes #286.

Note that only two GeoSPARQL terms are included. The rest can be accessed through prefix "geosparql", we won't use prefix "geo" as it would conflict with https://schema.org/geo which will be used to point to the `Geometry` object.

See https://opengeospatial.github.io/ogc-geosparql/geosparql11/spec.html for more information. 