### PR TITLE
add example for directories on the web to specification

### DIFF
--- a/docs/1.1/data-entities.md
+++ b/docs/1.1/data-entities.md
@@ -301,6 +301,24 @@ These can be included for File Data Entities as additional metadata, regardless 
 
 A _Directory File Entry_ or [Dataset] identifier expressed as an absolute URL on the web can be harder to download than a [File] because it consists of multiple resources. It is RECOMMENDED that such directories have a complete listing of their content in [hasPart], enabling download traversal.
 
+```json
+  {
+    "@id": "http://example.com/downloads/2020/",
+    "@type": "Dataset",
+    "name": "A directory with manny small files",
+    "description": "This directory contains multiple small files.",
+    "hasPart": [
+      {
+        "@id": "http://example.com/downloads/2020/file1.csv"
+      },
+      {
+        "@id": "http://example.com/downloads/2020/file2.csv"
+      },
+      ...
+    ]
+  }
+```
+
 Alternatively, a common mechanism to provide downloads of a reasonably sized directory is as an archive file in formats such as `.zip` or `.tar.gz`, described as a [DataDownload]. 
 
 ```json

--- a/docs/1.1/data-entities.md
+++ b/docs/1.1/data-entities.md
@@ -299,13 +299,13 @@ These can be included for File Data Entities as additional metadata, regardless 
 
 ### Directories on the web; dataset distributions
 
-A _Directory File Entry_ or [Dataset] identifier expressed as an absolute URL on the web can be harder to download than a [File] because it consists of multiple resources. It is RECOMMENDED that such directories have a complete listing of their content in [hasPart], enabling download traversal.
+A _Directory File Entry_ or [Dataset] identifier expressed as an absolute URL on the web can be harder to download than a [File] because it consists of multiple resources. It is RECOMMENDED that such directories have a complete listing of their content in [hasPart], enabling download traversal:
 
 ```json
   {
     "@id": "http://example.com/downloads/2020/",
     "@type": "Dataset",
-    "name": "A directory with manny small files",
+    "name": "A directory with many small files",
     "description": "This directory contains multiple small files.",
     "hasPart": [
       {


### PR DESCRIPTION
The documentation talks about how directories on the web that are not distributed as archives should be included. The docu also recommends to include all files inside such a directory as `hasPart`. However, no example is given for this. The only example shows how archives can be linked.

This PR adds an example that links to a web dir that also lists individual files of the dataset.