### PR TITLE
Fix unreadable SVG

### DIFF
--- a/docs/assets/img/crate1-folders.svg
+++ b/docs/assets/img/crate1-folders.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 168.80416 66.939585"
    version="1.1"
    id="svg5"
-   aria-labelledby="lightbulb11 description11"
+   aria-labelledby="title_crate1 description_crate1"
    inkscape:version="1.3 (0e150ed6c4, 2023-07-21)"
    sodipodi:docname="crate1-folders.svg"
    inkscape:export-filename="crate1-folders.svg"
@@ -21,8 +21,8 @@
    xmlns:cc="http://creativecommons.org/ns#"
    xmlns:dc="http://purl.org/dc/elements/1.1/">
   <title
-     id="title95238">RO-Crate root</title>
-   <desc>Folder listing of crate1, including data.csv and ro-crate-metadata.json</desc>
+     id="title_crate1">RO-Crate root</title>
+   <desc id="description_crate1">Folder listing of crate1, including data.csv and ro-crate-metadata.json</desc>
   <sodipodi:namedview
      id="namedview7"
      pagecolor="#ffffff"

--- a/docs/assets/img/crate1-folders.svg
+++ b/docs/assets/img/crate1-folders.svg
@@ -7,8 +7,12 @@
    viewBox="0 0 168.80416 66.939585"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
-   sodipodi:docname="ro-crate-root.svg"
+   aria-labelledby="lightbulb11 description11"
+   inkscape:version="1.3 (0e150ed6c4, 2023-07-21)"
+   sodipodi:docname="crate1-folders.svg"
+   inkscape:export-filename="crate1-folders.svg"
+   inkscape:export-xdpi="96"
+   inkscape:export-ydpi="96"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns="http://www.w3.org/2000/svg"
@@ -18,6 +22,7 @@
    xmlns:dc="http://purl.org/dc/elements/1.1/">
   <title
      id="title95238">RO-Crate root</title>
+   <desc>Folder listing of crate1, including data.csv and ro-crate-metadata.json</desc>
   <sodipodi:namedview
      id="namedview7"
      pagecolor="#ffffff"
@@ -35,12 +40,14 @@
      inkscape:zoom="1"
      inkscape:cx="330.5"
      inkscape:cy="201.5"
-     inkscape:window-width="1846"
-     inkscape:window-height="1136"
-     inkscape:window-x="0"
-     inkscape:window-y="0"
+     inkscape:window-width="1920"
+     inkscape:window-height="991"
+     inkscape:window-x="1911"
+     inkscape:window-y="-9"
      inkscape:window-maximized="1"
-     inkscape:current-layer="layer1" />
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1" />
   <defs
      id="defs2" />
   <g
@@ -73,9 +80,7 @@
            d="m 102.15171,208.79138 v 0.26459 0.26458 h 0.91054 0.91054 l 0.16329,-0.26458 0.1633,-0.26459 h -1.07384 z m 2.61483,0 0.16329,0.26459 0.1633,0.26458 h 0.91054 0.91054 v -0.26458 -0.26459 h -1.07384 z m -2.61483,1.05834 v 0.26458 0.26458 h 1.05833 1.05834 v -0.26458 -0.26458 h -1.05834 z m 2.64583,0 v 0.26458 0.26458 h 1.05834 1.05833 v -0.26458 -0.26458 h -1.05833 z m -2.64583,1.32291 v 0.26459 0.26458 h 1.05833 1.05834 v -0.26458 -0.26459 h -1.05834 z m 2.64583,0 v 0.26459 0.26458 h 1.05834 1.05833 v -0.26458 -0.26459 h -1.05833 z m -2.64583,1.05834 v 0.26458 0.26458 h 1.07383 1.07384 l -0.1633,-0.26458 -0.16329,-0.26458 h -0.91054 z m 2.94142,0 -0.1633,0.26458 -0.16329,0.26458 h 1.07383 1.07384 v -0.26458 -0.26458 h -0.91054 z" />
       </g>
       <g
-         aria-label="crate1/
-    data.csv
-    ro-crate-metadata.json"
+         aria-label="crate1/     data.csv     ro-crate-metadata.json"
          id="text5966"
          style="font-size:10.5833px;line-height:1.45;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';letter-spacing:0px;word-spacing:0px;fill:#c6cbcc;stroke-width:0.264583">
         <path
@@ -190,27 +195,6 @@
            d="m 165.41201,89.215443 v 3.493316 h -0.95084 v -3.46231 q 0,-0.821653 -0.32039,-1.229895 -0.3204,-0.408243 -0.96118,-0.408243 -0.76998,0 -1.2144,0.490925 -0.44441,0.490924 -0.44441,1.338415 v 3.271108 h -0.95601 v -5.787742 h 0.95601 v 0.899167 q 0.34106,-0.52193 0.80098,-0.780312 0.46509,-0.258381 1.0697,-0.258381 0.99735,0 1.50895,0.620115 0.51159,0.614948 0.51159,1.813837 z"
            id="path95158" />
       </g>
-      <text
-         xml:space="preserve"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:10.5833px;line-height:1.45;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;letter-spacing:0px;word-spacing:0px;fill:#c6cbcc;fill-opacity:1;stroke:none;stroke-width:0.264583"
-         x="31.107971"
-         y="62.017189"
-         id="text5966-4"><tspan
-           sodipodi:role="line"
-           id="tspan5964-8"
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:10.5833px;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#c6cbcc;fill-opacity:1;stroke-width:0.264583"
-           x="31.107971"
-           y="62.017189">crate1/</tspan><tspan
-           sodipodi:role="line"
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:10.5833px;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#c6cbcc;fill-opacity:1;stroke-width:0.264583"
-           x="31.107971"
-           y="77.362976"
-           id="tspan5968-1">    data.csv</tspan><tspan
-           sodipodi:role="line"
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:10.5833px;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#c6cbcc;fill-opacity:1;stroke-width:0.264583"
-           x="31.107971"
-           y="92.708755"
-           id="tspan5970-2">    ro-crate-metadata.json</tspan></text>
       <g
          aria-label="^"
          id="text42090"
@@ -249,6 +233,12 @@
         </dc:creator>
         <cc:license
            rdf:resource="http://creativecommons.org/publicdomain/zero/1.0/" />
+        <dc:contributor>
+          <cc:Agent>
+            <dc:title>Eli Chadwick https://orcid.org/0000-0002-0035-6475</dc:title>
+          </cc:Agent>
+        </dc:contributor>
+        <dc:description>Folder listing of crate1, including data.csv and ro-crate-metadata.json</dc:description>
       </cc:Work>
       <cc:License
          rdf:about="http://creativecommons.org/publicdomain/zero/1.0/">


### PR DESCRIPTION
Should fix #294.

I am not sure that the text/aria-labels within the SVG are even exposed to screen readers when we import the file using `<img src="..." alt="...">` - when I checked with NVDA/Firefox it only read the content in `alt`. But I followed pattern 11 from Deque's [Creating Accessible SVGs](https://www.deque.com/blog/creating-accessible-svgs/) anyway, as it may be different for other screen reader/browser combinations.