### PR TITLE
Made the language about hybrid attached/detatched crates stronger

### DIFF
--- a/docs/1.2-DRAFT/data-entities.md
+++ b/docs/1.2-DRAFT/data-entities.md
@@ -373,7 +373,7 @@ These MAY be included for File Data Entities as additional metadata, regardless 
 * [subjectOf] to a [CreativeWork] (or [WebPage]) that mentions this file or its content (but also other resources)
 * [mainEntityOfPage] to a [CreativeWork]  (or [WebPage]) that primarily describes this file (or its content) 
 
-Note that if a local file is intended to be packaged the `@id` property MUST  a _URI Path_ relative to the _RO Crate root_, for example `survey-responses-2019.csv` in this example, in this case the content URL points to a download endpoint as a string.
+Note that if a local file is intended to be packaged within an Attached RO-Crate, the `@id` property MUST be a _URI Path_ relative to the _RO Crate root_, for example `survey-responses-2019.csv` as in the example below, where the content URL points to a download endpoint as a string.
 
 ```json
   {

--- a/docs/1.2-DRAFT/data-entities.md
+++ b/docs/1.2-DRAFT/data-entities.md
@@ -309,17 +309,21 @@ As files on the web may change, the timestamp property [sdDatePublished] SHOULD 
   }
 ```
 
+NOTE: Do not use web based URIs for files which _are_ present in the crate.
+
 ### Embedded data entities that are also on the web
 
-File Data Entities may already have a corresponding web presence, for instance a landing page that describes the file, including persistent identifiers (e.g. DOI) resolving to an intermediate HTML page instead of the downloadable file directly. 
+File Data Entities that are present as local files may already have a corresponding web presence, for instance a landing page that describes the file, including persistent identifiers (e.g. DOI) resolving to an intermediate HTML page instead of the downloadable file directly. 
 
-These can be included for File Data Entities as additional metadata, regardless of whether the File is included in the _RO-Crate Root_ directory or exists on the Web, by using the properties:
+These MAY be included for File Data Entities as additional metadata, regardless of whether the File is included in the _RO-Crate Root_ directory or exists on the Web, by using the properties:
 
 * [identifier] for formal identifier strings such as DOIs
 * [contentUrl] with a string URL corresponding to a *download* link. Following the link (allowing for HTTP redirects) SHOULD directly download the file.
 * [url] with a string URL for a download/landing page for this particular file (e.g. direct download is not available)
 * [subjectOf] to a [CreativeWork] (or [WebPage]) that mentions this file or its content (but also other resources)
 * [mainEntityOfPage] to a [CreativeWork]  (or [WebPage]) that primarily describes this file (or its content) 
+
+Note that if a local file is intended to be packaged the `@id` property MUST  a _URI Path_ relative to the _RO Crate root_, for example `survey-responses-2019.csv` in this example, in this case the content URL points to a download endpoint as a string.
 
 ```json
   {
@@ -329,16 +333,8 @@ These can be included for File Data Entities as additional metadata, regardless 
     "encodingFormat": "text/csv",
     "contentUrl": "http://example.com/downloads/2019/survey-responses-2019.csv",
     "subjectOf": {"@id": "http://example.com/reports/2019/annual-survey.html"}
-  },
-  {
-    "@id": "https://zenodo.org/record/3541888/files/ro-crate-1.0.0.pdf",
-    "@type": "File",
-    "name": "RO-Crate specification",
-    "encodingFormat": "application/pdf",
-    "identifier": "https://doi.org/10.5281/zenodo.3541888",
-    "url": "https://zenodo.org/record/3541888"
-  }
-```
+  } ````
+
 
 ### Directories on the web; dataset distributions
 

--- a/docs/1.2-DRAFT/data-entities.md
+++ b/docs/1.2-DRAFT/data-entities.md
@@ -383,7 +383,13 @@ Note that if a local file is intended to be packaged within an Attached RO-Crate
     "encodingFormat": "text/csv",
     "contentUrl": "http://example.com/downloads/2019/survey-responses-2019.csv",
     "subjectOf": {"@id": "http://example.com/reports/2019/annual-survey.html"}
-  } ````
+  },
+  {
+    "@id": "http://example.com/reports/2019/annual-survey.html",
+    "@type": "WebPage",
+    "name": "Survey responses (landing page)"
+  }
+```
 
 
 ### Directories on the web; dataset distributions

--- a/docs/1.2-DRAFT/data-entities.md
+++ b/docs/1.2-DRAFT/data-entities.md
@@ -5,9 +5,9 @@ parent: RO-Crate 1.2-DRAFT
 ---
 <!--
    Copyright 2019-2020 University of Technology Sydney
-   Copyright 2019-2023 The University of Manchester UK 
-   Copyright 2019-2023 RO-Crate contributors <https://github.com/ResearchObject/ro-crate/graphs/contributors>
-f
+   Copyright 2019-2024 The University of Manchester UK 
+   Copyright 2019-2024 RO-Crate contributors <https://github.com/ResearchObject/ro-crate/graphs/contributors>
+
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at

--- a/docs/1.2-DRAFT/data-entities.md
+++ b/docs/1.2-DRAFT/data-entities.md
@@ -7,7 +7,7 @@ parent: RO-Crate 1.2-DRAFT
    Copyright 2019-2020 University of Technology Sydney
    Copyright 2019-2023 The University of Manchester UK 
    Copyright 2019-2023 RO-Crate contributors <https://github.com/ResearchObject/ro-crate/graphs/contributors>
-
+f
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
@@ -373,7 +373,7 @@ These MAY be included for File Data Entities as additional metadata, regardless 
 * [subjectOf] to a [CreativeWork] (or [WebPage]) that mentions this file or its content (but also other resources)
 * [mainEntityOfPage] to a [CreativeWork]  (or [WebPage]) that primarily describes this file (or its content) 
 
-Note that if a local file is intended to be packaged within an Attached RO-Crate, the `@id` property MUST be a _URI Path_ relative to the _RO Crate root_, for example `survey-responses-2019.csv` as in the example below, where the content URL points to a download endpoint as a string.
+Note that if a local file is intended to be packaged within an _Attached RO-Crate_, the `@id` property MUST be a _URI Path_ relative to the _RO Crate root_, for example `survey-responses-2019.csv` as in the example below, where the content URL points to a download endpoint as a string.
 
 ```json
   {

--- a/docs/_includes/references.liquid
+++ b/docs/_includes/references.liquid
@@ -145,6 +145,7 @@ and is also rendered into the end of the PDF.
 [alternateName]: http://schema.org/alternateName
 [author]: http://schema.org/author
 [citation]: http://schema.org/citation
+[contentUrl]: http://schema.org/contentUrl
 [contact]: http://schema.org/accountablePerson
 [contactPoint]: http://schema.org/contactPoint
 [contactType]: http://schema.org/contactType


### PR DESCRIPTION
Following a discussion on Slack about how to describe files which are available locally AND on the web (in this case in ROHub) I have strengthened the wording to make it clear that in this case the `@id` should use a relative URI to point to the local file and contentUrl should point to the download.

Including the folks who were part of that conversation as reviewers.