### PR TITLE
Use relative path for fonts

### DIFF
--- a/docs/_sass/_custom_classes.scss
+++ b/docs/_sass/_custom_classes.scss
@@ -15,35 +15,35 @@ body {
 
 @font-face {
     font-family: PTSans;
-    src: url('/assets/fonts/PTSans-Regular.ttf') format('truetype'),
-        url('/assets/fonts/PTSans-Regular.woff') format('woff'),
-        url('/assets/fonts/PTSans-Regular.woff2') format('woff2');
+    src: url('../fonts/PTSans-Regular.ttf') format('truetype'),
+        url('../fonts/PTSans-Regular.woff') format('woff'),
+        url('../fonts/PTSans-Regular.woff2') format('woff2');
     font-display: swap;
 }
 
 @font-face {
     font-family: PTSans;
-    src: url('/assets/fonts/PTSans-Bold.ttf') format('truetype'),
-        url('/assets/fonts/PTSans-Bold.woff') format('woff'),
-        url('/assets/fonts/PTSans-Bold.woff2') format('woff2');
+    src: url('../fonts/PTSans-Bold.ttf') format('truetype'),
+        url('../fonts/PTSans-Bold.woff') format('woff'),
+        url('../fonts/PTSans-Bold.woff2') format('woff2');
     font-weight: 700;
     font-display: swap;
 }
 
 @font-face {
     font-family: PTSans;
-    src: url('/assets/fonts/PTSans-Italic.ttf') format('truetype'),
-        url('/assets/fonts/PTSans-Italic.woff') format('woff'),
-        url('/assets/fonts/PTSans-Italic.woff2') format('woff2');
+    src: url('../fonts/PTSans-Italic.ttf') format('truetype'),
+        url('../fonts/PTSans-Italic.woff') format('woff'),
+        url('../fonts/PTSans-Italic.woff2') format('woff2');
     font-style: italic;
     font-display: swap;
 }
 
 @font-face {
     font-family: PTSans;
-    src: url('/assets/fonts/PTSans-BoldItalic.ttf') format('truetype'),
-        url('/assets/fonts/PTSans-BoldItalic.woff') format('woff'),
-        url('/assets/fonts/PTSans-BoldItalic.woff2') format('woff2');
+    src: url('../fonts/PTSans-BoldItalic.ttf') format('truetype'),
+        url('../fonts/PTSans-BoldItalic.woff') format('woff'),
+        url('../fonts/PTSans-BoldItalic.woff2') format('woff2');
     font-weight: 700;
     font-style: italic;
     font-display: swap;


### PR DESCRIPTION
The font paths aren't right in the deployed site (again because local setup has small differences). This should fix them - as tested on [my fork](https://elichad.github.io/ro-crate/)