### PR TITLE
Revert to ETT footer and customise it with YAML/CSS

### DIFF
--- a/docs/_data/footer.yml
+++ b/docs/_data/footer.yml
@@ -1,1 +1,3 @@
 copyright: © Copyright 2021-2024. University of Technology Sydney, The University of Manchester UK and RO-Crate contributors
+columns: [] # if anything is added to this list later, unhide the link container in the CSS (footer .container)
+extra_line: 

--- a/docs/_includes/footer.html
+++ b/docs/_includes/footer.html
@@ -1,9 +1,0 @@
-<footer id="footer">
-  <div class="copyright p-4">
-    <div class="container d-flex justify-content-between flex-column flex-lg-row">
-      {%- unless site.data.footer.copyright == nil %}
-      <div class="d-flex align-items-center mb-3 mb-lg-0 mx-auto mx-lg-0 text-center">{{ site.data.footer.copyright | markdownify }}</div>
-      {%- endunless %}
-    </div>
-  </div>
-</footer>

--- a/docs/_sass/_custom_classes.scss
+++ b/docs/_sass/_custom_classes.scss
@@ -260,3 +260,8 @@ section#search-section {
 #back-to-top.visible {
   bottom: 7px;
 }
+
+// hide the link container, as we have no links to display
+footer .container {
+    display: none;
+}


### PR DESCRIPTION
Instead of overriding the ETT footer, use the default footer and use css / yaml config to avoid showing any links. 

This has the benefit of better maintainability (easier ETT version upgrades) and supporting footer links later if we decide to add some. This also reinstates the ETT logo in the footer, so fixes #316.