### PR TITLE
Improve visibility of child spec pages

### DIFF
--- a/docs/_data/sidebars/spec.yml
+++ b/docs/_data/sidebars/spec.yml
@@ -2,7 +2,7 @@ title: Specification
 title_url: specification
 versions:
 - title: RO-Crate 1.1 (newest release)
-  url: /specification/1.1/
+  url: /specification/1.1/index.html
   subitems:
   - title: Introduction
     url: /specification/1.1/introduction.html
@@ -34,7 +34,7 @@ versions:
       - title: RO-Crate JSON-LD
         url: /specification/1.1/appendix/jsonld.html
 - title: RO-Crate 1.2-DRAFT (draft for next release)
-  url: /specification/1.2-DRAFT
+  url: /specification/1.2-DRAFT/index.html
   subitems:
   - title: Introduction
     url: /specification/1.2-DRAFT/introduction.html
@@ -70,6 +70,6 @@ versions:
       - title: RO-Crate JSON-LD
         url: /specification/1.2-DRAFT/appendix/jsonld.html
 - title: RO-Crate 1.0
-  url: /specification/1.0
+  url: /specification/1.0/index.html
 - title: RO-Crate 0.2
-  url: /specification/0.2
+  url: /specification/0.2/index.html

--- a/docs/_specification/1.1/index.md
+++ b/docs/_specification/1.1/index.md
@@ -35,5 +35,25 @@ excerpt: |
 
 {% include_relative _metadata.liquid  %}
 
+## Contents
+
+{%- assign sidebar = site.data.sidebars[page.sidebar] %}
+<ul>
+{% for version in sidebar.versions %}
+{%- if page.url == version.url %}
+  {% for item in version.subitems %}
+  <li><a href="{{item.url | relative_url}}">{{item.title}}</a>
+  {% if item contains "subitems" %}
+    <ul>
+    {% for subitem in item.subitems %}
+    <li><a href="{{subitem.url | relative_url}}">{{subitem.title}}</a></li>
+    {% endfor %}
+    </ul>
+  {% endif %}
+  </li>
+  {% endfor %}
+{% endif %}
+{% endfor %}
+</ul>
 
 {% include references.liquid %}

--- a/docs/_specification/1.2-DRAFT/index.md
+++ b/docs/_specification/1.2-DRAFT/index.md
@@ -34,5 +34,26 @@ excerpt: |
 
 {% include_relative _metadata.liquid  %}
 
+## Contents
+
+{%- assign sidebar = site.data.sidebars[page.sidebar] %}
+<ul>
+{% for version in sidebar.versions %}
+{%- if page.url == version.url %}
+  {% for item in version.subitems %}
+  <li><a href="{{item.url | relative_url}}">{{item.title}}</a>
+  {% if item contains "subitems" %}
+    <ul>
+    {% for subitem in item.subitems %}
+    <li><a href="{{subitem.url | relative_url}}">{{subitem.title}}</a></li>
+    {% endfor %}
+    </ul>
+  {% endif %}
+  </li>
+  {% endfor %}
+{% endif %}
+{% endfor %}
+</ul>
+
 
 {% include references.liquid %}


### PR DESCRIPTION
Fixes #328 in two ways:

- version menu now expands in the sidebar when you go to the landing page for a version (this was broken because the urls set in the sidebar YAML weren't matching the pages exactly)
- lists all the pages on the landing page as well for good measure (like the old site had)

https://github.com/user-attachments/assets/2fb9bf28-916d-43fc-ad80-00b01eae5f40

