### PR TITLE
Add getting started links to RO-Crate homepage

### DIFF
--- a/docs/_sass/_custom_classes.scss
+++ b/docs/_sass/_custom_classes.scss
@@ -178,7 +178,13 @@ body {
     h3 {
         font-weight: 700;
     }
-    
+
+    .homepage-link {
+        border: 2px solid $dark;
+        padding: 0.75rem;
+        margin: 0 0.5rem 0 0.5rem;
+    }
+
     .featured-content {
       position: relative;  
       border-top: 1px solid $primary;

--- a/docs/_sass/_custom_classes.scss
+++ b/docs/_sass/_custom_classes.scss
@@ -181,6 +181,8 @@ body {
 
     .homepage-link {
         border: 2px solid $dark;
+        color: $white;
+        background-color: $dark;
         padding: 0.75rem;
         margin: 0 0.5rem 0 0.5rem;
     }

--- a/docs/index.html
+++ b/docs/index.html
@@ -11,11 +11,13 @@ layout: none
   {% include topnav.html search=true %}
   <div class="landingpage" id="content">
     <section class="container mb-5">
-      <div>
+      <div class="text-center">
         <h1>Research Object Crate (RO-Crate)</h1>
-        <p class="text-center lead">RO-Crate is a community effort to establish a lightweight approach to packaging
+        <p class="lead">RO-Crate is a community effort to establish a lightweight approach to packaging
           research data with their metadata.
         </p>
+        <a href="about_ro_crate" class="btn btn-primary homepage-link">About RO-Crate</a>
+        <a href="tutorials" class="btn btn-primary homepage-link">Getting started with RO-Crate</a>
       </div>
     </section>
     <section class="featured-content">


### PR DESCRIPTION
Fixes #319 . @smza this was something you mentioned a few weeks ago – do you have any feedback on this?

Adds links to the [about page](https://www.researchobject.org/ro-crate/about_ro_crate) and the [tutorials page](https://www.researchobject.org/ro-crate/tutorials) below the RO-Crate title and tag line on the homepage:

![Screenshot with links described in text](https://github.com/user-attachments/assets/6d27b5c4-9c86-46ee-9de2-c8941c441806)

![Screenshot showing buttons in context of whole homepage](https://github.com/user-attachments/assets/89652f5f-0635-426a-828e-4c613526793e)


