### PR TITLE
added roc-validator

### DIFF
--- a/docs/_data/tools_list.yml
+++ b/docs/_data/tools_list.yml
@@ -171,9 +171,15 @@
   level:
   url: https://github.com/KockataEPich/CheckMyCrate/tree/Version
 
+- name: roc-validator
+  description: RO-Crate validator with support for profiles and SHACL
+  status: beta
+  level:
+  url: https://pypi.org/project/roc-validator/
+
 - name: ro-crate-validator-py
   description: Modular RO-Crate validator
-  status: alpha
+  status: deprecated
   level:
   url: https://github.com/ResearchObject/ro-crate-validator-py/
 


### PR DESCRIPTION
.. and deprecated ro-crate-validator-py

@simleo may want to check on name to be listed as, I think we should link to pypi.