### PR TITLE
Clarify guidance around where and how to declare profile conformance

### DIFF
--- a/docs/_specification/1.2-DRAFT/profiles.md
+++ b/docs/_specification/1.2-DRAFT/profiles.md
@@ -56,7 +56,22 @@ The profile description declares the set of conventions to be used.
 
 ## Declaring conformance of an RO-Crate profile
 
-An RO-Crate can describe a profile by adding it as an [contextual entity](contextual-entities):
+RO-Crates that are _conforming to_ (or intending to conform to) such a profile SHOULD declare this using `conformsTo` on the [Root Data Entity](root-data-entity):
+
+```json
+{
+    "@id": "./",
+    "@type": "Dataset",
+    "conformsTo":
+        {"@id": "https://w3id.org/ro/wfrun/process/0.4"}       
+}
+```
+
+It is valid for a crate to conform to multiple profiles, in which case `conformsTo` is an unordered array.
+
+{% include callout.html type="note" content="Profile conformance is declared on the _Root Data Entity_ (`./` in this example), rather than on the _RO-Crate Metadata Descriptor_ (`ro-crate-metadata.json`) where conformance to the base RO-Crate specification is declared. This is because the profile applies to the whole RO-Crate, and may cover aspects beyond the crate's metadata file (e.g. identifiers, packaging, purpose)." %}
+
+Each profile listed in `conformsTo` on the _Root Data Entity_ MUST link to a corresponding [contextual entity](contextual-entities) for the profile, for example:
 
 ```json
 {
@@ -75,22 +90,6 @@ In the contextual entity for a profile:
 * The entity SHOULD have an absolute URI as `@id`
 * The entity SHOULD have a descriptive [name]
 * The entity MAY declare [version], preferably according to [Semantic Versioning][semver]
-
-RO-Crates that are _conforming to_ (or intending to conform to) such a profile SHOULD declare this using `conformsTo` on the [Root Data Entity](root-data-entity):
-
-```json
-{
-    "@id": "./",
-    "@type": "Dataset",
-    "conformsTo":
-        {"@id": "https://w3id.org/ro/wfrun/process/0.4"}       
-}
-```
-
-It is valid for a crate to conform to multiple profiles, in which case `conformsTo` is an unordered array.
-
-{% include callout.html type="note" content="Profile conformance is declared on the _Root Data Entity_ (`./` in this example), rather than on the _RO-Crate Metadata Descriptor_ (`ro-crate-metadata.json`) where conformance to the base RO-Crate specification is declared. This is because the profile applies to the whole RO-Crate, and may cover aspects beyond the crate's metadata file (e.g. identifiers, packaging, purpose)." %}
-
 
 
 ## Profile Crate

--- a/docs/_specification/1.2-DRAFT/root-data-entity.md
+++ b/docs/_specification/1.2-DRAFT/root-data-entity.md
@@ -68,13 +68,12 @@ crates for RO-Crate 1.0 or older) and `@type` [CreativeWork]. This descriptor MU
 
 {% include callout.html type="note" content="Even in [Detached RO-Crate Packages](structure#detached-ro-crate-package) which do not have an _RO-Crate Metadata File_ present, the identifier `ro-crate-metadata.json` MUST be used." %}
 
-The [conformsTo] of the _RO-Crate Metadata Descriptor_ 
-SHOULD be a versioned permalink URI of the RO-Crate specification
+The [conformsTo] of the _RO-Crate Metadata Descriptor_ SHOULD have a single value which 
+is a versioned permalink URI of the RO-Crate specification
 that the _RO-Crate JSON-LD_ conforms to. The URI SHOULD 
 start with `https://w3id.org/ro/crate/`. 
 
-{% include callout.html type="tip" content="The `conformsTo` property MAY be an array, to additionally indicate 
-specializing [RO-Crate profiles](profiles)." %}
+{% include callout.html type="note" content="In RO-Crates conforming to version 1.1 and earlier, `conformsTo` MAY be an array and can include [RO-Crate profiles](profiles) in addition to the base specification. In version 1.2, it is now recommended that profile declarations are included on the _Root Data Entity_ instead (see [Direct Properties of the Root Data Entity](#direct-properties-of-the-root-data-entity))." %}
 
 ### Finding the Root Data Entity
 
@@ -143,8 +142,7 @@ requires a `Dataset` to have a `name` and `description`." %}
 
 Additional properties of _schema.org_ types [Dataset] and [CreativeWork] MAY be added to further describe the RO-Crate as a whole, e.g. [author], [abstract], [publisher]. See sections [contextual entities](contextual-entities) and [provenance](provenance) for further details.
 
-
-
+If the RO-Crate conforms to one or more [profiles](profiles), this should be described following the guidance in the section [Declaring conformance of an RO-Crate profile](profiles#declaring-conformance-of-an-ro-crate-profile).
 
 ### Root Data Entity identifier
 


### PR DESCRIPTION
Fixes #393.

Summary of added requirements (as mentioned in linked issue):
* Metadata descriptor SHOULD have a single value for conformsTo, but it MAY be an array for legacy crates (1.1 and earlier).
* If the crate conforms to one or more profiles, each profile SHOULD be included in conformsTo on the Root Data Entity, and MUST have a corresponding contextual entity