### PR TITLE
fix typo - `ro-crate-preview-files` -> `ro-crate-preview_files`

### DIFF
--- a/docs/_specification/1.2-DRAFT/structure.md
+++ b/docs/_specification/1.2-DRAFT/structure.md
@@ -150,7 +150,7 @@ If present in the root directory of an _Attached RO-Crate Package_ as `ro-crate-
 {% include callout.html type="note" content="Previous versions of the Specification recommended that the _RO-Crate Website_ should contain a redundant copy of the RO-Crate Metadata Document, but there is no evidence that this has been useful and it is no longer recommended." %}
 
 
-The _RO-Crate Website_ is not considered a part of the RO-Crate payload in an _Attached RO-Crate Package_, but serves as a way to make metadata available in a user-appropriate format. The `ro-crate-preview.html` file and the `ro-crate-preview-files/` directory and any contents SHOULD NOT be included in the `hasPart` property of the _Root Dataset_ or any other `Dataset` entity within an RO-Crate.
+The _RO-Crate Website_ is not considered a part of the RO-Crate payload in an _Attached RO-Crate Package_, but serves as a way to make metadata available in a user-appropriate format. The `ro-crate-preview.html` file and the `ro-crate-preview_files/` directory and any contents SHOULD NOT be included in the `hasPart` property of the _Root Dataset_ or any other `Dataset` entity within an RO-Crate.
 
 Metadata about parts of the _RO-Crate Website_ MAY be included in an RO-Crate as in the following example. Metadata such as an `author` property, `dateCreated` or other provenance can be included, including details about the software that created them, as described in [Software used to create files](./provenance.html#software-used-to-create-files).
 


### PR DESCRIPTION
We use `ro-crate-preview_files` almost everywhere, except for this one case, so I think this is just a typo.

Also exists as far back as v0.2, but I haven't touched the previous versions.