### PR TITLE
Add tip that `File` and `Dataset` may appear on non-data entities

### DIFF
--- a/docs/_specification/1.2-DRAFT/contextual-entities.md
+++ b/docs/_specification/1.2-DRAFT/contextual-entities.md
@@ -53,10 +53,9 @@ Some contextual entities can also be considered data entities -- for instance th
 
 Likewise, some data entities may also be described as contextual entities, for instance a `File` that is also a [ScholarlyArticle]. In such cases the _contextual data entity_ MUST be described as a single JSON-LD object in the RO-Crate Metadata JSON-LD `@graph` and SHOULD list both relevant data and contextual types in a `@type` array. 
 
-{% include callout.html type="tip" content="Files in the _RO-Crate Root_ are not necessarily data entities -- the [RO-Crate Metadata Descriptor](root-data-entity#ro-crate-metadata-descriptor) is a file in the _RO-Crate Root_, but is considered a _Contextual Entity_ as it is describing the RO-Crate, rather than being part of it. On the other hand, the [Root Data Entity](root-data-entity#root-data-entity) is a data entity within its own metadata file." %}
+{% include callout.html type="tip" content="Not all files that are present in the _RO-Crate Root_ directory are necessarily data entities -- the [RO-Crate Metadata Descriptor](root-data-entity#ro-crate-metadata-descriptor) is a file in the _RO-Crate Root_, but is considered a _Contextual Entity_ as it is describing the RO-Crate, rather than being part of it. On the other hand, the [Root Data Entity](root-data-entity#root-data-entity) is a data entity within its own metadata file." %}
 
 The RO-Crate Metadata JSON-LD `@graph` MUST NOT list multiple entities with the same `@id`; behaviour of consumers of an RO-Crate encountering multiple entities with the same `@id` is undefined.
-
 
 ## Identifiers for contextual entities
 

--- a/docs/_specification/1.2-DRAFT/data-entities.md
+++ b/docs/_specification/1.2-DRAFT/data-entities.md
@@ -59,6 +59,7 @@ There is no requirement to represent _every_ file and folder in an RO-Crate as _
 
 In any of the above cases where files are not described, a directory containing a set of files MAY be described using a `Dataset` _Data Entity_ that encapsulates the files with a `description` property that explains the contents. If the RO-Crate file structure is flat, or files are not grouped together, a `description` property on the _Root Data Entity_ may be used, or a `Dataset` with a local reference beginning with `#` (e.g. to describe a certain type of file which occurs throughout the crate). This approach is recommended for RO-Crates which are to be deposited in a long-term archive.
 
+{% include callout.html type="tip" content='While the types `File` and `Dataset` are most frequently used in _Data Entities_, not all entities with these types are necessarily _Data Entities_. `File` or `Dataset` entities that are not _Data Entities_ do not need to be included in [hasPart] on the _Root Data Entity_.' %}
 
 ## Encoding file paths in `@id`s
 


### PR DESCRIPTION
Related to #400, applies my suggestion from this comment https://github.com/ResearchObject/ro-crate/issues/400#issuecomment-2766759017

Also rephrases a statement that confused me!
> That statement "Files in the RO-Crate Root are not necessarily data entities" needs to be reworded - it invites confusion of files in the real world with entities in the `@graph`.
> https://github.com/ResearchObject/ro-crate/issues/400#issuecomment-2641035619