### PR TITLE
Fix RDF triple loading example

### DIFF
--- a/docs/_specification/1.2-DRAFT/appendix/relative-uris.md
+++ b/docs/_specification/1.2-DRAFT/appendix/relative-uris.md
@@ -482,7 +482,15 @@ If a web-based URI for the _RO-Crate root_ is known, then this can be supplied a
     {
       "@id": "./",
       "@type": "Dataset",
-      "name": "Example RO-Crate"
+      "name": "Example RO-Crate",
+      "hasPart": [
+        {
+          "@id": "data1.txt"
+        },
+        {
+          "@id": "subfolder/"
+        }
+      ]
     },
     {
       "@id": "data1.txt",


### PR DESCRIPTION
Fixes one example where the root data entity is missing the `hasPart`, making it inconsistent with the triple expansion below.