### PR TITLE
Clarify when File/Dataset entities are and are not data entities

### DIFF
--- a/docs/_specification/1.2-DRAFT/data-entities.md
+++ b/docs/_specification/1.2-DRAFT/data-entities.md
@@ -176,7 +176,7 @@ Additionally, `File` entities SHOULD have:
 
 RO-Crate's `File` is an alias for schema.org type [MediaObject], any of its properties MAY also be used (adding contextual entities as needed).  [Files on the web](#data-entities-in-an-attached-ro-crate-that-are-also-on-the-web) SHOULD also use `identifier`, `url`, `subjectOf`, and/or `mainEntityOfPage`.
 
-A `File` entity MAY have an `@id` that is a local identifier beginning with `#`, in which case it is **not** considered to be a Data Entity, though it MAY still be linked to the _Root Data Entity_ via [hasPart]. This is useful for describing physical files which may not be present, for example if they are expected to be created by running a process. In this case the `localPath` property SHOULD be used to indicate that a `File` may be found at that path in some circumstances.
+A `File` entity MAY have an `@id` that is a local identifier beginning with `#`, in which case it is **not** considered to be a Data Entity, though it MAY still be linked to the _Root Data Entity_ via [hasPart]. This is useful for describing physical files which are deliberately not present, for example if they are expected to be created by running a process. In this case, the `localPath` property SHOULD be used to indicate that a `File` could be found at that path in some circumstances.
 
 {% include callout.html type="note" content='It is up to implementers to decide whether to offer some form of URL "link checker" service for [Web-based Data Entities](#web-based-data-entities) for both attached and detached RO-Crate Packages. If `contentUrl` has more than one value, then a checker service SHOULD try each provided value until one resolves and returns a correct [contentSize].' %}
 

--- a/docs/_specification/1.2-DRAFT/data-entities.md
+++ b/docs/_specification/1.2-DRAFT/data-entities.md
@@ -37,9 +37,11 @@ The primary purpose for RO-Crate is to gather and describe a set of _Data Entiti
 * Actual files which are datastreams available on the local file system or over the web - when represented in the RO-Crate Metadata Document these have the type `File`. 
 * Folders, or directories, of files represented using the type `Dataset`.
 
-An entity which has `File` or `Dataset` as one of its `@type` values is considered to be a Data Entity if its @id is a fully qualified URI, or in the case of an Attached RO-Crate Package it is a path. 
+An entity which has `File` or `Dataset` as one of its `@type` values:
+*  is considered to be a _Data Entity_ if its `@id` is an absolute URI or a relative URI.
+* MAY have an `@id` which is a local identifier beginning with a `#`, in which case it is NOT considered to be a `Data Entity`.
 
-Such an entity MAY have an `@id` which begins with a `#` in which case it is NOT considered to be a `Data Entity`. The requirements for `File` and `Dataset` are set out below.
+The requirements for `File` and `Dataset` are set out below.
 
 The Data Entities can be further described by referencing [contextual entities](contextual-entities) such as persons, organizations and publications.
 
@@ -164,8 +166,6 @@ Further constraints on the `@id` are dependent on whether the [File] entity is b
 
 2. For a _Detached RO-Crate Package_   `@id` MUST be an Absolute URI; all [File] Data Entities are [Web-based Data Entities](#web-based-data-entities).
 
-A `File` entity MAY have an `@id` beginning with `#` in which case it is not considered to be a Data Entity. This is useful for describing physical files which may not be present, for example if they are expected to be created by running a process. In this case the `localPath` property SHOULD be used to indicate that a `File` may be found at that path in some circumstances.
-
 Additionally, `File` entities SHOULD have:
 
 * [name] giving a human readable name (not necessarily the filename)
@@ -176,7 +176,7 @@ Additionally, `File` entities SHOULD have:
 
 RO-Crate's `File` is an alias for schema.org type [MediaObject], any of its properties MAY also be used (adding contextual entities as needed).  [Files on the web](#data-entities-in-an-attached-ro-crate-that-are-also-on-the-web) SHOULD also use `identifier`, `url`, `subjectOf`, and/or `mainEntityOfPage`.
 
-
+A `File` entity MAY have an `@id` beginning with `#` in which case it is not considered to be a Data Entity. This is useful for describing physical files which may not be present, for example if they are expected to be created by running a process. In this case the `localPath` property SHOULD be used to indicate that a `File` may be found at that path in some circumstances.
 
 {% include callout.html type="note" content='It is up to implementers to decide whether to offer some form of URL "link checker" service for [Web-based Data Entities](#web-based-data-entities) for both attached and detached RO-Crate Packages. If `contentUrl` has more than one value, then a checker service SHOULD try each provided value until one resolves and returns a correct [contentSize].' %}
 
@@ -205,9 +205,9 @@ Additionally, `Dataset` entities SHOULD have:
 
 Any of the properties of schema.org [Dataset] MAY additionally be used (adding contextual entities as needed). [Directories on the web](#directories-on-the-web-dataset-distributions) SHOULD also provide `distribution`.
 
-A [Dataset] which has an `@id` beginning with `#` is not considered a Data Entity - but MAY be used to describe a set of files or other resources. For example, if the dataset contained a large number of `*.ai` files which were spread throughout the crate structure and which did not have File Data Entities then a approach to describing them would be:
+A [Dataset] which has an `@id` beginning with `#` is NOT considered a Data Entity - but MAY be used to describe a set of files or other resources. For example, if the dataset contained a large number of `*.ai` files which were spread throughout the crate structure and which did not have File Data Entities then a approach to describing them would be:
 
-```JSON
+```json
 {
     "@id": "./",
     "@type": [

--- a/docs/_specification/1.2-DRAFT/data-entities.md
+++ b/docs/_specification/1.2-DRAFT/data-entities.md
@@ -39,7 +39,7 @@ The primary purpose for RO-Crate is to gather and describe a set of _Data Entiti
 
 An entity which has `File` or `Dataset` as one of its `@type` values:
 *  is considered to be a _Data Entity_ if its `@id` is an absolute URI or a relative URI.
-* MAY have an `@id` which is a local identifier beginning with a `#`, in which case it is NOT considered to be a `Data Entity`.
+* MAY have an `@id` which is a local identifier beginning with a `#`, in which case it is **not** considered to be a `Data Entity`.
 
 The requirements for `File` and `Dataset` are set out below.
 
@@ -176,7 +176,7 @@ Additionally, `File` entities SHOULD have:
 
 RO-Crate's `File` is an alias for schema.org type [MediaObject], any of its properties MAY also be used (adding contextual entities as needed).  [Files on the web](#data-entities-in-an-attached-ro-crate-that-are-also-on-the-web) SHOULD also use `identifier`, `url`, `subjectOf`, and/or `mainEntityOfPage`.
 
-A `File` entity MAY have an `@id` beginning with `#` in which case it is not considered to be a Data Entity. This is useful for describing physical files which may not be present, for example if they are expected to be created by running a process. In this case the `localPath` property SHOULD be used to indicate that a `File` may be found at that path in some circumstances.
+A `File` entity MAY have an `@id` that is a local identifier beginning with `#`, in which case it is **not** considered to be a Data Entity. This is useful for describing physical files which may not be present, for example if they are expected to be created by running a process. In this case the `localPath` property SHOULD be used to indicate that a `File` may be found at that path in some circumstances.
 
 {% include callout.html type="note" content='It is up to implementers to decide whether to offer some form of URL "link checker" service for [Web-based Data Entities](#web-based-data-entities) for both attached and detached RO-Crate Packages. If `contentUrl` has more than one value, then a checker service SHOULD try each provided value until one resolves and returns a correct [contentSize].' %}
 
@@ -205,7 +205,7 @@ Additionally, `Dataset` entities SHOULD have:
 
 Any of the properties of schema.org [Dataset] MAY additionally be used (adding contextual entities as needed). [Directories on the web](#directories-on-the-web-dataset-distributions) SHOULD also provide `distribution`.
 
-A [Dataset] which has an `@id` beginning with `#` is NOT considered a Data Entity - but MAY be used to describe a set of files or other resources. For example, if the dataset contained a large number of `*.ai` files which were spread throughout the crate structure and which did not have File Data Entities then a approach to describing them would be:
+A [Dataset] which has an `@id` that is a local identifier beginning with `#` is **not** considered a Data Entity - but MAY be used to describe a set of files or other resources. For example, if the dataset contained a large number of `*.ai` files which were spread throughout the crate structure and which did not have File Data Entities then a approach to describing them would be:
 
 ```json
 {
@@ -503,7 +503,7 @@ If the referenced RO-Crate B has an `identifier` declared as B's [Root Data Enti
 }
 ```
 
-{% include callout.html type="tip" content="The `conformsTo` generic RO-Crate profile on the `Dataset` entity that represents B MUST be version-less. The referenced RO-Crate B is NOT required to conform to the same version of the RO-Crate specification as A's RO-Crate Metadata Document." %}
+{% include callout.html type="tip" content="The `conformsTo` generic RO-Crate profile on the `Dataset` entity that represents B MUST be version-less. The referenced RO-Crate B is **not** required to conform to the same version of the RO-Crate specification as A's RO-Crate Metadata Document." %}
 
 {% include callout.html type="warning" content="It is NOT RECOMMENDED to declare the generic profile `https://w3id.org/ro/crate` on the referencing RO-Crate A's own [Root Data Entity](root-data-entity.html#direct-properties-of-the-root-data-entity), see [metadata descriptor](root-data-entity.html#ro-crate-metadata-descriptor). " %}
 

--- a/docs/_specification/1.2-DRAFT/data-entities.md
+++ b/docs/_specification/1.2-DRAFT/data-entities.md
@@ -205,7 +205,7 @@ Additionally, `Dataset` entities SHOULD have:
 
 Any of the properties of schema.org [Dataset] MAY additionally be used (adding contextual entities as needed). [Directories on the web](#directories-on-the-web-dataset-distributions) SHOULD also provide `distribution`.
 
-A [Dataset] which has an `@id` that is a local identifier beginning with `#` is **not** considered a Data Entity -- but MAY be used to describe a set of files or other resources, and MAY still be linked to the _Root Data Entity_ via [hasPart]. For -example, if the dataset contained a large number of `*.ai` files which were spread throughout the crate structure and which did not have File Data Entities then a approach to describing them would be:
+A [Dataset] which has an `@id` that is a local identifier beginning with `#` is **not** considered a Data Entity -- but MAY be used to describe a set of files or other resources, and MAY still be linked to the _Root Data Entity_ via [hasPart]. For example, if the dataset contained a large number of `*.ai` files which were spread throughout the crate structure and which did not have corresponding File Data Entities, then a approach to describing these files would be:
 
 ```json
 {
@@ -225,7 +225,6 @@ A [Dataset] which has an `@id` that is a local identifier beginning with `#` is 
     "name": ".ai Files",
     "description": "This dataset contains some files with the extension '.ai' which despite their extension have an encoding format of 'application/pdf'. These have yet to be catalogued."
 }
-
 ```
 
 

--- a/docs/_specification/1.2-DRAFT/data-entities.md
+++ b/docs/_specification/1.2-DRAFT/data-entities.md
@@ -1,7 +1,7 @@
 ---
 title: Data Entities
 redirect_from:
-  - /1.2-DRAFT/data-entities
+  -- /1.2-DRAFT/data-entities
 nav_order: 6
 parent: RO-Crate 1.2-DRAFT
 ---
@@ -132,7 +132,7 @@ This example contains both a [File Data Entity](#file-data-entity) and a [Direct
       "@id": "lots_of_little_files/",
       "@type": "Dataset",
       "name": "Too many files",
-      "description": "This directory contains many small files - the name of the file is a date in YYYY-MM-DD.csv, each file contains daily temperature readings, sampled hourly for the Glop Pot cave."
+      "description": "This directory contains many small files -- the name of the file is a date in YYYY-MM-DD.csv, each file contains daily temperature readings, sampled hourly for the Glop Pot cave."
     },
     {
       "@id": "https://orcid.org/0000-0003-4953-0830",
@@ -189,7 +189,7 @@ A [Dataset] (directory) _Data Entity_ MUST have the following properties:
 
 *  `@type` MUST be `Dataset` or an array where `Dataset` is one of the values.
 *  `@id`  MUST be either:
-    *   In an _Attached RO-Crate Package_ ONLY - a _URI Path_ that SHOULD end with `/`.  This MUST resolve to a directory which is present in the RO-Crate Root along with its parent directories. 
+    *   In an _Attached RO-Crate Package_ ONLY -- a _URI Path_ that SHOULD end with `/`.  This MUST resolve to a directory which is present in the RO-Crate Root along with its parent directories. 
     *   An absolute URI which SHOULD resolve to a programmatic listing of the content of the "directory" (e.g. another RO-Crate). 
 
 For a _Detached RO-Crate Package_:
@@ -205,7 +205,7 @@ Additionally, `Dataset` entities SHOULD have:
 
 Any of the properties of schema.org [Dataset] MAY additionally be used (adding contextual entities as needed). [Directories on the web](#directories-on-the-web-dataset-distributions) SHOULD also provide `distribution`.
 
-A [Dataset] which has an `@id` that is a local identifier beginning with `#` is **not** considered a Data Entity - but MAY be used to describe a set of files or other resources, and MAY still be linked to the _Root Data Entity_ via [hasPart]. For example, if the dataset contained a large number of `*.ai` files which were spread throughout the crate structure and which did not have File Data Entities then a approach to describing them would be:
+A [Dataset] which has an `@id` that is a local identifier beginning with `#` is **not** considered a Data Entity -- but MAY be used to describe a set of files or other resources, and MAY still be linked to the _Root Data Entity_ via [hasPart]. For -example, if the dataset contained a large number of `*.ai` files which were spread throughout the crate structure and which did not have File Data Entities then a approach to describing them would be:
 
 ```json
 {
@@ -400,7 +400,7 @@ In all cases, consumers should be aware that a `DataDownload` is a snapshot that
 
 ## Adding detailed descriptions of File encodings
 
-The [above example](#example-attached-ro-crate-package) provides a media type for the file `cp7glop.ai` - which is
+The [above example](#example-attached-ro-crate-package) provides a media type for the file `cp7glop.ai` -- which is
 useful as it may not be apparent that the file is readable as a PDF file from the
 extension alone. To add more detail, encodings SHOULD be linked using a [PRONOM]
 identifier to a _Contextual Entity_ with `@type` array containing [WebPage] and `Standard`.
@@ -416,7 +416,7 @@ identifier to a _Contextual Entity_ with `@type` array containing [WebPage] and 
   },
   {
     "@id": "https://www.nationalarchives.gov.uk/PRONOM/fmt/19",
-    "name": "Acrobat PDF 1.5 - Portable Document Format",
+    "name": "Acrobat PDF 1.5 -- Portable Document Format",
     "@type": ["WebPage", "Standard"]
   }
 

--- a/docs/_specification/1.2-DRAFT/data-entities.md
+++ b/docs/_specification/1.2-DRAFT/data-entities.md
@@ -34,8 +34,12 @@ parent: RO-Crate 1.2-DRAFT
 
 The primary purpose for RO-Crate is to gather and describe a set of _Data Entities_ in the form of:
 
-* Files which are datastreams available on the local file system or over the web
-* Directories
+* Actual files which are datastreams available on the local file system or over the web - when represented in the RO-Crate Metadata Document these have the type `File`. 
+* Folders, or directories, of files represented using the type `Dataset`.
+
+An entity which has `File` or `Dataset` as one of its `@type` values is considered to be a Data Entity if its @id is a fully qualified URI, or in the case of an Attached RO-Crate Package it is a path. 
+
+Such an entity MAY have an `@id` which begins with a `#` in which case it is NOT considered to be a `Data Entity`. The requirements for `File` and `Dataset` are set out below.
 
 The Data Entities can be further described by referencing [contextual entities](contextual-entities) such as persons, organizations and publications.
 
@@ -141,6 +145,7 @@ This example contains both a [File Data Entity](#file-data-entity) and a [Direct
 
 ### File Data Entity {#file-data-entity}
 
+
 A [File] _Data Entity_ MUST have the following properties:
 
 *  `@type`: MUST be `File`, or an array where `File` is one of the values.
@@ -159,6 +164,7 @@ Further constraints on the `@id` are dependent on whether the [File] entity is b
 
 2. For a _Detached RO-Crate Package_   `@id` MUST be an Absolute URI; all [File] Data Entities are [Web-based Data Entities](#web-based-data-entities).
 
+A `File` entity MAY have an `@id` beginning with `#` in which case it is not considered to be a Data Entity. This is useful for describing physical files which may not be present, for example if they are expected to be created by running a process. In this case the `localPath` property SHOULD be used to indicate that a `File` MAY be found at that path.
 
 Additionally, `File` entities SHOULD have:
 
@@ -185,12 +191,10 @@ A [Dataset] (directory) _Data Entity_ MUST have the following properties:
 *  `@id`  MUST be either:
     *   In an _Attached RO-Crate Package_ ONLY - a _URI Path_ that SHOULD end with `/`.  This MUST resolve to a directory which is present in the RO-Crate Root along with its parent directories. 
     *   An absolute URI which SHOULD resolve to a programmatic listing of the content of the "directory" (e.g. another RO-Crate). 
-    *   A local reference beginning with `#`
-
-
 
 For a _Detached RO-Crate Package_:
 * The `localPath` property MAY be used to indicate the directory path to use when converting from a _Detached_ to an _Attached RO-Crate Package_. 
+
 
 
 Additionally, `Dataset` entities SHOULD have:
@@ -201,7 +205,7 @@ Additionally, `Dataset` entities SHOULD have:
 
 Any of the properties of schema.org [Dataset] MAY additionally be used (adding contextual entities as needed). [Directories on the web](#directories-on-the-web-dataset-distributions) SHOULD also provide `distribution`.
 
-If the dataset contained a large number of `*.ai` files which were spread throughout the crate structure and which did not have File Data Entities then a approach to describing them would be:
+A [Dataset] which has an `@id` beginning with `#` is not considered a Data Entity - but MAY be used to describe a set of files or other resources. For example, if the dataset contained a large number of `*.ai` files which were spread throughout the crate structure and which did not have File Data Entities then a approach to describing them would be:
 
 ```JSON
 {

--- a/docs/_specification/1.2-DRAFT/data-entities.md
+++ b/docs/_specification/1.2-DRAFT/data-entities.md
@@ -176,7 +176,7 @@ Additionally, `File` entities SHOULD have:
 
 RO-Crate's `File` is an alias for schema.org type [MediaObject], any of its properties MAY also be used (adding contextual entities as needed).  [Files on the web](#data-entities-in-an-attached-ro-crate-that-are-also-on-the-web) SHOULD also use `identifier`, `url`, `subjectOf`, and/or `mainEntityOfPage`.
 
-A `File` entity MAY have an `@id` that is a local identifier beginning with `#`, in which case it is **not** considered to be a Data Entity. This is useful for describing physical files which may not be present, for example if they are expected to be created by running a process. In this case the `localPath` property SHOULD be used to indicate that a `File` may be found at that path in some circumstances.
+A `File` entity MAY have an `@id` that is a local identifier beginning with `#`, in which case it is **not** considered to be a Data Entity, though it MAY still be linked to the _Root Data Entity_ via [hasPart]. This is useful for describing physical files which may not be present, for example if they are expected to be created by running a process. In this case the `localPath` property SHOULD be used to indicate that a `File` may be found at that path in some circumstances.
 
 {% include callout.html type="note" content='It is up to implementers to decide whether to offer some form of URL "link checker" service for [Web-based Data Entities](#web-based-data-entities) for both attached and detached RO-Crate Packages. If `contentUrl` has more than one value, then a checker service SHOULD try each provided value until one resolves and returns a correct [contentSize].' %}
 
@@ -205,7 +205,7 @@ Additionally, `Dataset` entities SHOULD have:
 
 Any of the properties of schema.org [Dataset] MAY additionally be used (adding contextual entities as needed). [Directories on the web](#directories-on-the-web-dataset-distributions) SHOULD also provide `distribution`.
 
-A [Dataset] which has an `@id` that is a local identifier beginning with `#` is **not** considered a Data Entity - but MAY be used to describe a set of files or other resources. For example, if the dataset contained a large number of `*.ai` files which were spread throughout the crate structure and which did not have File Data Entities then a approach to describing them would be:
+A [Dataset] which has an `@id` that is a local identifier beginning with `#` is **not** considered a Data Entity - but MAY be used to describe a set of files or other resources, and MAY still be linked to the _Root Data Entity_ via [hasPart]. For example, if the dataset contained a large number of `*.ai` files which were spread throughout the crate structure and which did not have File Data Entities then a approach to describing them would be:
 
 ```json
 {

--- a/docs/_specification/1.2-DRAFT/data-entities.md
+++ b/docs/_specification/1.2-DRAFT/data-entities.md
@@ -164,7 +164,7 @@ Further constraints on the `@id` are dependent on whether the [File] entity is b
 
 2. For a _Detached RO-Crate Package_   `@id` MUST be an Absolute URI; all [File] Data Entities are [Web-based Data Entities](#web-based-data-entities).
 
-A `File` entity MAY have an `@id` beginning with `#` in which case it is not considered to be a Data Entity. This is useful for describing physical files which may not be present, for example if they are expected to be created by running a process. In this case the `localPath` property SHOULD be used to indicate that a `File` MAY be found at that path.
+A `File` entity MAY have an `@id` beginning with `#` in which case it is not considered to be a Data Entity. This is useful for describing physical files which may not be present, for example if they are expected to be created by running a process. In this case the `localPath` property SHOULD be used to indicate that a `File` may be found at that path in some circumstances.
 
 Additionally, `File` entities SHOULD have:
 

--- a/docs/_specification/1.2-DRAFT/data-entities.md
+++ b/docs/_specification/1.2-DRAFT/data-entities.md
@@ -34,11 +34,11 @@ parent: RO-Crate 1.2-DRAFT
 
 The primary purpose for RO-Crate is to gather and describe a set of _Data Entities_ in the form of:
 
-* Actual files which are datastreams available on the local file system or over the web - when represented in the RO-Crate Metadata Document these have the type `File`. 
-* Folders, or directories, of files represented using the type `Dataset`.
+* Actual files which are datastreams available on the local file system or over the web -- when represented in the RO-Crate Metadata Document, these have the type `File`. 
+* Folders (or directories) of files -- represented using the type `Dataset`.
 
 An entity which has `File` or `Dataset` as one of its `@type` values:
-*  is considered to be a _Data Entity_ if its `@id` is an absolute URI or a relative URI.
+* Is considered to be a _Data Entity_ if its `@id` is an absolute URI or a relative URI.
 * MAY have an `@id` which is a local identifier beginning with a `#`, in which case it is **not** considered to be a `Data Entity`.
 
 The requirements for `File` and `Dataset` are set out below.


### PR DESCRIPTION
In short, `File` and `Dataset` entities are data entities if they use an absolute or relative URI, and not data entities if they use a local identifier starting with `#`.

Fixes(?) #400 

See https://github.com/ResearchObject/ro-crate/issues/400#issuecomment-2779152885 for further explanation