### PR TITLE
Hover indicators for links and cards on homepage

### DIFF
--- a/docs/_sass/_custom_classes.scss
+++ b/docs/_sass/_custom_classes.scss
@@ -114,35 +114,42 @@ body {
             background-color: $light !important;
         }
     }
-    .card {
-        border-left: 0px solid $primary;
-        transition: $card-slide-transition;
-        &:hover {
-            border-left-width: 6px;
-            margin-right: -6px;
-        }
+}
 
-        .card-header {
-            padding-top: 15px;
-            padding-bottom: 0;
-            a:hover {
-                text-decoration: none;
-            }
-            h3 {
-                font-size: 1.2rem;
-                font-weight: bold;
-                display: inline;
-                vertical-align: super;
-            }
-        }
-        button {
-            background-color: $white;
-        }
-        .card-footer {
-            padding-top: 0;
+.card {
+    border-left: 0px solid $primary;
+    transition: $card-slide-transition;
+
+    a {
+        text-decoration: none;
+    }
+
+    &:hover {
+        border-left-width: 6px;
+        margin-right: -6px;
+    }
+
+    .card-header {
+        padding-top: 15px;
+        padding-bottom: 0;
+
+        h3 {
+            font-size: 1.2rem;
+            font-weight: bold;
+            display: inline;
+            vertical-align: super;
         }
     }
+
+    button {
+        background-color: $white;
+    }
+
+    .card-footer {
+        padding-top: 0;
+    }
 }
+
 
 
 /*-----Top navigation-----*/

--- a/docs/_sass/_custom_classes.scss
+++ b/docs/_sass/_custom_classes.scss
@@ -185,6 +185,13 @@ body {
         background-color: $dark;
         padding: 0.75rem;
         margin: 0 0.5rem 0 0.5rem;
+
+        &:hover {
+            background-color: $primary;
+            border: 2px solid $primary;
+            color: $black;
+
+        }
     }
 
     .featured-content {

--- a/docs/index.html
+++ b/docs/index.html
@@ -39,7 +39,7 @@ layout: none
           <div class="col">
             <div class="card bg-white h-100">
               <div class="card-body text-center">
-                <a href="domains">
+                <a class="stretched-link" href="domains">
                   <i class="fa fa-3x fa-flask mt-3 mb-4"></i>                
                   <h3 class="card-title no-anchor text-dark">Domain</h3>
                 </a>
@@ -52,7 +52,7 @@ layout: none
           <div class="col">
             <div class="card bg-white h-100">
               <div class="card-body text-center">
-                <a href="tasks">
+                <a class="stretched-link" href="tasks">
                   <i class="fa fa-3x fa-pencil mt-3 mb-4"></i>                
                   <h3 class="card-title no-anchor text-dark">Task</h3>
                 </a>
@@ -64,7 +64,7 @@ layout: none
           <div class="col">
             <div class="card bg-white h-100">
               <div class="card-body text-center">
-                <a href="roles">
+                <a class="stretched-link" href="roles">
                   <i class="fa fa-3x fa-user mt-3 mb-4"></i>                
                   <h3 class="card-title no-anchor text-dark">Role</h3>
                 </a>


### PR DESCRIPTION
Fixes #345 .

1. Adds hover indicator (colour change) for links at top of homepage. In the screenshot below the link on the right has the hover state

![screenshot of RO-Crate homepage with one link hovered and one not](https://github.com/user-attachments/assets/53b2f394-2a9a-403e-96d0-ab2b3fe5d22d)

2. Unifies the hover behaviour of the use-case / domain-task-role cards (previously the latter had no hover indicator)