### PR TITLE
remove London timezone from embedded calendar

### DIFF
--- a/docs/pages/community/community.md
+++ b/docs/pages/community/community.md
@@ -143,9 +143,9 @@ There are also regular [regional drop-in calls](https://s.apache.org/ro-crate-re
 
 Members of the RO-Crate team can often be found presenting at open science conferences and events: see the list of [recent and upcoming events](outreach#upcoming-and-recent-events) for details.
 
-See the [RO-Crate Community Calendar](https://calendar.google.com/calendar/embed?src=b53932af95f34472d7253e3f54e7e11ab1bbe3bf4477c5c60e94db75e08d151e%40group.calendar.google.com&ctz=Europe%2FLondon) embedded below to import events to your own calendar (or [download the whole calendar as .ics](https://calendar.google.com/calendar/ical/b53932af95f34472d7253e3f54e7e11ab1bbe3bf4477c5c60e94db75e08d151e%40group.calendar.google.com/public/basic.ics)).
+See the [RO-Crate Community Calendar](https://calendar.google.com/calendar/embed?src=b53932af95f34472d7253e3f54e7e11ab1bbe3bf4477c5c60e94db75e08d151e%40group.calendar.google.com) embedded below to import events to your own calendar (or [download the whole calendar as .ics](https://calendar.google.com/calendar/ical/b53932af95f34472d7253e3f54e7e11ab1bbe3bf4477c5c60e94db75e08d151e%40group.calendar.google.com/public/basic.ics)).
 
-<iframe src="https://calendar.google.com/calendar/embed?src=b53932af95f34472d7253e3f54e7e11ab1bbe3bf4477c5c60e94db75e08d151e%40group.calendar.google.com&ctz=Europe%2FLondon" style="border: 0" width="800" height="600" frameborder="0" scrolling="no"></iframe>
+<iframe src="https://calendar.google.com/calendar/embed?src=b53932af95f34472d7253e3f54e7e11ab1bbe3bf4477c5c60e94db75e08d151e%40group.calendar.google.com" style="border: 0" width="800" height="600" frameborder="0" scrolling="no"></iframe>
 
 ## Mailing list
 

--- a/docs/pages/community/community.md
+++ b/docs/pages/community/community.md
@@ -143,7 +143,7 @@ There are also regular [regional drop-in calls](https://s.apache.org/ro-crate-re
 
 Members of the RO-Crate team can often be found presenting at open science conferences and events: see the list of [recent and upcoming events](outreach#upcoming-and-recent-events) for details.
 
-See the [RO-Crate Community Calendar](https://calendar.google.com/calendar/embed?src=b53932af95f34472d7253e3f54e7e11ab1bbe3bf4477c5c60e94db75e08d151e%40group.calendar.google.com) embedded below to import events to your own calendar (or [download the whole calendar as .ics](https://calendar.google.com/calendar/ical/b53932af95f34472d7253e3f54e7e11ab1bbe3bf4477c5c60e94db75e08d151e%40group.calendar.google.com/public/basic.ics)).
+See the [RO-Crate Community Calendar](https://calendar.google.com/calendar/embed?src=b53932af95f34472d7253e3f54e7e11ab1bbe3bf4477c5c60e94db75e08d151e%40group.calendar.google.com) embedded below (in timezone UTC) to import events to your own calendar (or [download the whole calendar as .ics](https://calendar.google.com/calendar/ical/b53932af95f34472d7253e3f54e7e11ab1bbe3bf4477c5c60e94db75e08d151e%40group.calendar.google.com/public/basic.ics)).
 
 <iframe src="https://calendar.google.com/calendar/embed?src=b53932af95f34472d7253e3f54e7e11ab1bbe3bf4477c5c60e94db75e08d151e%40group.calendar.google.com" style="border: 0" width="800" height="600" frameborder="0" scrolling="no"></iframe>
 


### PR DESCRIPTION
Extra work is needed to make the timezone dynamic based on user locale, so for now, just set it to UTC so it's universally inconvenient.