### PR TITLE
Ensure all our rdfs: properties are defined in core RO-Crate profile

### DIFF
--- a/docs/_specification/1.2/ro-crate-metadata.json
+++ b/docs/_specification/1.2/ro-crate-metadata.json
@@ -309,10 +309,28 @@
           "@id": "http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"
         },
         {
+          "@id": "http://www.w3.org/1999/02/22-rdf-syntax-ns#subClassOf"
+        },
+        {
+          "@id": "http://www.w3.org/1999/02/22-rdf-syntax-ns#subPropertyOf"
+        },
+        {
+          "@id": "http://www.w3.org/1999/02/22-rdf-syntax-ns#label"
+        },
+        {
+          "@id": "http://www.w3.org/1999/02/22-rdf-syntax-ns#comment"
+        },
+        {
           "@id": "http://schema.org/Class"
         },
         {
           "@id": "http://schema.org/Property"
+        },
+        {
+          "@id": "http://schema.org/domainIncludes"
+        },
+        {
+          "@id": "http://schema.org/rangeIncludes"
         },
         {
           "@id": "http://www.opengis.net/ont/geosparql#Geometry"
@@ -517,6 +535,7 @@
       "inDefinedTermSet": {
         "@id": "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
       },
+      "termCode": "rdfs:Class",
       "name": "Class (rdfs)",
       "description": "Class definition",
       "url": "https://www.w3.org/TR/rdf-schema/#ch_class"
@@ -527,10 +546,105 @@
       "inDefinedTermSet": {
         "@id": "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
       },
+      "termCode": "rdfs:Property",
       "name": "Property (rdfs)",
-      "description": "Property definition, typically with domainIncludes and rangeIncludes",
+      "description": "Property definition, in schema.org style schema typically with domainIncludes and rangeIncludes",
       "url": "https://www.w3.org/TR/rdf-schema/#ch_property"
     },
+    {
+      "@id": "http://www.w3.org/1999/02/22-rdf-syntax-ns#subPropertyOf",
+      "@type": ["DefinedTerm","rdfs:Property"],
+      "inDefinedTermSet": {
+        "@id": "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+      },
+      "termCode": "rdfs:subPropertyOf",
+      "name": "subPropertyOf (rdfs)",
+      "domainIncludes": { "@id": "http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"},
+      "rangeIncludes": { "@id": "http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"},
+      "description": "A subproperty is a specialisation of another property",
+      "url": "https://www.w3.org/TR/rdf-schema/#ch_subpropertyof"
+    },
+    {
+      "@id": "http://www.w3.org/1999/02/22-rdf-syntax-ns#subClassOf",
+      "@type": ["DefinedTerm","rdfs:Property"],
+      "inDefinedTermSet": {
+        "@id": "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+      },
+      "domainIncludes": { "@id": "http://www.w3.org/1999/02/22-rdf-syntax-ns#Class"},
+      "rangeIncludes": { "@id": "http://www.w3.org/1999/02/22-rdf-syntax-ns#Class"},
+      "termCode": "rdfs:subClassOf",
+      "name": "subClassOf (rdfs)",
+      "description": "A subclass is a specialisation of another class",
+      "url": "https://www.w3.org/TR/rdf-schema/#ch_subclassof"
+    },
+    {
+      "@id": "http://www.w3.org/1999/02/22-rdf-syntax-ns#label",
+      "@type": ["DefinedTerm","rdfs:Property"],
+      "inDefinedTermSet": {
+        "@id": "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+      },
+      "domainIncludes": [ 
+        { "@id": "http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"},
+        { "@id": "http://www.w3.org/1999/02/22-rdf-syntax-ns#Class"}        
+      ],
+      "rangeIncludes": { "@id": "http://schema.org/Text"},
+      "termCode": "rdfs:label",
+      "name": "label (rdfs)",
+      "description": "A human-readable name of the property/class defined with RDFS, equivalent to 'name' in schema.org",
+      "url": "https://www.w3.org/TR/rdf-schema/#ch_label"
+    },     
+    {
+      "@id": "http://www.w3.org/1999/02/22-rdf-syntax-ns#comment",
+      "@type": ["DefinedTerm","rdfs:Property"],
+      "inDefinedTermSet": {
+        "@id": "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+      },
+      "domainIncludes": [ 
+        { "@id": "http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"},
+        { "@id": "http://www.w3.org/1999/02/22-rdf-syntax-ns#Class"}        
+      ],
+      "rangeIncludes": { "@id": "http://schema.org/Text"},      
+      "termCode": "rdfs:comment",
+      "name": "comment (rdfs)",
+      "description": "A human-readable description of the property/class defined with RDFS, equivalent to 'description' in schema.org",
+      "url": "https://www.w3.org/TR/rdf-schema/#ch_comment"
+    },
+    {
+      "@id": "http://schema.org/domainIncludes",
+      "@type": ["DefinedTerm","rdfs:Property"],
+      "inDefinedTermSet": {
+        "@id": "https://schema.org/docs/releases.html#v22.0"
+      },
+      "name": "domainIncludes",
+      "termCode": "domainIncludes",
+      "domainIncludes": [
+        {"@id": "http://schema.org/Class"},
+        {"@id": "http://www.w3.org/1999/02/22-rdf-syntax-ns#Class"}
+      ],
+      "rangeIncludes": [
+        {"@id": "http://schema.org/Class"},
+        {"@id": "http://www.w3.org/1999/02/22-rdf-syntax-ns#Class"}
+      ],
+      "description": "The domain of a property includes the given classes, meaning the property may be used on instances of these classes. Equivalent to rdfs:domain but allowing multiple disjoint classes."      
+    },
+    {
+      "@id": "http://schema.org/rangeIncludes",
+      "@type": ["DefinedTerm","rdfs:Property"],
+      "inDefinedTermSet": {
+        "@id": "https://schema.org/docs/releases.html#v22.0"
+      },
+      "domainIncludes": [
+        {"@id": "http://schema.org/Class"},
+        {"@id": "http://www.w3.org/1999/02/22-rdf-syntax-ns#Class"}
+      ],
+      "rangeIncludes": [
+        {"@id": "http://schema.org/Class"},
+        {"@id": "http://www.w3.org/1999/02/22-rdf-syntax-ns#Class"}
+      ],      
+      "name": "rangeIncludes",
+      "termCode": "rangeIncludes",
+      "description": "The range of a property includes the given types, meaning instances of these types may be the target of this property. Equivalent to rdfs:range but allowing multiple disjoint types. For datatype properties, point to subclasses of http://schema.org/DataType e.g. for a string, http://schema.org/Text"
+    },    
     {
       "@id": "http://schema.org/Class",
       "@type": ["DefinedTerm","Class"],

--- a/docs/_specification/1.2/ro-crate-preview.html
+++ b/docs/_specification/1.2/ro-crate-preview.html
@@ -6,9 +6,7 @@
 
 <script type="application/ld+json"> 
   {
-  "@context": [
-    "https://w3id.org/ro/crate/1.2/context"
-  ],
+  "@context": "https://w3id.org/ro/crate/1.2/context",
   "@graph": [
     {
       "@id": "ro-crate-metadata.json",
@@ -348,10 +346,28 @@
           "@id": "http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"
         },
         {
+          "@id": "http://www.w3.org/1999/02/22-rdf-syntax-ns#subClassOf"
+        },
+        {
+          "@id": "http://www.w3.org/1999/02/22-rdf-syntax-ns#subPropertyOf"
+        },
+        {
+          "@id": "http://www.w3.org/1999/02/22-rdf-syntax-ns#label"
+        },
+        {
+          "@id": "http://www.w3.org/1999/02/22-rdf-syntax-ns#comment"
+        },
+        {
           "@id": "http://schema.org/Class"
         },
         {
           "@id": "http://schema.org/Property"
+        },
+        {
+          "@id": "http://schema.org/rangeIncludes"
+        },
+        {
+          "@id": "http://schema.org/domainIncludes"
         },
         {
           "@id": "http://www.opengis.net/ont/geosparql#Geometry"
@@ -1378,6 +1394,7 @@
       "inDefinedTermSet": {
         "@id": "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
       },
+      "termCode": "rdfs:Class",
       "name": "Class (rdfs)",
       "description": "Class definition",
       "url": "https://www.w3.org/TR/rdf-schema/#ch_class"
@@ -1391,9 +1408,100 @@
       "inDefinedTermSet": {
         "@id": "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
       },
+      "termCode": "rdfs:Property",
       "name": "Property (rdfs)",
-      "description": "Property definition, typically with domainIncludes and rangeIncludes",
+      "description": "Property definition, in schema.org style schema typically with domainIncludes and rangeIncludes",
       "url": "https://www.w3.org/TR/rdf-schema/#ch_property"
+    },
+    {
+      "@id": "http://www.w3.org/1999/02/22-rdf-syntax-ns#subClassOf",
+      "@type": [
+        "DefinedTerm",
+        "rdfs:Property"
+      ],
+      "inDefinedTermSet": {
+        "@id": "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+      },
+      "domainIncludes": {
+        "@id": "http://www.w3.org/1999/02/22-rdf-syntax-ns#Class"
+      },
+      "rangeIncludes": {
+        "@id": "http://www.w3.org/1999/02/22-rdf-syntax-ns#Class"
+      },
+      "termCode": "rdfs:subClassOf",
+      "name": "subClassOf (rdfs)",
+      "description": "A subclass is a specialisation of another class",
+      "url": "https://www.w3.org/TR/rdf-schema/#ch_subclassof"
+    },
+    {
+      "@id": "http://www.w3.org/1999/02/22-rdf-syntax-ns#subPropertyOf",
+      "@type": [
+        "DefinedTerm",
+        "rdfs:Property"
+      ],
+      "inDefinedTermSet": {
+        "@id": "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+      },
+      "termCode": "rdfs:subPropertyOf",
+      "name": "subPropertyOf (rdfs)",
+      "domainIncludes": {
+        "@id": "http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"
+      },
+      "rangeIncludes": {
+        "@id": "http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"
+      },
+      "description": "A subproperty is a specialisation of another property",
+      "url": "https://www.w3.org/TR/rdf-schema/#ch_subpropertyof"
+    },
+    {
+      "@id": "http://www.w3.org/1999/02/22-rdf-syntax-ns#label",
+      "@type": [
+        "DefinedTerm",
+        "rdfs:Property"
+      ],
+      "inDefinedTermSet": {
+        "@id": "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+      },
+      "domainIncludes": [
+        {
+          "@id": "http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"
+        },
+        {
+          "@id": "http://www.w3.org/1999/02/22-rdf-syntax-ns#Class"
+        }
+      ],
+      "rangeIncludes": {
+        "@id": "http://schema.org/Text"
+      },
+      "termCode": "rdfs:label",
+      "name": "label (rdfs)",
+      "description": "A human-readable name of the property/class defined with RDFS, equivalent to 'name' in schema.org",
+      "url": "https://www.w3.org/TR/rdf-schema/#ch_label"
+    },
+    {
+      "@id": "http://www.w3.org/1999/02/22-rdf-syntax-ns#comment",
+      "@type": [
+        "DefinedTerm",
+        "rdfs:Property"
+      ],
+      "inDefinedTermSet": {
+        "@id": "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+      },
+      "domainIncludes": [
+        {
+          "@id": "http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"
+        },
+        {
+          "@id": "http://www.w3.org/1999/02/22-rdf-syntax-ns#Class"
+        }
+      ],
+      "rangeIncludes": {
+        "@id": "http://schema.org/Text"
+      },
+      "termCode": "rdfs:comment",
+      "name": "comment (rdfs)",
+      "description": "A human-readable description of the property/class defined with RDFS, equivalent to 'description' in schema.org",
+      "url": "https://www.w3.org/TR/rdf-schema/#ch_comment"
     },
     {
       "@id": "http://schema.org/Class",
@@ -1418,6 +1526,64 @@
       },
       "name": "Property (schema.org)",
       "description": "Property reference, as indicated by @id url or inDefinedTermSet"
+    },
+    {
+      "@id": "http://schema.org/rangeIncludes",
+      "@type": [
+        "DefinedTerm",
+        "rdfs:Property"
+      ],
+      "inDefinedTermSet": {
+        "@id": "https://schema.org/docs/releases.html#v22.0"
+      },
+      "domainIncludes": [
+        {
+          "@id": "http://schema.org/Class"
+        },
+        {
+          "@id": "http://www.w3.org/1999/02/22-rdf-syntax-ns#Class"
+        }
+      ],
+      "rangeIncludes": [
+        {
+          "@id": "http://schema.org/Class"
+        },
+        {
+          "@id": "http://www.w3.org/1999/02/22-rdf-syntax-ns#Class"
+        }
+      ],
+      "name": "rangeIncludes",
+      "termCode": "rangeIncludes",
+      "description": "The range of a property includes the given types, meaning instances of these types may be the target of this property. Equivalent to rdfs:range but allowing multiple disjoint types. For datatype properties, point to subclasses of http://schema.org/DataType e.g. for a string, http://schema.org/Text"
+    },
+    {
+      "@id": "http://schema.org/domainIncludes",
+      "@type": [
+        "DefinedTerm",
+        "rdfs:Property"
+      ],
+      "inDefinedTermSet": {
+        "@id": "https://schema.org/docs/releases.html#v22.0"
+      },
+      "name": "domainIncludes",
+      "termCode": "domainIncludes",
+      "domainIncludes": [
+        {
+          "@id": "http://schema.org/Class"
+        },
+        {
+          "@id": "http://www.w3.org/1999/02/22-rdf-syntax-ns#Class"
+        }
+      ],
+      "rangeIncludes": [
+        {
+          "@id": "http://schema.org/Class"
+        },
+        {
+          "@id": "http://www.w3.org/1999/02/22-rdf-syntax-ns#Class"
+        }
+      ],
+      "description": "The domain of a property includes the given classes, meaning the property may be used on instances of these classes. Equivalent to rdfs:domain but allowing multiple disjoint classes."
     },
     {
       "@id": "http://www.opengis.net/ont/geosparql#Geometry",
@@ -2600,8 +2766,8 @@ table.table {
   </nav>
 <div class="container">
 <div class="jumbotron">
-<h4 class="citation"></h4>
-<h3 class="item_name">RO-Crate specification 1.2</h3>
+<h4 class="citation"></h3>
+<h3 class="item_name">RO-Crate specification 1.2</h4>
 
 
 <a href="./ro-crate-metadata.json">⬇️🏷️ Download all the metadata for <span class='name'>RO-Crate specification 1.2</span> in JSON-LD format</a>
@@ -2616,12 +2782,12 @@ table.table {
 
 <div id="summary">
 <div class='all-meta'>
-            <div>
-                <h3><a href="https://w3id.org/ro/crate/1.2">Go to: </a> RO-Crate specification 1.2</h3>
-                
-                
-                
-                
+           <div>
+            <h3><a href="https://w3id.org/ro/crate/1.2">Go to: </a> RO-Crate specification 1.2</h3>
+            
+            
+            
+            
         <div id="https://w3id.org/ro/crate/1.2">
             
             <table class="table metadata table-striped" >
@@ -2629,7 +2795,7 @@ table.table {
             <th style="text-align:left;" class="prop">@id</th>
             <td style='text-align:left'><a href="https://w3id.org/ro/crate/1.2">https://w3id.org/ro/crate/1.2</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">name</th>
+            <th style="text-align:left;" class="prop">name<span>&nbsp;</span><a href="http://schema.org/name">[?]</a></th>
             <td style='text-align:left'><span>RO-Crate specification 1.2</span></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">@type</th>
@@ -2639,20 +2805,20 @@ table.table {
                         <li><span>Profile</span></li>
                         </ul></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">description</th>
+            <th style="text-align:left;" class="prop">description<span>&nbsp;</span><a href="http://schema.org/description">[?]</a></th>
             <td style='text-align:left'><span>Profile Crate for RO-Crate specification. This specification defines a method, known as RO-Crate (Research Object Crate), of organizing file-based data with associated metadata, using linked data principles, in both human and machine readable formats, with the ability to include additional domain-specific metadata. 
 
 The core of RO-Crate is a JSON-LD file, the RO-Crate Metadata File, named ro-crate-metadata.json. This file contains structured metadata about the dataset as a whole (the Root Data Entity) and, optionally, about some or all of its files. This provides a simple way to, for example, assert the authors (e.g. people, organizations) of the RO-Crate or one its files, or to capture more complex provenance for files, such as how they were created using software and equipment. 
 
 While providing the formal specification for RO-Crate, this document also aims to be a practical guide for software authors to create tools for generating and consuming research data packages, with explanation by examples.</span></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">isPartOf</th>
+            <th style="text-align:left;" class="prop">isPartOf<span>&nbsp;</span><a href="http://schema.org/isPartOf">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//w3id.org/ro/crate/">Research Object Crate (RO-Crate) website</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">datePublished</th>
+            <th style="text-align:left;" class="prop">datePublished<span>&nbsp;</span><a href="http://schema.org/datePublished">[?]</a></th>
             <td style='text-align:left'><span>2025-06-04</span></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">author</th>
+            <th style="text-align:left;" class="prop">author<span>&nbsp;</span><a href="http://schema.org/author">[?]</a></th>
             <td style='text-align:left'>
                         <details style='margin-left: 3%'>
                             <summary>
@@ -2837,13 +3003,13 @@ While providing the formal specification for RO-Crate, this document also aims t
                         </details>
                 </td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">cite-as</th>
+            <th style="text-align:left;" class="prop">cite-as<span>&nbsp;</span><a href="http://www.iana.org/assignments/relation/cite-as">[?]</a></th>
             <td style='text-align:left'><a href="https://doi.org/10.5281/zenodo.13751027">https://doi.org/10.5281/zenodo.13751027</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">citation</th>
+            <th style="text-align:left;" class="prop">citation<span>&nbsp;</span><a href="http://schema.org/citation">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//doi.org/10.3233/DS-210053">Packaging research artefacts with RO-Crate</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">hasPart</th>
+            <th style="text-align:left;" class="prop">hasPart<span>&nbsp;</span><a href="http://schema.org/hasPart">[?]</a></th>
             <td style='text-align:left'><ul>
                         <li><a href="#https%3A//www.researchobject.org/ro-crate/1.2/">RO-Crate Metadata Specification 1.2</a></li>
                         
@@ -2883,9 +3049,21 @@ While providing the formal specification for RO-Crate, this document also aims t
                         
                         <li><a href="#http%3A//www.w3.org/1999/02/22-rdf-syntax-ns%23Property">Property (rdfs)</a></li>
                         
+                        <li><a href="#http%3A//www.w3.org/1999/02/22-rdf-syntax-ns%23subClassOf">subClassOf (rdfs)</a></li>
+                        
+                        <li><a href="#http%3A//www.w3.org/1999/02/22-rdf-syntax-ns%23subPropertyOf">subPropertyOf (rdfs)</a></li>
+                        
+                        <li><a href="#http%3A//www.w3.org/1999/02/22-rdf-syntax-ns%23label">label (rdfs)</a></li>
+                        
+                        <li><a href="#http%3A//www.w3.org/1999/02/22-rdf-syntax-ns%23comment">comment (rdfs)</a></li>
+                        
                         <li><a href="#http%3A//schema.org/Class">Class (schema.org)</a></li>
                         
                         <li><a href="#http%3A//schema.org/Property">Property (schema.org)</a></li>
+                        
+                        <li><a href="#http%3A//schema.org/rangeIncludes">rangeIncludes</a></li>
+                        
+                        <li><a href="#http%3A//schema.org/domainIncludes">domainIncludes</a></li>
                         
                         <li><a href="#http%3A//www.opengis.net/ont/geosparql%23Geometry">Geometry</a></li>
                         
@@ -2910,13 +3088,13 @@ While providing the formal specification for RO-Crate, this document also aims t
                         <li><a href="#https%3A//w3id.org/ro/terms%23localPath">localPath</a></li>
                         </ul></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">identifier</th>
+            <th style="text-align:left;" class="prop">identifier<span>&nbsp;</span><a href="http://schema.org/identifier">[?]</a></th>
             <td style='text-align:left'>undefined: doi:10.5281/zenodo.13751027</td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">isBasedOn</th>
+            <th style="text-align:left;" class="prop">isBasedOn<span>&nbsp;</span><a href="http://schema.org/isBasedOn">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//w3id.org/ro/crate/1.1">RO-Crate specification 1.1</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">isProfileOf</th>
+            <th style="text-align:left;" class="prop">isProfileOf<span>&nbsp;</span><a href="http://www.w3.org/ns/dx/prof/isProfileOf">[?]</a></th>
             <td style='text-align:left'><ul>
                         <li><a href="#http%3A//www.w3.org/TR/2014/REC-json-ld-20140116/">JSON-LD 1.0</a></li>
                         
@@ -2925,19 +3103,19 @@ While providing the formal specification for RO-Crate, this document also aims t
                         <li><a href="#https%3A//schema.org/docs/releases.html%23v22.0">Schema.org vocabulary (http prefix)</a></li>
                         </ul></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">license</th>
+            <th style="text-align:left;" class="prop">license<span>&nbsp;</span><a href="http://schema.org/license">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//www.apache.org/licenses/LICENSE-2.0">Apache License 2.0</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">maintainer</th>
+            <th style="text-align:left;" class="prop">maintainer<span>&nbsp;</span><a href="http://schema.org/maintainer">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//www.researchobject.org/ro-crate/community">RO-Crate Community</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">publisher</th>
+            <th style="text-align:left;" class="prop">publisher<span>&nbsp;</span><a href="http://schema.org/publisher">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//www.researchobject.org/">ResearchObject.org</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">version</th>
+            <th style="text-align:left;" class="prop">version<span>&nbsp;</span><a href="http://schema.org/version">[?]</a></th>
             <td style='text-align:left'><span>1.2.0</span></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">hasResource</th>
+            <th style="text-align:left;" class="prop">hasResource<span>&nbsp;</span><a href="http://www.w3.org/ns/dx/prof/hasResource">[?]</a></th>
             <td style='text-align:left'><ul>
                         <li><a href="#%23vocabulary-schema">#vocabulary-schema</a></li>
                         
@@ -2958,26 +3136,27 @@ While providing the formal specification for RO-Crate, this document also aims t
                         <li><a href="#%23example-rainfall">#example-rainfall</a></li>
                         </ul></td>
             </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
-            <th style="text-align:left;" class="prop">conformsTo</th>
+            <th style="text-align:left;" class="prop">conformsTo<span>&nbsp;</span><a href="http://purl.org/dc/terms/conformsTo">[?]</a></th>
             <td style='text-align:left'><ul>
                         <li><a href="#ro-crate-metadata.json">ro-crate-metadata.json</a></li>
                         
                         <li><a href="#https%3A//www.researchobject.org/ro-crate/1.2/examples/rainfall-1.2.0/">Example dataset for RO-Crate specification</a></li>
                         </ul></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">about</th>
+            <th style="text-align:left;" class="prop">about<span>&nbsp;</span><a href="http://schema.org/about">[?]</a></th>
             <td style='text-align:left'><a href="#ro-crate-metadata.json">ro-crate-metadata.json</a></td>
             </tr></tbody>
             </table>
         </div>
-            </div>
+
+        </div>
         <hr/><br/><br/>
-            <div>
-                <h3><a href="https://w3id.org/ro/crate/">Go to: </a> Research Object Crate (RO-Crate) website</h3>
-                
-                
-                
-                
+           <div>
+            <h3><a href="https://w3id.org/ro/crate/">Go to: </a> Research Object Crate (RO-Crate) website</h3>
+            
+            
+            
+            
         <div id="https://w3id.org/ro/crate/">
             
             <table class="table metadata table-striped" >
@@ -2985,34 +3164,35 @@ While providing the formal specification for RO-Crate, this document also aims t
             <th style="text-align:left;" class="prop">@id</th>
             <td style='text-align:left'><a href="https://w3id.org/ro/crate/">https://w3id.org/ro/crate/</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">name</th>
+            <th style="text-align:left;" class="prop">name<span>&nbsp;</span><a href="http://schema.org/name">[?]</a></th>
             <td style='text-align:left'><span>Research Object Crate (RO-Crate) website</span></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">@type</th>
             <td style='text-align:left'><span>WebSite</span></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">maintainer</th>
+            <th style="text-align:left;" class="prop">maintainer<span>&nbsp;</span><a href="http://schema.org/maintainer">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//www.researchobject.org/ro-crate/community">RO-Crate Community</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">publisher</th>
+            <th style="text-align:left;" class="prop">publisher<span>&nbsp;</span><a href="http://schema.org/publisher">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//www.researchobject.org/">ResearchObject.org</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">url</th>
+            <th style="text-align:left;" class="prop">url<span>&nbsp;</span><a href="http://schema.org/url">[?]</a></th>
             <td style='text-align:left'><a href="https://www.researchobject.org/ro-crate/">https://www.researchobject.org/ro-crate/</a></td>
             </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
-            <th style="text-align:left;" class="prop">isPartOf</th>
+            <th style="text-align:left;" class="prop">isPartOf<span>&nbsp;</span><a href="http://schema.org/isPartOf">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//w3id.org/ro/crate/1.2">RO-Crate specification 1.2</a></td>
             </tr></tbody>
             </table>
         </div>
-            </div>
+
+        </div>
         <hr/><br/><br/>
-            <div>
-                <h3><a href="https://orcid.org/0000-0001-8131-2150">Go to: </a> Eoghan Ó Carragáin</h3>
-                
-                
-                
-                
+           <div>
+            <h3><a href="https://orcid.org/0000-0001-8131-2150">Go to: </a> Eoghan Ó Carragáin</h3>
+            
+            
+            
+            
         <div id="https://orcid.org/0000-0001-8131-2150">
             
             <table class="table metadata table-striped" >
@@ -3020,32 +3200,33 @@ While providing the formal specification for RO-Crate, this document also aims t
             <th style="text-align:left;" class="prop">@id</th>
             <td style='text-align:left'><a href="https://orcid.org/0000-0001-8131-2150">https://orcid.org/0000-0001-8131-2150</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">name</th>
+            <th style="text-align:left;" class="prop">name<span>&nbsp;</span><a href="http://schema.org/name">[?]</a></th>
             <td style='text-align:left'><span>Eoghan Ó Carragáin</span></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">@type</th>
             <td style='text-align:left'><span>Person</span></td>
             </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
-            <th style="text-align:left;" class="prop">author</th>
+            <th style="text-align:left;" class="prop">author<span>&nbsp;</span><a href="http://schema.org/author">[?]</a></th>
             <td style='text-align:left'><ul>
                         <li><a href="#https%3A//w3id.org/ro/crate/1.2">RO-Crate specification 1.2</a></li>
                         
                         <li><a href="#https%3A//doi.org/10.3233/DS-210053">Packaging research artefacts with RO-Crate</a></li>
                         </ul></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">member</th>
+            <th style="text-align:left;" class="prop">member<span>&nbsp;</span><a href="http://schema.org/member">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//www.researchobject.org/ro-crate/community">RO-Crate Community</a></td>
             </tr></tbody>
             </table>
         </div>
-            </div>
+
+        </div>
         <hr/><br/><br/>
-            <div>
-                <h3><a href="https://orcid.org/0000-0002-3545-944X">Go to: </a> Peter Sefton</h3>
-                
-                
-                
-                
+           <div>
+            <h3><a href="https://orcid.org/0000-0002-3545-944X">Go to: </a> Peter Sefton</h3>
+            
+            
+            
+            
         <div id="https://orcid.org/0000-0002-3545-944X">
             
             <table class="table metadata table-striped" >
@@ -3053,32 +3234,33 @@ While providing the formal specification for RO-Crate, this document also aims t
             <th style="text-align:left;" class="prop">@id</th>
             <td style='text-align:left'><a href="https://orcid.org/0000-0002-3545-944X">https://orcid.org/0000-0002-3545-944X</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">name</th>
+            <th style="text-align:left;" class="prop">name<span>&nbsp;</span><a href="http://schema.org/name">[?]</a></th>
             <td style='text-align:left'><span>Peter Sefton</span></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">@type</th>
             <td style='text-align:left'><span>Person</span></td>
             </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
-            <th style="text-align:left;" class="prop">author</th>
+            <th style="text-align:left;" class="prop">author<span>&nbsp;</span><a href="http://schema.org/author">[?]</a></th>
             <td style='text-align:left'><ul>
                         <li><a href="#https%3A//w3id.org/ro/crate/1.2">RO-Crate specification 1.2</a></li>
                         
                         <li><a href="#https%3A//doi.org/10.3233/DS-210053">Packaging research artefacts with RO-Crate</a></li>
                         </ul></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">member</th>
+            <th style="text-align:left;" class="prop">member<span>&nbsp;</span><a href="http://schema.org/member">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//www.researchobject.org/ro-crate/community">RO-Crate Community</a></td>
             </tr></tbody>
             </table>
         </div>
-            </div>
+
+        </div>
         <hr/><br/><br/>
-            <div>
-                <h3><a href="https://orcid.org/0000-0001-9842-9718">Go to: </a> Stian Soiland-Reyes</h3>
-                
-                
-                
-                
+           <div>
+            <h3><a href="https://orcid.org/0000-0001-9842-9718">Go to: </a> Stian Soiland-Reyes</h3>
+            
+            
+            
+            
         <div id="https://orcid.org/0000-0001-9842-9718">
             
             <table class="table metadata table-striped" >
@@ -3086,32 +3268,33 @@ While providing the formal specification for RO-Crate, this document also aims t
             <th style="text-align:left;" class="prop">@id</th>
             <td style='text-align:left'><a href="https://orcid.org/0000-0001-9842-9718">https://orcid.org/0000-0001-9842-9718</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">name</th>
+            <th style="text-align:left;" class="prop">name<span>&nbsp;</span><a href="http://schema.org/name">[?]</a></th>
             <td style='text-align:left'><span>Stian Soiland-Reyes</span></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">@type</th>
             <td style='text-align:left'><span>Person</span></td>
             </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
-            <th style="text-align:left;" class="prop">author</th>
+            <th style="text-align:left;" class="prop">author<span>&nbsp;</span><a href="http://schema.org/author">[?]</a></th>
             <td style='text-align:left'><ul>
                         <li><a href="#https%3A//w3id.org/ro/crate/1.2">RO-Crate specification 1.2</a></li>
                         
                         <li><a href="#https%3A//doi.org/10.3233/DS-210053">Packaging research artefacts with RO-Crate</a></li>
                         </ul></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">member</th>
+            <th style="text-align:left;" class="prop">member<span>&nbsp;</span><a href="http://schema.org/member">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//www.researchobject.org/ro-crate/community">RO-Crate Community</a></td>
             </tr></tbody>
             </table>
         </div>
-            </div>
+
+        </div>
         <hr/><br/><br/>
-            <div>
-                <h3><a href="https://orcid.org/0000-0002-9260-0753">Go to: </a> Oscar Corcho</h3>
-                
-                
-                
-                
+           <div>
+            <h3><a href="https://orcid.org/0000-0002-9260-0753">Go to: </a> Oscar Corcho</h3>
+            
+            
+            
+            
         <div id="https://orcid.org/0000-0002-9260-0753">
             
             <table class="table metadata table-striped" >
@@ -3119,28 +3302,29 @@ While providing the formal specification for RO-Crate, this document also aims t
             <th style="text-align:left;" class="prop">@id</th>
             <td style='text-align:left'><a href="https://orcid.org/0000-0002-9260-0753">https://orcid.org/0000-0002-9260-0753</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">name</th>
+            <th style="text-align:left;" class="prop">name<span>&nbsp;</span><a href="http://schema.org/name">[?]</a></th>
             <td style='text-align:left'><span>Oscar Corcho</span></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">@type</th>
             <td style='text-align:left'><span>Person</span></td>
             </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
-            <th style="text-align:left;" class="prop">author</th>
+            <th style="text-align:left;" class="prop">author<span>&nbsp;</span><a href="http://schema.org/author">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//w3id.org/ro/crate/1.2">RO-Crate specification 1.2</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">member</th>
+            <th style="text-align:left;" class="prop">member<span>&nbsp;</span><a href="http://schema.org/member">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//www.researchobject.org/ro-crate/community">RO-Crate Community</a></td>
             </tr></tbody>
             </table>
         </div>
-            </div>
+
+        </div>
         <hr/><br/><br/>
-            <div>
-                <h3><a href="https://orcid.org/0000-0003-0454-7145">Go to: </a> Daniel Garijo</h3>
-                
-                
-                
-                
+           <div>
+            <h3><a href="https://orcid.org/0000-0003-0454-7145">Go to: </a> Daniel Garijo</h3>
+            
+            
+            
+            
         <div id="https://orcid.org/0000-0003-0454-7145">
             
             <table class="table metadata table-striped" >
@@ -3148,32 +3332,33 @@ While providing the formal specification for RO-Crate, this document also aims t
             <th style="text-align:left;" class="prop">@id</th>
             <td style='text-align:left'><a href="https://orcid.org/0000-0003-0454-7145">https://orcid.org/0000-0003-0454-7145</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">name</th>
+            <th style="text-align:left;" class="prop">name<span>&nbsp;</span><a href="http://schema.org/name">[?]</a></th>
             <td style='text-align:left'><span>Daniel Garijo</span></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">@type</th>
             <td style='text-align:left'><span>Person</span></td>
             </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
-            <th style="text-align:left;" class="prop">author</th>
+            <th style="text-align:left;" class="prop">author<span>&nbsp;</span><a href="http://schema.org/author">[?]</a></th>
             <td style='text-align:left'><ul>
                         <li><a href="#https%3A//w3id.org/ro/crate/1.2">RO-Crate specification 1.2</a></li>
                         
                         <li><a href="#https%3A//doi.org/10.3233/DS-210053">Packaging research artefacts with RO-Crate</a></li>
                         </ul></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">member</th>
+            <th style="text-align:left;" class="prop">member<span>&nbsp;</span><a href="http://schema.org/member">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//www.researchobject.org/ro-crate/community">RO-Crate Community</a></td>
             </tr></tbody>
             </table>
         </div>
-            </div>
+
+        </div>
         <hr/><br/><br/>
-            <div>
-                <h3><a href="https://orcid.org/0000-0003-4289-4922">Go to: </a> Raul Palma</h3>
-                
-                
-                
-                
+           <div>
+            <h3><a href="https://orcid.org/0000-0003-4289-4922">Go to: </a> Raul Palma</h3>
+            
+            
+            
+            
         <div id="https://orcid.org/0000-0003-4289-4922">
             
             <table class="table metadata table-striped" >
@@ -3181,28 +3366,29 @@ While providing the formal specification for RO-Crate, this document also aims t
             <th style="text-align:left;" class="prop">@id</th>
             <td style='text-align:left'><a href="https://orcid.org/0000-0003-4289-4922">https://orcid.org/0000-0003-4289-4922</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">name</th>
+            <th style="text-align:left;" class="prop">name<span>&nbsp;</span><a href="http://schema.org/name">[?]</a></th>
             <td style='text-align:left'><span>Raul Palma</span></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">@type</th>
             <td style='text-align:left'><span>Person</span></td>
             </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
-            <th style="text-align:left;" class="prop">author</th>
+            <th style="text-align:left;" class="prop">author<span>&nbsp;</span><a href="http://schema.org/author">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//w3id.org/ro/crate/1.2">RO-Crate specification 1.2</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">member</th>
+            <th style="text-align:left;" class="prop">member<span>&nbsp;</span><a href="http://schema.org/member">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//www.researchobject.org/ro-crate/community">RO-Crate Community</a></td>
             </tr></tbody>
             </table>
         </div>
-            </div>
+
+        </div>
         <hr/><br/><br/>
-            <div>
-                <h3><a href="https://orcid.org/0000-0001-6565-5145">Go to: </a> Frederik Coppens</h3>
-                
-                
-                
-                
+           <div>
+            <h3><a href="https://orcid.org/0000-0001-6565-5145">Go to: </a> Frederik Coppens</h3>
+            
+            
+            
+            
         <div id="https://orcid.org/0000-0001-6565-5145">
             
             <table class="table metadata table-striped" >
@@ -3210,32 +3396,33 @@ While providing the formal specification for RO-Crate, this document also aims t
             <th style="text-align:left;" class="prop">@id</th>
             <td style='text-align:left'><a href="https://orcid.org/0000-0001-6565-5145">https://orcid.org/0000-0001-6565-5145</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">name</th>
+            <th style="text-align:left;" class="prop">name<span>&nbsp;</span><a href="http://schema.org/name">[?]</a></th>
             <td style='text-align:left'><span>Frederik Coppens</span></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">@type</th>
             <td style='text-align:left'><span>Person</span></td>
             </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
-            <th style="text-align:left;" class="prop">author</th>
+            <th style="text-align:left;" class="prop">author<span>&nbsp;</span><a href="http://schema.org/author">[?]</a></th>
             <td style='text-align:left'><ul>
                         <li><a href="#https%3A//w3id.org/ro/crate/1.2">RO-Crate specification 1.2</a></li>
                         
                         <li><a href="#https%3A//doi.org/10.3233/DS-210053">Packaging research artefacts with RO-Crate</a></li>
                         </ul></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">member</th>
+            <th style="text-align:left;" class="prop">member<span>&nbsp;</span><a href="http://schema.org/member">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//www.researchobject.org/ro-crate/community">RO-Crate Community</a></td>
             </tr></tbody>
             </table>
         </div>
-            </div>
+
+        </div>
         <hr/><br/><br/>
-            <div>
-                <h3><a href="https://orcid.org/0000-0003-1219-2137">Go to: </a> Carole Goble</h3>
-                
-                
-                
-                
+           <div>
+            <h3><a href="https://orcid.org/0000-0003-1219-2137">Go to: </a> Carole Goble</h3>
+            
+            
+            
+            
         <div id="https://orcid.org/0000-0003-1219-2137">
             
             <table class="table metadata table-striped" >
@@ -3243,32 +3430,33 @@ While providing the formal specification for RO-Crate, this document also aims t
             <th style="text-align:left;" class="prop">@id</th>
             <td style='text-align:left'><a href="https://orcid.org/0000-0003-1219-2137">https://orcid.org/0000-0003-1219-2137</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">name</th>
+            <th style="text-align:left;" class="prop">name<span>&nbsp;</span><a href="http://schema.org/name">[?]</a></th>
             <td style='text-align:left'><span>Carole Goble</span></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">@type</th>
             <td style='text-align:left'><span>Person</span></td>
             </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
-            <th style="text-align:left;" class="prop">author</th>
+            <th style="text-align:left;" class="prop">author<span>&nbsp;</span><a href="http://schema.org/author">[?]</a></th>
             <td style='text-align:left'><ul>
                         <li><a href="#https%3A//w3id.org/ro/crate/1.2">RO-Crate specification 1.2</a></li>
                         
                         <li><a href="#https%3A//doi.org/10.3233/DS-210053">Packaging research artefacts with RO-Crate</a></li>
                         </ul></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">member</th>
+            <th style="text-align:left;" class="prop">member<span>&nbsp;</span><a href="http://schema.org/member">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//www.researchobject.org/ro-crate/community">RO-Crate Community</a></td>
             </tr></tbody>
             </table>
         </div>
-            </div>
+
+        </div>
         <hr/><br/><br/>
-            <div>
-                <h3><a href="https://orcid.org/0000-0002-4806-5140">Go to: </a> José María Fernández</h3>
-                
-                
-                
-                
+           <div>
+            <h3><a href="https://orcid.org/0000-0002-4806-5140">Go to: </a> José María Fernández</h3>
+            
+            
+            
+            
         <div id="https://orcid.org/0000-0002-4806-5140">
             
             <table class="table metadata table-striped" >
@@ -3276,32 +3464,33 @@ While providing the formal specification for RO-Crate, this document also aims t
             <th style="text-align:left;" class="prop">@id</th>
             <td style='text-align:left'><a href="https://orcid.org/0000-0002-4806-5140">https://orcid.org/0000-0002-4806-5140</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">name</th>
+            <th style="text-align:left;" class="prop">name<span>&nbsp;</span><a href="http://schema.org/name">[?]</a></th>
             <td style='text-align:left'><span>José María Fernández</span></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">@type</th>
             <td style='text-align:left'><span>Person</span></td>
             </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
-            <th style="text-align:left;" class="prop">author</th>
+            <th style="text-align:left;" class="prop">author<span>&nbsp;</span><a href="http://schema.org/author">[?]</a></th>
             <td style='text-align:left'><ul>
                         <li><a href="#https%3A//w3id.org/ro/crate/1.2">RO-Crate specification 1.2</a></li>
                         
                         <li><a href="#https%3A//doi.org/10.3233/DS-210053">Packaging research artefacts with RO-Crate</a></li>
                         </ul></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">member</th>
+            <th style="text-align:left;" class="prop">member<span>&nbsp;</span><a href="http://schema.org/member">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//www.researchobject.org/ro-crate/community">RO-Crate Community</a></td>
             </tr></tbody>
             </table>
         </div>
-            </div>
+
+        </div>
         <hr/><br/><br/>
-            <div>
-                <h3><a href="https://orcid.org/0000-0002-7370-4805">Go to: </a> Kyle Chard</h3>
-                
-                
-                
-                
+           <div>
+            <h3><a href="https://orcid.org/0000-0002-7370-4805">Go to: </a> Kyle Chard</h3>
+            
+            
+            
+            
         <div id="https://orcid.org/0000-0002-7370-4805">
             
             <table class="table metadata table-striped" >
@@ -3309,28 +3498,29 @@ While providing the formal specification for RO-Crate, this document also aims t
             <th style="text-align:left;" class="prop">@id</th>
             <td style='text-align:left'><a href="https://orcid.org/0000-0002-7370-4805">https://orcid.org/0000-0002-7370-4805</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">name</th>
+            <th style="text-align:left;" class="prop">name<span>&nbsp;</span><a href="http://schema.org/name">[?]</a></th>
             <td style='text-align:left'><span>Kyle Chard</span></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">@type</th>
             <td style='text-align:left'><span>Person</span></td>
             </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
-            <th style="text-align:left;" class="prop">author</th>
+            <th style="text-align:left;" class="prop">author<span>&nbsp;</span><a href="http://schema.org/author">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//w3id.org/ro/crate/1.2">RO-Crate specification 1.2</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">member</th>
+            <th style="text-align:left;" class="prop">member<span>&nbsp;</span><a href="http://schema.org/member">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//www.researchobject.org/ro-crate/community">RO-Crate Community</a></td>
             </tr></tbody>
             </table>
         </div>
-            </div>
+
+        </div>
         <hr/><br/><br/>
-            <div>
-                <h3><a href="https://orcid.org/0000-0002-5491-6431">Go to: </a> Jose Manuel Gomez-Perez</h3>
-                
-                
-                
-                
+           <div>
+            <h3><a href="https://orcid.org/0000-0002-5491-6431">Go to: </a> Jose Manuel Gomez-Perez</h3>
+            
+            
+            
+            
         <div id="https://orcid.org/0000-0002-5491-6431">
             
             <table class="table metadata table-striped" >
@@ -3338,28 +3528,29 @@ While providing the formal specification for RO-Crate, this document also aims t
             <th style="text-align:left;" class="prop">@id</th>
             <td style='text-align:left'><a href="https://orcid.org/0000-0002-5491-6431">https://orcid.org/0000-0002-5491-6431</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">name</th>
+            <th style="text-align:left;" class="prop">name<span>&nbsp;</span><a href="http://schema.org/name">[?]</a></th>
             <td style='text-align:left'><span>Jose Manuel Gomez-Perez</span></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">@type</th>
             <td style='text-align:left'><span>Person</span></td>
             </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
-            <th style="text-align:left;" class="prop">author</th>
+            <th style="text-align:left;" class="prop">author<span>&nbsp;</span><a href="http://schema.org/author">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//w3id.org/ro/crate/1.2">RO-Crate specification 1.2</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">member</th>
+            <th style="text-align:left;" class="prop">member<span>&nbsp;</span><a href="http://schema.org/member">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//www.researchobject.org/ro-crate/community">RO-Crate Community</a></td>
             </tr></tbody>
             </table>
         </div>
-            </div>
+
+        </div>
         <hr/><br/><br/>
-            <div>
-                <h3><a href="https://orcid.org/0000-0002-2961-9670">Go to: </a> Michael R Crusoe</h3>
-                
-                
-                
-                
+           <div>
+            <h3><a href="https://orcid.org/0000-0002-2961-9670">Go to: </a> Michael R Crusoe</h3>
+            
+            
+            
+            
         <div id="https://orcid.org/0000-0002-2961-9670">
             
             <table class="table metadata table-striped" >
@@ -3367,28 +3558,29 @@ While providing the formal specification for RO-Crate, this document also aims t
             <th style="text-align:left;" class="prop">@id</th>
             <td style='text-align:left'><a href="https://orcid.org/0000-0002-2961-9670">https://orcid.org/0000-0002-2961-9670</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">name</th>
+            <th style="text-align:left;" class="prop">name<span>&nbsp;</span><a href="http://schema.org/name">[?]</a></th>
             <td style='text-align:left'><span>Michael R Crusoe</span></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">@type</th>
             <td style='text-align:left'><span>Person</span></td>
             </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
-            <th style="text-align:left;" class="prop">author</th>
+            <th style="text-align:left;" class="prop">author<span>&nbsp;</span><a href="http://schema.org/author">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//w3id.org/ro/crate/1.2">RO-Crate specification 1.2</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">member</th>
+            <th style="text-align:left;" class="prop">member<span>&nbsp;</span><a href="http://schema.org/member">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//www.researchobject.org/ro-crate/community">RO-Crate Community</a></td>
             </tr></tbody>
             </table>
         </div>
-            </div>
+
+        </div>
         <hr/><br/><br/>
-            <div>
-                <h3><a href="https://orcid.org/0000-0002-6190-122X">Go to: </a> Ignacio Eguinoa</h3>
-                
-                
-                
-                
+           <div>
+            <h3><a href="https://orcid.org/0000-0002-6190-122X">Go to: </a> Ignacio Eguinoa</h3>
+            
+            
+            
+            
         <div id="https://orcid.org/0000-0002-6190-122X">
             
             <table class="table metadata table-striped" >
@@ -3396,28 +3588,29 @@ While providing the formal specification for RO-Crate, this document also aims t
             <th style="text-align:left;" class="prop">@id</th>
             <td style='text-align:left'><a href="https://orcid.org/0000-0002-6190-122X">https://orcid.org/0000-0002-6190-122X</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">name</th>
+            <th style="text-align:left;" class="prop">name<span>&nbsp;</span><a href="http://schema.org/name">[?]</a></th>
             <td style='text-align:left'><span>Ignacio Eguinoa</span></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">@type</th>
             <td style='text-align:left'><span>Person</span></td>
             </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
-            <th style="text-align:left;" class="prop">author</th>
+            <th style="text-align:left;" class="prop">author<span>&nbsp;</span><a href="http://schema.org/author">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//w3id.org/ro/crate/1.2">RO-Crate specification 1.2</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">member</th>
+            <th style="text-align:left;" class="prop">member<span>&nbsp;</span><a href="http://schema.org/member">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//www.researchobject.org/ro-crate/community">RO-Crate Community</a></td>
             </tr></tbody>
             </table>
         </div>
-            </div>
+
+        </div>
         <hr/><br/><br/>
-            <div>
-                <h3><a href="https://orcid.org/0000-0002-2036-8350">Go to: </a> Nick Juty</h3>
-                
-                
-                
-                
+           <div>
+            <h3><a href="https://orcid.org/0000-0002-2036-8350">Go to: </a> Nick Juty</h3>
+            
+            
+            
+            
         <div id="https://orcid.org/0000-0002-2036-8350">
             
             <table class="table metadata table-striped" >
@@ -3425,28 +3618,29 @@ While providing the formal specification for RO-Crate, this document also aims t
             <th style="text-align:left;" class="prop">@id</th>
             <td style='text-align:left'><a href="https://orcid.org/0000-0002-2036-8350">https://orcid.org/0000-0002-2036-8350</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">name</th>
+            <th style="text-align:left;" class="prop">name<span>&nbsp;</span><a href="http://schema.org/name">[?]</a></th>
             <td style='text-align:left'><span>Nick Juty</span></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">@type</th>
             <td style='text-align:left'><span>Person</span></td>
             </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
-            <th style="text-align:left;" class="prop">author</th>
+            <th style="text-align:left;" class="prop">author<span>&nbsp;</span><a href="http://schema.org/author">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//w3id.org/ro/crate/1.2">RO-Crate specification 1.2</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">member</th>
+            <th style="text-align:left;" class="prop">member<span>&nbsp;</span><a href="http://schema.org/member">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//www.researchobject.org/ro-crate/community">RO-Crate Community</a></td>
             </tr></tbody>
             </table>
         </div>
-            </div>
+
+        </div>
         <hr/><br/><br/>
-            <div>
-                <h3><a href="https://orcid.org/0000-0001-8420-5254">Go to: </a> Kristi Holmes</h3>
-                
-                
-                
-                
+           <div>
+            <h3><a href="https://orcid.org/0000-0001-8420-5254">Go to: </a> Kristi Holmes</h3>
+            
+            
+            
+            
         <div id="https://orcid.org/0000-0001-8420-5254">
             
             <table class="table metadata table-striped" >
@@ -3454,28 +3648,29 @@ While providing the formal specification for RO-Crate, this document also aims t
             <th style="text-align:left;" class="prop">@id</th>
             <td style='text-align:left'><a href="https://orcid.org/0000-0001-8420-5254">https://orcid.org/0000-0001-8420-5254</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">name</th>
+            <th style="text-align:left;" class="prop">name<span>&nbsp;</span><a href="http://schema.org/name">[?]</a></th>
             <td style='text-align:left'><span>Kristi Holmes</span></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">@type</th>
             <td style='text-align:left'><span>Person</span></td>
             </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
-            <th style="text-align:left;" class="prop">author</th>
+            <th style="text-align:left;" class="prop">author<span>&nbsp;</span><a href="http://schema.org/author">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//w3id.org/ro/crate/1.2">RO-Crate specification 1.2</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">member</th>
+            <th style="text-align:left;" class="prop">member<span>&nbsp;</span><a href="http://schema.org/member">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//www.researchobject.org/ro-crate/community">RO-Crate Community</a></td>
             </tr></tbody>
             </table>
         </div>
-            </div>
+
+        </div>
         <hr/><br/><br/>
-            <div>
-                <h3><a href="https://orcid.org/0000-0002-3588-6257">Go to: </a> Jason A. Clark</h3>
-                
-                
-                
-                
+           <div>
+            <h3><a href="https://orcid.org/0000-0002-3588-6257">Go to: </a> Jason A. Clark</h3>
+            
+            
+            
+            
         <div id="https://orcid.org/0000-0002-3588-6257">
             
             <table class="table metadata table-striped" >
@@ -3483,28 +3678,29 @@ While providing the formal specification for RO-Crate, this document also aims t
             <th style="text-align:left;" class="prop">@id</th>
             <td style='text-align:left'><a href="https://orcid.org/0000-0002-3588-6257">https://orcid.org/0000-0002-3588-6257</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">name</th>
+            <th style="text-align:left;" class="prop">name<span>&nbsp;</span><a href="http://schema.org/name">[?]</a></th>
             <td style='text-align:left'><span>Jason A. Clark</span></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">@type</th>
             <td style='text-align:left'><span>Person</span></td>
             </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
-            <th style="text-align:left;" class="prop">author</th>
+            <th style="text-align:left;" class="prop">author<span>&nbsp;</span><a href="http://schema.org/author">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//w3id.org/ro/crate/1.2">RO-Crate specification 1.2</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">member</th>
+            <th style="text-align:left;" class="prop">member<span>&nbsp;</span><a href="http://schema.org/member">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//www.researchobject.org/ro-crate/community">RO-Crate Community</a></td>
             </tr></tbody>
             </table>
         </div>
-            </div>
+
+        </div>
         <hr/><br/><br/>
-            <div>
-                <h3><a href="https://orcid.org/0000-0002-0309-604X">Go to: </a> Salvador Capella-Gutierrez</h3>
-                
-                
-                
-                
+           <div>
+            <h3><a href="https://orcid.org/0000-0002-0309-604X">Go to: </a> Salvador Capella-Gutierrez</h3>
+            
+            
+            
+            
         <div id="https://orcid.org/0000-0002-0309-604X">
             
             <table class="table metadata table-striped" >
@@ -3512,28 +3708,29 @@ While providing the formal specification for RO-Crate, this document also aims t
             <th style="text-align:left;" class="prop">@id</th>
             <td style='text-align:left'><a href="https://orcid.org/0000-0002-0309-604X">https://orcid.org/0000-0002-0309-604X</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">name</th>
+            <th style="text-align:left;" class="prop">name<span>&nbsp;</span><a href="http://schema.org/name">[?]</a></th>
             <td style='text-align:left'><span>Salvador Capella-Gutierrez</span></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">@type</th>
             <td style='text-align:left'><span>Person</span></td>
             </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
-            <th style="text-align:left;" class="prop">author</th>
+            <th style="text-align:left;" class="prop">author<span>&nbsp;</span><a href="http://schema.org/author">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//w3id.org/ro/crate/1.2">RO-Crate specification 1.2</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">member</th>
+            <th style="text-align:left;" class="prop">member<span>&nbsp;</span><a href="http://schema.org/member">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//www.researchobject.org/ro-crate/community">RO-Crate Community</a></td>
             </tr></tbody>
             </table>
         </div>
-            </div>
+
+        </div>
         <hr/><br/><br/>
-            <div>
-                <h3><a href="https://orcid.org/0000-0002-5711-4872">Go to: </a> Alasdair J. G. Gray</h3>
-                
-                
-                
-                
+           <div>
+            <h3><a href="https://orcid.org/0000-0002-5711-4872">Go to: </a> Alasdair J. G. Gray</h3>
+            
+            
+            
+            
         <div id="https://orcid.org/0000-0002-5711-4872">
             
             <table class="table metadata table-striped" >
@@ -3541,28 +3738,29 @@ While providing the formal specification for RO-Crate, this document also aims t
             <th style="text-align:left;" class="prop">@id</th>
             <td style='text-align:left'><a href="https://orcid.org/0000-0002-5711-4872">https://orcid.org/0000-0002-5711-4872</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">name</th>
+            <th style="text-align:left;" class="prop">name<span>&nbsp;</span><a href="http://schema.org/name">[?]</a></th>
             <td style='text-align:left'><span>Alasdair J. G. Gray</span></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">@type</th>
             <td style='text-align:left'><span>Person</span></td>
             </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
-            <th style="text-align:left;" class="prop">author</th>
+            <th style="text-align:left;" class="prop">author<span>&nbsp;</span><a href="http://schema.org/author">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//w3id.org/ro/crate/1.2">RO-Crate specification 1.2</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">member</th>
+            <th style="text-align:left;" class="prop">member<span>&nbsp;</span><a href="http://schema.org/member">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//www.researchobject.org/ro-crate/community">RO-Crate Community</a></td>
             </tr></tbody>
             </table>
         </div>
-            </div>
+
+        </div>
         <hr/><br/><br/>
-            <div>
-                <h3><a href="https://orcid.org/0000-0003-2130-0865">Go to: </a> Stuart Owen</h3>
-                
-                
-                
-                
+           <div>
+            <h3><a href="https://orcid.org/0000-0003-2130-0865">Go to: </a> Stuart Owen</h3>
+            
+            
+            
+            
         <div id="https://orcid.org/0000-0003-2130-0865">
             
             <table class="table metadata table-striped" >
@@ -3570,28 +3768,29 @@ While providing the formal specification for RO-Crate, this document also aims t
             <th style="text-align:left;" class="prop">@id</th>
             <td style='text-align:left'><a href="https://orcid.org/0000-0003-2130-0865">https://orcid.org/0000-0003-2130-0865</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">name</th>
+            <th style="text-align:left;" class="prop">name<span>&nbsp;</span><a href="http://schema.org/name">[?]</a></th>
             <td style='text-align:left'><span>Stuart Owen</span></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">@type</th>
             <td style='text-align:left'><span>Person</span></td>
             </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
-            <th style="text-align:left;" class="prop">author</th>
+            <th style="text-align:left;" class="prop">author<span>&nbsp;</span><a href="http://schema.org/author">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//w3id.org/ro/crate/1.2">RO-Crate specification 1.2</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">member</th>
+            <th style="text-align:left;" class="prop">member<span>&nbsp;</span><a href="http://schema.org/member">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//www.researchobject.org/ro-crate/community">RO-Crate Community</a></td>
             </tr></tbody>
             </table>
         </div>
-            </div>
+
+        </div>
         <hr/><br/><br/>
-            <div>
-                <h3><a href="https://orcid.org/0000-0003-3156-2105">Go to: </a> Alan R Williams</h3>
-                
-                
-                
-                
+           <div>
+            <h3><a href="https://orcid.org/0000-0003-3156-2105">Go to: </a> Alan R Williams</h3>
+            
+            
+            
+            
         <div id="https://orcid.org/0000-0003-3156-2105">
             
             <table class="table metadata table-striped" >
@@ -3599,28 +3798,29 @@ While providing the formal specification for RO-Crate, this document also aims t
             <th style="text-align:left;" class="prop">@id</th>
             <td style='text-align:left'><a href="https://orcid.org/0000-0003-3156-2105">https://orcid.org/0000-0003-3156-2105</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">name</th>
+            <th style="text-align:left;" class="prop">name<span>&nbsp;</span><a href="http://schema.org/name">[?]</a></th>
             <td style='text-align:left'><span>Alan R Williams</span></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">@type</th>
             <td style='text-align:left'><span>Person</span></td>
             </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
-            <th style="text-align:left;" class="prop">author</th>
+            <th style="text-align:left;" class="prop">author<span>&nbsp;</span><a href="http://schema.org/author">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//w3id.org/ro/crate/1.2">RO-Crate specification 1.2</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">member</th>
+            <th style="text-align:left;" class="prop">member<span>&nbsp;</span><a href="http://schema.org/member">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//www.researchobject.org/ro-crate/community">RO-Crate Community</a></td>
             </tr></tbody>
             </table>
         </div>
-            </div>
+
+        </div>
         <hr/><br/><br/>
-            <div>
-                <h3><a href="https://orcid.org/0000-0003-1130-2154">Go to: </a> Giacomo Tartari</h3>
-                
-                
-                
-                
+           <div>
+            <h3><a href="https://orcid.org/0000-0003-1130-2154">Go to: </a> Giacomo Tartari</h3>
+            
+            
+            
+            
         <div id="https://orcid.org/0000-0003-1130-2154">
             
             <table class="table metadata table-striped" >
@@ -3628,28 +3828,29 @@ While providing the formal specification for RO-Crate, this document also aims t
             <th style="text-align:left;" class="prop">@id</th>
             <td style='text-align:left'><a href="https://orcid.org/0000-0003-1130-2154">https://orcid.org/0000-0003-1130-2154</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">name</th>
+            <th style="text-align:left;" class="prop">name<span>&nbsp;</span><a href="http://schema.org/name">[?]</a></th>
             <td style='text-align:left'><span>Giacomo Tartari</span></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">@type</th>
             <td style='text-align:left'><span>Person</span></td>
             </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
-            <th style="text-align:left;" class="prop">author</th>
+            <th style="text-align:left;" class="prop">author<span>&nbsp;</span><a href="http://schema.org/author">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//w3id.org/ro/crate/1.2">RO-Crate specification 1.2</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">member</th>
+            <th style="text-align:left;" class="prop">member<span>&nbsp;</span><a href="http://schema.org/member">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//www.researchobject.org/ro-crate/community">RO-Crate Community</a></td>
             </tr></tbody>
             </table>
         </div>
-            </div>
+
+        </div>
         <hr/><br/><br/>
-            <div>
-                <h3><a href="https://orcid.org/0000-0002-0048-3300">Go to: </a> Finn Bacall</h3>
-                
-                
-                
-                
+           <div>
+            <h3><a href="https://orcid.org/0000-0002-0048-3300">Go to: </a> Finn Bacall</h3>
+            
+            
+            
+            
         <div id="https://orcid.org/0000-0002-0048-3300">
             
             <table class="table metadata table-striped" >
@@ -3657,28 +3858,29 @@ While providing the formal specification for RO-Crate, this document also aims t
             <th style="text-align:left;" class="prop">@id</th>
             <td style='text-align:left'><a href="https://orcid.org/0000-0002-0048-3300">https://orcid.org/0000-0002-0048-3300</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">name</th>
+            <th style="text-align:left;" class="prop">name<span>&nbsp;</span><a href="http://schema.org/name">[?]</a></th>
             <td style='text-align:left'><span>Finn Bacall</span></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">@type</th>
             <td style='text-align:left'><span>Person</span></td>
             </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
-            <th style="text-align:left;" class="prop">author</th>
+            <th style="text-align:left;" class="prop">author<span>&nbsp;</span><a href="http://schema.org/author">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//w3id.org/ro/crate/1.2">RO-Crate specification 1.2</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">member</th>
+            <th style="text-align:left;" class="prop">member<span>&nbsp;</span><a href="http://schema.org/member">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//www.researchobject.org/ro-crate/community">RO-Crate Community</a></td>
             </tr></tbody>
             </table>
         </div>
-            </div>
+
+        </div>
         <hr/><br/><br/>
-            <div>
-                <h3><a href="https://orcid.org/0000-0002-1756-2128">Go to: </a> Thomas Thelen</h3>
-                
-                
-                
-                
+           <div>
+            <h3><a href="https://orcid.org/0000-0002-1756-2128">Go to: </a> Thomas Thelen</h3>
+            
+            
+            
+            
         <div id="https://orcid.org/0000-0002-1756-2128">
             
             <table class="table metadata table-striped" >
@@ -3686,28 +3888,29 @@ While providing the formal specification for RO-Crate, this document also aims t
             <th style="text-align:left;" class="prop">@id</th>
             <td style='text-align:left'><a href="https://orcid.org/0000-0002-1756-2128">https://orcid.org/0000-0002-1756-2128</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">name</th>
+            <th style="text-align:left;" class="prop">name<span>&nbsp;</span><a href="http://schema.org/name">[?]</a></th>
             <td style='text-align:left'><span>Thomas Thelen</span></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">@type</th>
             <td style='text-align:left'><span>Person</span></td>
             </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
-            <th style="text-align:left;" class="prop">author</th>
+            <th style="text-align:left;" class="prop">author<span>&nbsp;</span><a href="http://schema.org/author">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//w3id.org/ro/crate/1.2">RO-Crate specification 1.2</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">member</th>
+            <th style="text-align:left;" class="prop">member<span>&nbsp;</span><a href="http://schema.org/member">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//www.researchobject.org/ro-crate/community">RO-Crate Community</a></td>
             </tr></tbody>
             </table>
         </div>
-            </div>
+
+        </div>
         <hr/><br/><br/>
-            <div>
-                <h3><a href="https://orcid.org/0000-0002-7552-1009">Go to: </a> Hervé Ménager</h3>
-                
-                
-                
-                
+           <div>
+            <h3><a href="https://orcid.org/0000-0002-7552-1009">Go to: </a> Hervé Ménager</h3>
+            
+            
+            
+            
         <div id="https://orcid.org/0000-0002-7552-1009">
             
             <table class="table metadata table-striped" >
@@ -3715,28 +3918,29 @@ While providing the formal specification for RO-Crate, this document also aims t
             <th style="text-align:left;" class="prop">@id</th>
             <td style='text-align:left'><a href="https://orcid.org/0000-0002-7552-1009">https://orcid.org/0000-0002-7552-1009</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">name</th>
+            <th style="text-align:left;" class="prop">name<span>&nbsp;</span><a href="http://schema.org/name">[?]</a></th>
             <td style='text-align:left'><span>Hervé Ménager</span></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">@type</th>
             <td style='text-align:left'><span>Person</span></td>
             </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
-            <th style="text-align:left;" class="prop">author</th>
+            <th style="text-align:left;" class="prop">author<span>&nbsp;</span><a href="http://schema.org/author">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//w3id.org/ro/crate/1.2">RO-Crate specification 1.2</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">member</th>
+            <th style="text-align:left;" class="prop">member<span>&nbsp;</span><a href="http://schema.org/member">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//www.researchobject.org/ro-crate/community">RO-Crate Community</a></td>
             </tr></tbody>
             </table>
         </div>
-            </div>
+
+        </div>
         <hr/><br/><br/>
-            <div>
-                <h3><a href="https://orcid.org/0000-0003-4929-1219">Go to: </a> Laura Rodríguez-Navas</h3>
-                
-                
-                
-                
+           <div>
+            <h3><a href="https://orcid.org/0000-0003-4929-1219">Go to: </a> Laura Rodríguez-Navas</h3>
+            
+            
+            
+            
         <div id="https://orcid.org/0000-0003-4929-1219">
             
             <table class="table metadata table-striped" >
@@ -3744,28 +3948,29 @@ While providing the formal specification for RO-Crate, this document also aims t
             <th style="text-align:left;" class="prop">@id</th>
             <td style='text-align:left'><a href="https://orcid.org/0000-0003-4929-1219">https://orcid.org/0000-0003-4929-1219</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">name</th>
+            <th style="text-align:left;" class="prop">name<span>&nbsp;</span><a href="http://schema.org/name">[?]</a></th>
             <td style='text-align:left'><span>Laura Rodríguez-Navas</span></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">@type</th>
             <td style='text-align:left'><span>Person</span></td>
             </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
-            <th style="text-align:left;" class="prop">author</th>
+            <th style="text-align:left;" class="prop">author<span>&nbsp;</span><a href="http://schema.org/author">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//w3id.org/ro/crate/1.2">RO-Crate specification 1.2</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">member</th>
+            <th style="text-align:left;" class="prop">member<span>&nbsp;</span><a href="http://schema.org/member">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//www.researchobject.org/ro-crate/community">RO-Crate Community</a></td>
             </tr></tbody>
             </table>
         </div>
-            </div>
+
+        </div>
         <hr/><br/><br/>
-            <div>
-                <h3><a href="https://orcid.org/0000-0003-1541-5631">Go to: </a> Paul Walk</h3>
-                
-                
-                
-                
+           <div>
+            <h3><a href="https://orcid.org/0000-0003-1541-5631">Go to: </a> Paul Walk</h3>
+            
+            
+            
+            
         <div id="https://orcid.org/0000-0003-1541-5631">
             
             <table class="table metadata table-striped" >
@@ -3773,28 +3978,29 @@ While providing the formal specification for RO-Crate, this document also aims t
             <th style="text-align:left;" class="prop">@id</th>
             <td style='text-align:left'><a href="https://orcid.org/0000-0003-1541-5631">https://orcid.org/0000-0003-1541-5631</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">name</th>
+            <th style="text-align:left;" class="prop">name<span>&nbsp;</span><a href="http://schema.org/name">[?]</a></th>
             <td style='text-align:left'><span>Paul Walk</span></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">@type</th>
             <td style='text-align:left'><span>Person</span></td>
             </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
-            <th style="text-align:left;" class="prop">author</th>
+            <th style="text-align:left;" class="prop">author<span>&nbsp;</span><a href="http://schema.org/author">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//w3id.org/ro/crate/1.2">RO-Crate specification 1.2</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">member</th>
+            <th style="text-align:left;" class="prop">member<span>&nbsp;</span><a href="http://schema.org/member">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//www.researchobject.org/ro-crate/community">RO-Crate Community</a></td>
             </tr></tbody>
             </table>
         </div>
-            </div>
+
+        </div>
         <hr/><br/><br/>
-            <div>
-                <h3><a href="https://orcid.org/0000-0002-0337-8610">Go to: </a> brandon whitehead</h3>
-                
-                
-                
-                
+           <div>
+            <h3><a href="https://orcid.org/0000-0002-0337-8610">Go to: </a> brandon whitehead</h3>
+            
+            
+            
+            
         <div id="https://orcid.org/0000-0002-0337-8610">
             
             <table class="table metadata table-striped" >
@@ -3802,28 +4008,29 @@ While providing the formal specification for RO-Crate, this document also aims t
             <th style="text-align:left;" class="prop">@id</th>
             <td style='text-align:left'><a href="https://orcid.org/0000-0002-0337-8610">https://orcid.org/0000-0002-0337-8610</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">name</th>
+            <th style="text-align:left;" class="prop">name<span>&nbsp;</span><a href="http://schema.org/name">[?]</a></th>
             <td style='text-align:left'><span>brandon whitehead</span></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">@type</th>
             <td style='text-align:left'><span>Person</span></td>
             </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
-            <th style="text-align:left;" class="prop">author</th>
+            <th style="text-align:left;" class="prop">author<span>&nbsp;</span><a href="http://schema.org/author">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//w3id.org/ro/crate/1.2">RO-Crate specification 1.2</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">member</th>
+            <th style="text-align:left;" class="prop">member<span>&nbsp;</span><a href="http://schema.org/member">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//www.researchobject.org/ro-crate/community">RO-Crate Community</a></td>
             </tr></tbody>
             </table>
         </div>
-            </div>
+
+        </div>
         <hr/><br/><br/>
-            <div>
-                <h3><a href="https://orcid.org/0000-0001-6960-357X">Go to: </a> Mark Wilkinson</h3>
-                
-                
-                
-                
+           <div>
+            <h3><a href="https://orcid.org/0000-0001-6960-357X">Go to: </a> Mark Wilkinson</h3>
+            
+            
+            
+            
         <div id="https://orcid.org/0000-0001-6960-357X">
             
             <table class="table metadata table-striped" >
@@ -3831,28 +4038,29 @@ While providing the formal specification for RO-Crate, this document also aims t
             <th style="text-align:left;" class="prop">@id</th>
             <td style='text-align:left'><a href="https://orcid.org/0000-0001-6960-357X">https://orcid.org/0000-0001-6960-357X</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">name</th>
+            <th style="text-align:left;" class="prop">name<span>&nbsp;</span><a href="http://schema.org/name">[?]</a></th>
             <td style='text-align:left'><span>Mark Wilkinson</span></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">@type</th>
             <td style='text-align:left'><span>Person</span></td>
             </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
-            <th style="text-align:left;" class="prop">author</th>
+            <th style="text-align:left;" class="prop">author<span>&nbsp;</span><a href="http://schema.org/author">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//w3id.org/ro/crate/1.2">RO-Crate specification 1.2</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">member</th>
+            <th style="text-align:left;" class="prop">member<span>&nbsp;</span><a href="http://schema.org/member">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//www.researchobject.org/ro-crate/community">RO-Crate Community</a></td>
             </tr></tbody>
             </table>
         </div>
-            </div>
+
+        </div>
         <hr/><br/><br/>
-            <div>
-                <h3><a href="https://orcid.org/0000-0003-0183-6910">Go to: </a> Paul Groth</h3>
-                
-                
-                
-                
+           <div>
+            <h3><a href="https://orcid.org/0000-0003-0183-6910">Go to: </a> Paul Groth</h3>
+            
+            
+            
+            
         <div id="https://orcid.org/0000-0003-0183-6910">
             
             <table class="table metadata table-striped" >
@@ -3860,32 +4068,33 @@ While providing the formal specification for RO-Crate, this document also aims t
             <th style="text-align:left;" class="prop">@id</th>
             <td style='text-align:left'><a href="https://orcid.org/0000-0003-0183-6910">https://orcid.org/0000-0003-0183-6910</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">name</th>
+            <th style="text-align:left;" class="prop">name<span>&nbsp;</span><a href="http://schema.org/name">[?]</a></th>
             <td style='text-align:left'><span>Paul Groth</span></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">@type</th>
             <td style='text-align:left'><span>Person</span></td>
             </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
-            <th style="text-align:left;" class="prop">author</th>
+            <th style="text-align:left;" class="prop">author<span>&nbsp;</span><a href="http://schema.org/author">[?]</a></th>
             <td style='text-align:left'><ul>
                         <li><a href="#https%3A//w3id.org/ro/crate/1.2">RO-Crate specification 1.2</a></li>
                         
                         <li><a href="#https%3A//doi.org/10.3233/DS-210053">Packaging research artefacts with RO-Crate</a></li>
                         </ul></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">member</th>
+            <th style="text-align:left;" class="prop">member<span>&nbsp;</span><a href="http://schema.org/member">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//www.researchobject.org/ro-crate/community">RO-Crate Community</a></td>
             </tr></tbody>
             </table>
         </div>
-            </div>
+
+        </div>
         <hr/><br/><br/>
-            <div>
-                <h3><a href="https://orcid.org/0000-0003-0223-1059">Go to: </a> Erich Bremer</h3>
-                
-                
-                
-                
+           <div>
+            <h3><a href="https://orcid.org/0000-0003-0223-1059">Go to: </a> Erich Bremer</h3>
+            
+            
+            
+            
         <div id="https://orcid.org/0000-0003-0223-1059">
             
             <table class="table metadata table-striped" >
@@ -3893,28 +4102,29 @@ While providing the formal specification for RO-Crate, this document also aims t
             <th style="text-align:left;" class="prop">@id</th>
             <td style='text-align:left'><a href="https://orcid.org/0000-0003-0223-1059">https://orcid.org/0000-0003-0223-1059</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">name</th>
+            <th style="text-align:left;" class="prop">name<span>&nbsp;</span><a href="http://schema.org/name">[?]</a></th>
             <td style='text-align:left'><span>Erich Bremer</span></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">@type</th>
             <td style='text-align:left'><span>Person</span></td>
             </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
-            <th style="text-align:left;" class="prop">author</th>
+            <th style="text-align:left;" class="prop">author<span>&nbsp;</span><a href="http://schema.org/author">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//w3id.org/ro/crate/1.2">RO-Crate specification 1.2</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">member</th>
+            <th style="text-align:left;" class="prop">member<span>&nbsp;</span><a href="http://schema.org/member">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//www.researchobject.org/ro-crate/community">RO-Crate Community</a></td>
             </tr></tbody>
             </table>
         </div>
-            </div>
+
+        </div>
         <hr/><br/><br/>
-            <div>
-                <h3><a href="https://orcid.org/0000-0003-3986-0510">Go to: </a> Leyla Jael Castro</h3>
-                
-                
-                
-                
+           <div>
+            <h3><a href="https://orcid.org/0000-0003-3986-0510">Go to: </a> Leyla Jael Castro</h3>
+            
+            
+            
+            
         <div id="https://orcid.org/0000-0003-3986-0510">
             
             <table class="table metadata table-striped" >
@@ -3922,35 +4132,36 @@ While providing the formal specification for RO-Crate, this document also aims t
             <th style="text-align:left;" class="prop">@id</th>
             <td style='text-align:left'><a href="https://orcid.org/0000-0003-3986-0510">https://orcid.org/0000-0003-3986-0510</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">name</th>
+            <th style="text-align:left;" class="prop">name<span>&nbsp;</span><a href="http://schema.org/name">[?]</a></th>
             <td style='text-align:left'><span>Leyla Jael Castro</span></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">@type</th>
             <td style='text-align:left'><span>Person</span></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">alternateName</th>
+            <th style="text-align:left;" class="prop">alternateName<span>&nbsp;</span><a href="http://schema.org/alternateName">[?]</a></th>
             <td style='text-align:left'><span>LJ Garcia Castro</span></td>
             </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
-            <th style="text-align:left;" class="prop">author</th>
+            <th style="text-align:left;" class="prop">author<span>&nbsp;</span><a href="http://schema.org/author">[?]</a></th>
             <td style='text-align:left'><ul>
                         <li><a href="#https%3A//w3id.org/ro/crate/1.2">RO-Crate specification 1.2</a></li>
                         
                         <li><a href="#https%3A//doi.org/10.3233/DS-210053">Packaging research artefacts with RO-Crate</a></li>
                         </ul></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">member</th>
+            <th style="text-align:left;" class="prop">member<span>&nbsp;</span><a href="http://schema.org/member">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//www.researchobject.org/ro-crate/community">RO-Crate Community</a></td>
             </tr></tbody>
             </table>
         </div>
-            </div>
+
+        </div>
         <hr/><br/><br/>
-            <div>
-                <h3><a href="https://orcid.org/0000-0001-6022-9825">Go to: </a> Karl Sebby</h3>
-                
-                
-                
-                
+           <div>
+            <h3><a href="https://orcid.org/0000-0001-6022-9825">Go to: </a> Karl Sebby</h3>
+            
+            
+            
+            
         <div id="https://orcid.org/0000-0001-6022-9825">
             
             <table class="table metadata table-striped" >
@@ -3958,28 +4169,29 @@ While providing the formal specification for RO-Crate, this document also aims t
             <th style="text-align:left;" class="prop">@id</th>
             <td style='text-align:left'><a href="https://orcid.org/0000-0001-6022-9825">https://orcid.org/0000-0001-6022-9825</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">name</th>
+            <th style="text-align:left;" class="prop">name<span>&nbsp;</span><a href="http://schema.org/name">[?]</a></th>
             <td style='text-align:left'><span>Karl Sebby</span></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">@type</th>
             <td style='text-align:left'><span>Person</span></td>
             </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
-            <th style="text-align:left;" class="prop">author</th>
+            <th style="text-align:left;" class="prop">author<span>&nbsp;</span><a href="http://schema.org/author">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//w3id.org/ro/crate/1.2">RO-Crate specification 1.2</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">member</th>
+            <th style="text-align:left;" class="prop">member<span>&nbsp;</span><a href="http://schema.org/member">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//www.researchobject.org/ro-crate/community">RO-Crate Community</a></td>
             </tr></tbody>
             </table>
         </div>
-            </div>
+
+        </div>
         <hr/><br/><br/>
-            <div>
-                <h3><a href="https://orcid.org/0000-0002-3468-0652">Go to: </a> Alexander Kanitz</h3>
-                
-                
-                
-                
+           <div>
+            <h3><a href="https://orcid.org/0000-0002-3468-0652">Go to: </a> Alexander Kanitz</h3>
+            
+            
+            
+            
         <div id="https://orcid.org/0000-0002-3468-0652">
             
             <table class="table metadata table-striped" >
@@ -3987,28 +4199,29 @@ While providing the formal specification for RO-Crate, this document also aims t
             <th style="text-align:left;" class="prop">@id</th>
             <td style='text-align:left'><a href="https://orcid.org/0000-0002-3468-0652">https://orcid.org/0000-0002-3468-0652</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">name</th>
+            <th style="text-align:left;" class="prop">name<span>&nbsp;</span><a href="http://schema.org/name">[?]</a></th>
             <td style='text-align:left'><span>Alexander Kanitz</span></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">@type</th>
             <td style='text-align:left'><span>Person</span></td>
             </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
-            <th style="text-align:left;" class="prop">author</th>
+            <th style="text-align:left;" class="prop">author<span>&nbsp;</span><a href="http://schema.org/author">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//w3id.org/ro/crate/1.2">RO-Crate specification 1.2</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">member</th>
+            <th style="text-align:left;" class="prop">member<span>&nbsp;</span><a href="http://schema.org/member">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//www.researchobject.org/ro-crate/community">RO-Crate Community</a></td>
             </tr></tbody>
             </table>
         </div>
-            </div>
+
+        </div>
         <hr/><br/><br/>
-            <div>
-                <h3><a href="https://orcid.org/0000-0003-1991-0533">Go to: </a> Ana Trisovic</h3>
-                
-                
-                
-                
+           <div>
+            <h3><a href="https://orcid.org/0000-0003-1991-0533">Go to: </a> Ana Trisovic</h3>
+            
+            
+            
+            
         <div id="https://orcid.org/0000-0003-1991-0533">
             
             <table class="table metadata table-striped" >
@@ -4016,32 +4229,33 @@ While providing the formal specification for RO-Crate, this document also aims t
             <th style="text-align:left;" class="prop">@id</th>
             <td style='text-align:left'><a href="https://orcid.org/0000-0003-1991-0533">https://orcid.org/0000-0003-1991-0533</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">name</th>
+            <th style="text-align:left;" class="prop">name<span>&nbsp;</span><a href="http://schema.org/name">[?]</a></th>
             <td style='text-align:left'><span>Ana Trisovic</span></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">@type</th>
             <td style='text-align:left'><span>Person</span></td>
             </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
-            <th style="text-align:left;" class="prop">author</th>
+            <th style="text-align:left;" class="prop">author<span>&nbsp;</span><a href="http://schema.org/author">[?]</a></th>
             <td style='text-align:left'><ul>
                         <li><a href="#https%3A//w3id.org/ro/crate/1.2">RO-Crate specification 1.2</a></li>
                         
                         <li><a href="#https%3A//doi.org/10.3233/DS-210053">Packaging research artefacts with RO-Crate</a></li>
                         </ul></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">member</th>
+            <th style="text-align:left;" class="prop">member<span>&nbsp;</span><a href="http://schema.org/member">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//www.researchobject.org/ro-crate/community">RO-Crate Community</a></td>
             </tr></tbody>
             </table>
         </div>
-            </div>
+
+        </div>
         <hr/><br/><br/>
-            <div>
-                <h3><a href="https://orcid.org/0000-0003-3910-0474">Go to: </a> Gavin Kennedy</h3>
-                
-                
-                
-                
+           <div>
+            <h3><a href="https://orcid.org/0000-0003-3910-0474">Go to: </a> Gavin Kennedy</h3>
+            
+            
+            
+            
         <div id="https://orcid.org/0000-0003-3910-0474">
             
             <table class="table metadata table-striped" >
@@ -4049,28 +4263,29 @@ While providing the formal specification for RO-Crate, this document also aims t
             <th style="text-align:left;" class="prop">@id</th>
             <td style='text-align:left'><a href="https://orcid.org/0000-0003-3910-0474">https://orcid.org/0000-0003-3910-0474</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">name</th>
+            <th style="text-align:left;" class="prop">name<span>&nbsp;</span><a href="http://schema.org/name">[?]</a></th>
             <td style='text-align:left'><span>Gavin Kennedy</span></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">@type</th>
             <td style='text-align:left'><span>Person</span></td>
             </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
-            <th style="text-align:left;" class="prop">author</th>
+            <th style="text-align:left;" class="prop">author<span>&nbsp;</span><a href="http://schema.org/author">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//w3id.org/ro/crate/1.2">RO-Crate specification 1.2</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">member</th>
+            <th style="text-align:left;" class="prop">member<span>&nbsp;</span><a href="http://schema.org/member">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//www.researchobject.org/ro-crate/community">RO-Crate Community</a></td>
             </tr></tbody>
             </table>
         </div>
-            </div>
+
+        </div>
         <hr/><br/><br/>
-            <div>
-                <h3><a href="https://orcid.org/0000-0003-3486-8193">Go to: </a> Mark Graves</h3>
-                
-                
-                
-                
+           <div>
+            <h3><a href="https://orcid.org/0000-0003-3486-8193">Go to: </a> Mark Graves</h3>
+            
+            
+            
+            
         <div id="https://orcid.org/0000-0003-3486-8193">
             
             <table class="table metadata table-striped" >
@@ -4078,28 +4293,29 @@ While providing the formal specification for RO-Crate, this document also aims t
             <th style="text-align:left;" class="prop">@id</th>
             <td style='text-align:left'><a href="https://orcid.org/0000-0003-3486-8193">https://orcid.org/0000-0003-3486-8193</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">name</th>
+            <th style="text-align:left;" class="prop">name<span>&nbsp;</span><a href="http://schema.org/name">[?]</a></th>
             <td style='text-align:left'><span>Mark Graves</span></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">@type</th>
             <td style='text-align:left'><span>Person</span></td>
             </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
-            <th style="text-align:left;" class="prop">author</th>
+            <th style="text-align:left;" class="prop">author<span>&nbsp;</span><a href="http://schema.org/author">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//w3id.org/ro/crate/1.2">RO-Crate specification 1.2</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">member</th>
+            <th style="text-align:left;" class="prop">member<span>&nbsp;</span><a href="http://schema.org/member">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//www.researchobject.org/ro-crate/community">RO-Crate Community</a></td>
             </tr></tbody>
             </table>
         </div>
-            </div>
+
+        </div>
         <hr/><br/><br/>
-            <div>
-                <h3><a href="https://orcid.org/0000-0001-8172-8981">Go to: </a> Jasper Koehorst</h3>
-                
-                
-                
-                
+           <div>
+            <h3><a href="https://orcid.org/0000-0001-8172-8981">Go to: </a> Jasper Koehorst</h3>
+            
+            
+            
+            
         <div id="https://orcid.org/0000-0001-8172-8981">
             
             <table class="table metadata table-striped" >
@@ -4107,28 +4323,29 @@ While providing the formal specification for RO-Crate, this document also aims t
             <th style="text-align:left;" class="prop">@id</th>
             <td style='text-align:left'><a href="https://orcid.org/0000-0001-8172-8981">https://orcid.org/0000-0001-8172-8981</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">name</th>
+            <th style="text-align:left;" class="prop">name<span>&nbsp;</span><a href="http://schema.org/name">[?]</a></th>
             <td style='text-align:left'><span>Jasper Koehorst</span></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">@type</th>
             <td style='text-align:left'><span>Person</span></td>
             </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
-            <th style="text-align:left;" class="prop">author</th>
+            <th style="text-align:left;" class="prop">author<span>&nbsp;</span><a href="http://schema.org/author">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//w3id.org/ro/crate/1.2">RO-Crate specification 1.2</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">member</th>
+            <th style="text-align:left;" class="prop">member<span>&nbsp;</span><a href="http://schema.org/member">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//www.researchobject.org/ro-crate/community">RO-Crate Community</a></td>
             </tr></tbody>
             </table>
         </div>
-            </div>
+
+        </div>
         <hr/><br/><br/>
-            <div>
-                <h3><a href="https://orcid.org/0000-0001-8271-5429">Go to: </a> Simone Leo</h3>
-                
-                
-                
-                
+           <div>
+            <h3><a href="https://orcid.org/0000-0001-8271-5429">Go to: </a> Simone Leo</h3>
+            
+            
+            
+            
         <div id="https://orcid.org/0000-0001-8271-5429">
             
             <table class="table metadata table-striped" >
@@ -4136,32 +4353,33 @@ While providing the formal specification for RO-Crate, this document also aims t
             <th style="text-align:left;" class="prop">@id</th>
             <td style='text-align:left'><a href="https://orcid.org/0000-0001-8271-5429">https://orcid.org/0000-0001-8271-5429</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">name</th>
+            <th style="text-align:left;" class="prop">name<span>&nbsp;</span><a href="http://schema.org/name">[?]</a></th>
             <td style='text-align:left'><span>Simone Leo</span></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">@type</th>
             <td style='text-align:left'><span>Person</span></td>
             </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
-            <th style="text-align:left;" class="prop">author</th>
+            <th style="text-align:left;" class="prop">author<span>&nbsp;</span><a href="http://schema.org/author">[?]</a></th>
             <td style='text-align:left'><ul>
                         <li><a href="#https%3A//w3id.org/ro/crate/1.2">RO-Crate specification 1.2</a></li>
                         
                         <li><a href="#https%3A//doi.org/10.3233/DS-210053">Packaging research artefacts with RO-Crate</a></li>
                         </ul></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">member</th>
+            <th style="text-align:left;" class="prop">member<span>&nbsp;</span><a href="http://schema.org/member">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//www.researchobject.org/ro-crate/community">RO-Crate Community</a></td>
             </tr></tbody>
             </table>
         </div>
-            </div>
+
+        </div>
         <hr/><br/><br/>
-            <div>
-                <h3><a href="https://orcid.org/0000-0002-9648-6484">Go to: </a> Marc Portier</h3>
-                
-                
-                
-                
+           <div>
+            <h3><a href="https://orcid.org/0000-0002-9648-6484">Go to: </a> Marc Portier</h3>
+            
+            
+            
+            
         <div id="https://orcid.org/0000-0002-9648-6484">
             
             <table class="table metadata table-striped" >
@@ -4169,32 +4387,33 @@ While providing the formal specification for RO-Crate, this document also aims t
             <th style="text-align:left;" class="prop">@id</th>
             <td style='text-align:left'><a href="https://orcid.org/0000-0002-9648-6484">https://orcid.org/0000-0002-9648-6484</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">name</th>
+            <th style="text-align:left;" class="prop">name<span>&nbsp;</span><a href="http://schema.org/name">[?]</a></th>
             <td style='text-align:left'><span>Marc Portier</span></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">@type</th>
             <td style='text-align:left'><span>Person</span></td>
             </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
-            <th style="text-align:left;" class="prop">author</th>
+            <th style="text-align:left;" class="prop">author<span>&nbsp;</span><a href="http://schema.org/author">[?]</a></th>
             <td style='text-align:left'><ul>
                         <li><a href="#https%3A//w3id.org/ro/crate/1.2">RO-Crate specification 1.2</a></li>
                         
                         <li><a href="#https%3A//doi.org/10.3233/DS-210053">Packaging research artefacts with RO-Crate</a></li>
                         </ul></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">member</th>
+            <th style="text-align:left;" class="prop">member<span>&nbsp;</span><a href="http://schema.org/member">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//www.researchobject.org/ro-crate/community">RO-Crate Community</a></td>
             </tr></tbody>
             </table>
         </div>
-            </div>
+
+        </div>
         <hr/><br/><br/>
-            <div>
-                <h3><a href="https://orcid.org/0000-0002-5432-2748">Go to: </a> Paul Brack</h3>
-                
-                
-                
-                
+           <div>
+            <h3><a href="https://orcid.org/0000-0002-5432-2748">Go to: </a> Paul Brack</h3>
+            
+            
+            
+            
         <div id="https://orcid.org/0000-0002-5432-2748">
             
             <table class="table metadata table-striped" >
@@ -4202,28 +4421,29 @@ While providing the formal specification for RO-Crate, this document also aims t
             <th style="text-align:left;" class="prop">@id</th>
             <td style='text-align:left'><a href="https://orcid.org/0000-0002-5432-2748">https://orcid.org/0000-0002-5432-2748</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">name</th>
+            <th style="text-align:left;" class="prop">name<span>&nbsp;</span><a href="http://schema.org/name">[?]</a></th>
             <td style='text-align:left'><span>Paul Brack</span></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">@type</th>
             <td style='text-align:left'><span>Person</span></td>
             </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
-            <th style="text-align:left;" class="prop">author</th>
+            <th style="text-align:left;" class="prop">author<span>&nbsp;</span><a href="http://schema.org/author">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//w3id.org/ro/crate/1.2">RO-Crate specification 1.2</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">member</th>
+            <th style="text-align:left;" class="prop">member<span>&nbsp;</span><a href="http://schema.org/member">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//www.researchobject.org/ro-crate/community">RO-Crate Community</a></td>
             </tr></tbody>
             </table>
         </div>
-            </div>
+
+        </div>
         <hr/><br/><br/>
-            <div>
-                <h3><a href="https://orcid.org/0000-0003-1743-8300">Go to: </a> Milan Ojsteršek</h3>
-                
-                
-                
-                
+           <div>
+            <h3><a href="https://orcid.org/0000-0003-1743-8300">Go to: </a> Milan Ojsteršek</h3>
+            
+            
+            
+            
         <div id="https://orcid.org/0000-0003-1743-8300">
             
             <table class="table metadata table-striped" >
@@ -4231,28 +4451,29 @@ While providing the formal specification for RO-Crate, this document also aims t
             <th style="text-align:left;" class="prop">@id</th>
             <td style='text-align:left'><a href="https://orcid.org/0000-0003-1743-8300">https://orcid.org/0000-0003-1743-8300</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">name</th>
+            <th style="text-align:left;" class="prop">name<span>&nbsp;</span><a href="http://schema.org/name">[?]</a></th>
             <td style='text-align:left'><span>Milan Ojsteršek</span></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">@type</th>
             <td style='text-align:left'><span>Person</span></td>
             </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
-            <th style="text-align:left;" class="prop">author</th>
+            <th style="text-align:left;" class="prop">author<span>&nbsp;</span><a href="http://schema.org/author">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//w3id.org/ro/crate/1.2">RO-Crate specification 1.2</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">member</th>
+            <th style="text-align:left;" class="prop">member<span>&nbsp;</span><a href="http://schema.org/member">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//www.researchobject.org/ro-crate/community">RO-Crate Community</a></td>
             </tr></tbody>
             </table>
         </div>
-            </div>
+
+        </div>
         <hr/><br/><br/>
-            <div>
-                <h3><a href="https://orcid.org/0000-0003-0522-5674">Go to: </a> Bert Droesbeke</h3>
-                
-                
-                
-                
+           <div>
+            <h3><a href="https://orcid.org/0000-0003-0522-5674">Go to: </a> Bert Droesbeke</h3>
+            
+            
+            
+            
         <div id="https://orcid.org/0000-0003-0522-5674">
             
             <table class="table metadata table-striped" >
@@ -4260,28 +4481,29 @@ While providing the formal specification for RO-Crate, this document also aims t
             <th style="text-align:left;" class="prop">@id</th>
             <td style='text-align:left'><a href="https://orcid.org/0000-0003-0522-5674">https://orcid.org/0000-0003-0522-5674</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">name</th>
+            <th style="text-align:left;" class="prop">name<span>&nbsp;</span><a href="http://schema.org/name">[?]</a></th>
             <td style='text-align:left'><span>Bert Droesbeke</span></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">@type</th>
             <td style='text-align:left'><span>Person</span></td>
             </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
-            <th style="text-align:left;" class="prop">author</th>
+            <th style="text-align:left;" class="prop">author<span>&nbsp;</span><a href="http://schema.org/author">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//w3id.org/ro/crate/1.2">RO-Crate specification 1.2</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">member</th>
+            <th style="text-align:left;" class="prop">member<span>&nbsp;</span><a href="http://schema.org/member">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//www.researchobject.org/ro-crate/community">RO-Crate Community</a></td>
             </tr></tbody>
             </table>
         </div>
-            </div>
+
+        </div>
         <hr/><br/><br/>
-            <div>
-                <h3><a href="https://orcid.org/0000-0002-2142-1731">Go to: </a> Chenxu Niu</h3>
-                
-                
-                
-                
+           <div>
+            <h3><a href="https://orcid.org/0000-0002-2142-1731">Go to: </a> Chenxu Niu</h3>
+            
+            
+            
+            
         <div id="https://orcid.org/0000-0002-2142-1731">
             
             <table class="table metadata table-striped" >
@@ -4289,28 +4511,29 @@ While providing the formal specification for RO-Crate, this document also aims t
             <th style="text-align:left;" class="prop">@id</th>
             <td style='text-align:left'><a href="https://orcid.org/0000-0002-2142-1731">https://orcid.org/0000-0002-2142-1731</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">name</th>
+            <th style="text-align:left;" class="prop">name<span>&nbsp;</span><a href="http://schema.org/name">[?]</a></th>
             <td style='text-align:left'><span>Chenxu Niu</span></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">@type</th>
             <td style='text-align:left'><span>Person</span></td>
             </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
-            <th style="text-align:left;" class="prop">author</th>
+            <th style="text-align:left;" class="prop">author<span>&nbsp;</span><a href="http://schema.org/author">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//w3id.org/ro/crate/1.2">RO-Crate specification 1.2</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">member</th>
+            <th style="text-align:left;" class="prop">member<span>&nbsp;</span><a href="http://schema.org/member">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//www.researchobject.org/ro-crate/community">RO-Crate Community</a></td>
             </tr></tbody>
             </table>
         </div>
-            </div>
+
+        </div>
         <hr/><br/><br/>
-            <div>
-                <h3><a href="https://orcid.org/0000-0002-9986-7223">Go to: </a> Kosuke Tanabe</h3>
-                
-                
-                
-                
+           <div>
+            <h3><a href="https://orcid.org/0000-0002-9986-7223">Go to: </a> Kosuke Tanabe</h3>
+            
+            
+            
+            
         <div id="https://orcid.org/0000-0002-9986-7223">
             
             <table class="table metadata table-striped" >
@@ -4318,28 +4541,29 @@ While providing the formal specification for RO-Crate, this document also aims t
             <th style="text-align:left;" class="prop">@id</th>
             <td style='text-align:left'><a href="https://orcid.org/0000-0002-9986-7223">https://orcid.org/0000-0002-9986-7223</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">name</th>
+            <th style="text-align:left;" class="prop">name<span>&nbsp;</span><a href="http://schema.org/name">[?]</a></th>
             <td style='text-align:left'><span>Kosuke Tanabe</span></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">@type</th>
             <td style='text-align:left'><span>Person</span></td>
             </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
-            <th style="text-align:left;" class="prop">author</th>
+            <th style="text-align:left;" class="prop">author<span>&nbsp;</span><a href="http://schema.org/author">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//w3id.org/ro/crate/1.2">RO-Crate specification 1.2</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">member</th>
+            <th style="text-align:left;" class="prop">member<span>&nbsp;</span><a href="http://schema.org/member">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//www.researchobject.org/ro-crate/community">RO-Crate Community</a></td>
             </tr></tbody>
             </table>
         </div>
-            </div>
+
+        </div>
         <hr/><br/><br/>
-            <div>
-                <h3><a href="https://orcid.org/0000-0002-4929-7875">Go to: </a> Tomasz Miksa</h3>
-                
-                
-                
-                
+           <div>
+            <h3><a href="https://orcid.org/0000-0002-4929-7875">Go to: </a> Tomasz Miksa</h3>
+            
+            
+            
+            
         <div id="https://orcid.org/0000-0002-4929-7875">
             
             <table class="table metadata table-striped" >
@@ -4347,28 +4571,29 @@ While providing the formal specification for RO-Crate, this document also aims t
             <th style="text-align:left;" class="prop">@id</th>
             <td style='text-align:left'><a href="https://orcid.org/0000-0002-4929-7875">https://orcid.org/0000-0002-4929-7875</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">name</th>
+            <th style="text-align:left;" class="prop">name<span>&nbsp;</span><a href="http://schema.org/name">[?]</a></th>
             <td style='text-align:left'><span>Tomasz Miksa</span></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">@type</th>
             <td style='text-align:left'><span>Person</span></td>
             </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
-            <th style="text-align:left;" class="prop">author</th>
+            <th style="text-align:left;" class="prop">author<span>&nbsp;</span><a href="http://schema.org/author">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//w3id.org/ro/crate/1.2">RO-Crate specification 1.2</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">member</th>
+            <th style="text-align:left;" class="prop">member<span>&nbsp;</span><a href="http://schema.org/member">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//www.researchobject.org/ro-crate/community">RO-Crate Community</a></td>
             </tr></tbody>
             </table>
         </div>
-            </div>
+
+        </div>
         <hr/><br/><br/>
-            <div>
-                <h3><a href="https://orcid.org/0000-0001-5383-6993">Go to: </a> Marco La Rosa</h3>
-                
-                
-                
-                
+           <div>
+            <h3><a href="https://orcid.org/0000-0001-5383-6993">Go to: </a> Marco La Rosa</h3>
+            
+            
+            
+            
         <div id="https://orcid.org/0000-0001-5383-6993">
             
             <table class="table metadata table-striped" >
@@ -4376,32 +4601,33 @@ While providing the formal specification for RO-Crate, this document also aims t
             <th style="text-align:left;" class="prop">@id</th>
             <td style='text-align:left'><a href="https://orcid.org/0000-0001-5383-6993">https://orcid.org/0000-0001-5383-6993</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">name</th>
+            <th style="text-align:left;" class="prop">name<span>&nbsp;</span><a href="http://schema.org/name">[?]</a></th>
             <td style='text-align:left'><span>Marco La Rosa</span></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">@type</th>
             <td style='text-align:left'><span>Person</span></td>
             </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
-            <th style="text-align:left;" class="prop">author</th>
+            <th style="text-align:left;" class="prop">author<span>&nbsp;</span><a href="http://schema.org/author">[?]</a></th>
             <td style='text-align:left'><ul>
                         <li><a href="#https%3A//w3id.org/ro/crate/1.2">RO-Crate specification 1.2</a></li>
                         
                         <li><a href="#https%3A//doi.org/10.3233/DS-210053">Packaging research artefacts with RO-Crate</a></li>
                         </ul></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">member</th>
+            <th style="text-align:left;" class="prop">member<span>&nbsp;</span><a href="http://schema.org/member">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//www.researchobject.org/ro-crate/community">RO-Crate Community</a></td>
             </tr></tbody>
             </table>
         </div>
-            </div>
+
+        </div>
         <hr/><br/><br/>
-            <div>
-                <h3><a href="https://orcid.org/0000-0001-6387-5988">Go to: </a> Cedric Decruw</h3>
-                
-                
-                
-                
+           <div>
+            <h3><a href="https://orcid.org/0000-0001-6387-5988">Go to: </a> Cedric Decruw</h3>
+            
+            
+            
+            
         <div id="https://orcid.org/0000-0001-6387-5988">
             
             <table class="table metadata table-striped" >
@@ -4409,28 +4635,29 @@ While providing the formal specification for RO-Crate, this document also aims t
             <th style="text-align:left;" class="prop">@id</th>
             <td style='text-align:left'><a href="https://orcid.org/0000-0001-6387-5988">https://orcid.org/0000-0001-6387-5988</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">name</th>
+            <th style="text-align:left;" class="prop">name<span>&nbsp;</span><a href="http://schema.org/name">[?]</a></th>
             <td style='text-align:left'><span>Cedric Decruw</span></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">@type</th>
             <td style='text-align:left'><span>Person</span></td>
             </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
-            <th style="text-align:left;" class="prop">author</th>
+            <th style="text-align:left;" class="prop">author<span>&nbsp;</span><a href="http://schema.org/author">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//w3id.org/ro/crate/1.2">RO-Crate specification 1.2</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">member</th>
+            <th style="text-align:left;" class="prop">member<span>&nbsp;</span><a href="http://schema.org/member">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//www.researchobject.org/ro-crate/community">RO-Crate Community</a></td>
             </tr></tbody>
             </table>
         </div>
-            </div>
+
+        </div>
         <hr/><br/><br/>
-            <div>
-                <h3><a href="https://orcid.org/0000-0003-3883-4169">Go to: </a> Andreas Czerniak</h3>
-                
-                
-                
-                
+           <div>
+            <h3><a href="https://orcid.org/0000-0003-3883-4169">Go to: </a> Andreas Czerniak</h3>
+            
+            
+            
+            
         <div id="https://orcid.org/0000-0003-3883-4169">
             
             <table class="table metadata table-striped" >
@@ -4438,28 +4665,29 @@ While providing the formal specification for RO-Crate, this document also aims t
             <th style="text-align:left;" class="prop">@id</th>
             <td style='text-align:left'><a href="https://orcid.org/0000-0003-3883-4169">https://orcid.org/0000-0003-3883-4169</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">name</th>
+            <th style="text-align:left;" class="prop">name<span>&nbsp;</span><a href="http://schema.org/name">[?]</a></th>
             <td style='text-align:left'><span>Andreas Czerniak</span></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">@type</th>
             <td style='text-align:left'><span>Person</span></td>
             </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
-            <th style="text-align:left;" class="prop">author</th>
+            <th style="text-align:left;" class="prop">author<span>&nbsp;</span><a href="http://schema.org/author">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//w3id.org/ro/crate/1.2">RO-Crate specification 1.2</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">member</th>
+            <th style="text-align:left;" class="prop">member<span>&nbsp;</span><a href="http://schema.org/member">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//www.researchobject.org/ro-crate/community">RO-Crate Community</a></td>
             </tr></tbody>
             </table>
         </div>
-            </div>
+
+        </div>
         <hr/><br/><br/>
-            <div>
-                <h3><a href="https://orcid.org/0000-0002-5761-7533">Go to: </a> Jeremy Jay</h3>
-                
-                
-                
-                
+           <div>
+            <h3><a href="https://orcid.org/0000-0002-5761-7533">Go to: </a> Jeremy Jay</h3>
+            
+            
+            
+            
         <div id="https://orcid.org/0000-0002-5761-7533">
             
             <table class="table metadata table-striped" >
@@ -4467,28 +4695,29 @@ While providing the formal specification for RO-Crate, this document also aims t
             <th style="text-align:left;" class="prop">@id</th>
             <td style='text-align:left'><a href="https://orcid.org/0000-0002-5761-7533">https://orcid.org/0000-0002-5761-7533</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">name</th>
+            <th style="text-align:left;" class="prop">name<span>&nbsp;</span><a href="http://schema.org/name">[?]</a></th>
             <td style='text-align:left'><span>Jeremy Jay</span></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">@type</th>
             <td style='text-align:left'><span>Person</span></td>
             </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
-            <th style="text-align:left;" class="prop">author</th>
+            <th style="text-align:left;" class="prop">author<span>&nbsp;</span><a href="http://schema.org/author">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//w3id.org/ro/crate/1.2">RO-Crate specification 1.2</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">member</th>
+            <th style="text-align:left;" class="prop">member<span>&nbsp;</span><a href="http://schema.org/member">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//www.researchobject.org/ro-crate/community">RO-Crate Community</a></td>
             </tr></tbody>
             </table>
         </div>
-            </div>
+
+        </div>
         <hr/><br/><br/>
-            <div>
-                <h3><a href="https://orcid.org/0000-0002-0792-8157">Go to: </a> Sergio Serra</h3>
-                
-                
-                
-                
+           <div>
+            <h3><a href="https://orcid.org/0000-0002-0792-8157">Go to: </a> Sergio Serra</h3>
+            
+            
+            
+            
         <div id="https://orcid.org/0000-0002-0792-8157">
             
             <table class="table metadata table-striped" >
@@ -4496,28 +4725,29 @@ While providing the formal specification for RO-Crate, this document also aims t
             <th style="text-align:left;" class="prop">@id</th>
             <td style='text-align:left'><a href="https://orcid.org/0000-0002-0792-8157">https://orcid.org/0000-0002-0792-8157</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">name</th>
+            <th style="text-align:left;" class="prop">name<span>&nbsp;</span><a href="http://schema.org/name">[?]</a></th>
             <td style='text-align:left'><span>Sergio Serra</span></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">@type</th>
             <td style='text-align:left'><span>Person</span></td>
             </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
-            <th style="text-align:left;" class="prop">author</th>
+            <th style="text-align:left;" class="prop">author<span>&nbsp;</span><a href="http://schema.org/author">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//w3id.org/ro/crate/1.2">RO-Crate specification 1.2</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">member</th>
+            <th style="text-align:left;" class="prop">member<span>&nbsp;</span><a href="http://schema.org/member">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//www.researchobject.org/ro-crate/community">RO-Crate Community</a></td>
             </tr></tbody>
             </table>
         </div>
-            </div>
+
+        </div>
         <hr/><br/><br/>
-            <div>
-                <h3><a href="https://orcid.org/0000-0001-8772-7904">Go to: </a> Ronald Siebes</h3>
-                
-                
-                
-                
+           <div>
+            <h3><a href="https://orcid.org/0000-0001-8772-7904">Go to: </a> Ronald Siebes</h3>
+            
+            
+            
+            
         <div id="https://orcid.org/0000-0001-8772-7904">
             
             <table class="table metadata table-striped" >
@@ -4525,28 +4755,29 @@ While providing the formal specification for RO-Crate, this document also aims t
             <th style="text-align:left;" class="prop">@id</th>
             <td style='text-align:left'><a href="https://orcid.org/0000-0001-8772-7904">https://orcid.org/0000-0001-8772-7904</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">name</th>
+            <th style="text-align:left;" class="prop">name<span>&nbsp;</span><a href="http://schema.org/name">[?]</a></th>
             <td style='text-align:left'><span>Ronald Siebes</span></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">@type</th>
             <td style='text-align:left'><span>Person</span></td>
             </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
-            <th style="text-align:left;" class="prop">author</th>
+            <th style="text-align:left;" class="prop">author<span>&nbsp;</span><a href="http://schema.org/author">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//w3id.org/ro/crate/1.2">RO-Crate specification 1.2</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">member</th>
+            <th style="text-align:left;" class="prop">member<span>&nbsp;</span><a href="http://schema.org/member">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//www.researchobject.org/ro-crate/community">RO-Crate Community</a></td>
             </tr></tbody>
             </table>
         </div>
-            </div>
+
+        </div>
         <hr/><br/><br/>
-            <div>
-                <h3><a href="https://orcid.org/0000-0003-4196-3658">Go to: </a> Shaun de Witt</h3>
-                
-                
-                
-                
+           <div>
+            <h3><a href="https://orcid.org/0000-0003-4196-3658">Go to: </a> Shaun de Witt</h3>
+            
+            
+            
+            
         <div id="https://orcid.org/0000-0003-4196-3658">
             
             <table class="table metadata table-striped" >
@@ -4554,28 +4785,29 @@ While providing the formal specification for RO-Crate, this document also aims t
             <th style="text-align:left;" class="prop">@id</th>
             <td style='text-align:left'><a href="https://orcid.org/0000-0003-4196-3658">https://orcid.org/0000-0003-4196-3658</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">name</th>
+            <th style="text-align:left;" class="prop">name<span>&nbsp;</span><a href="http://schema.org/name">[?]</a></th>
             <td style='text-align:left'><span>Shaun de Witt</span></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">@type</th>
             <td style='text-align:left'><span>Person</span></td>
             </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
-            <th style="text-align:left;" class="prop">author</th>
+            <th style="text-align:left;" class="prop">author<span>&nbsp;</span><a href="http://schema.org/author">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//w3id.org/ro/crate/1.2">RO-Crate specification 1.2</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">member</th>
+            <th style="text-align:left;" class="prop">member<span>&nbsp;</span><a href="http://schema.org/member">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//www.researchobject.org/ro-crate/community">RO-Crate Community</a></td>
             </tr></tbody>
             </table>
         </div>
-            </div>
+
+        </div>
         <hr/><br/><br/>
-            <div>
-                <h3><a href="https://orcid.org/0000-0002-2318-4477">Go to: </a> Shady El Damaty</h3>
-                
-                
-                
-                
+           <div>
+            <h3><a href="https://orcid.org/0000-0002-2318-4477">Go to: </a> Shady El Damaty</h3>
+            
+            
+            
+            
         <div id="https://orcid.org/0000-0002-2318-4477">
             
             <table class="table metadata table-striped" >
@@ -4583,28 +4815,29 @@ While providing the formal specification for RO-Crate, this document also aims t
             <th style="text-align:left;" class="prop">@id</th>
             <td style='text-align:left'><a href="https://orcid.org/0000-0002-2318-4477">https://orcid.org/0000-0002-2318-4477</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">name</th>
+            <th style="text-align:left;" class="prop">name<span>&nbsp;</span><a href="http://schema.org/name">[?]</a></th>
             <td style='text-align:left'><span>Shady El Damaty</span></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">@type</th>
             <td style='text-align:left'><span>Person</span></td>
             </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
-            <th style="text-align:left;" class="prop">author</th>
+            <th style="text-align:left;" class="prop">author<span>&nbsp;</span><a href="http://schema.org/author">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//w3id.org/ro/crate/1.2">RO-Crate specification 1.2</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">member</th>
+            <th style="text-align:left;" class="prop">member<span>&nbsp;</span><a href="http://schema.org/member">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//www.researchobject.org/ro-crate/community">RO-Crate Community</a></td>
             </tr></tbody>
             </table>
         </div>
-            </div>
+
+        </div>
         <hr/><br/><br/>
-            <div>
-                <h3><a href="https://orcid.org/0000-0002-1248-3594">Go to: </a> Douglas Lowe</h3>
-                
-                
-                
-                
+           <div>
+            <h3><a href="https://orcid.org/0000-0002-1248-3594">Go to: </a> Douglas Lowe</h3>
+            
+            
+            
+            
         <div id="https://orcid.org/0000-0002-1248-3594">
             
             <table class="table metadata table-striped" >
@@ -4612,28 +4845,29 @@ While providing the formal specification for RO-Crate, this document also aims t
             <th style="text-align:left;" class="prop">@id</th>
             <td style='text-align:left'><a href="https://orcid.org/0000-0002-1248-3594">https://orcid.org/0000-0002-1248-3594</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">name</th>
+            <th style="text-align:left;" class="prop">name<span>&nbsp;</span><a href="http://schema.org/name">[?]</a></th>
             <td style='text-align:left'><span>Douglas Lowe</span></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">@type</th>
             <td style='text-align:left'><span>Person</span></td>
             </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
-            <th style="text-align:left;" class="prop">author</th>
+            <th style="text-align:left;" class="prop">author<span>&nbsp;</span><a href="http://schema.org/author">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//w3id.org/ro/crate/1.2">RO-Crate specification 1.2</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">member</th>
+            <th style="text-align:left;" class="prop">member<span>&nbsp;</span><a href="http://schema.org/member">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//www.researchobject.org/ro-crate/community">RO-Crate Community</a></td>
             </tr></tbody>
             </table>
         </div>
-            </div>
+
+        </div>
         <hr/><br/><br/>
-            <div>
-                <h3><a href="https://orcid.org/0000-0003-1498-6205">Go to: </a> Xuanqi Li</h3>
-                
-                
-                
-                
+           <div>
+            <h3><a href="https://orcid.org/0000-0003-1498-6205">Go to: </a> Xuanqi Li</h3>
+            
+            
+            
+            
         <div id="https://orcid.org/0000-0003-1498-6205">
             
             <table class="table metadata table-striped" >
@@ -4641,28 +4875,29 @@ While providing the formal specification for RO-Crate, this document also aims t
             <th style="text-align:left;" class="prop">@id</th>
             <td style='text-align:left'><a href="https://orcid.org/0000-0003-1498-6205">https://orcid.org/0000-0003-1498-6205</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">name</th>
+            <th style="text-align:left;" class="prop">name<span>&nbsp;</span><a href="http://schema.org/name">[?]</a></th>
             <td style='text-align:left'><span>Xuanqi Li</span></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">@type</th>
             <td style='text-align:left'><span>Person</span></td>
             </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
-            <th style="text-align:left;" class="prop">author</th>
+            <th style="text-align:left;" class="prop">author<span>&nbsp;</span><a href="http://schema.org/author">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//w3id.org/ro/crate/1.2">RO-Crate specification 1.2</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">member</th>
+            <th style="text-align:left;" class="prop">member<span>&nbsp;</span><a href="http://schema.org/member">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//www.researchobject.org/ro-crate/community">RO-Crate Community</a></td>
             </tr></tbody>
             </table>
         </div>
-            </div>
+
+        </div>
         <hr/><br/><br/>
-            <div>
-                <h3><a href="https://orcid.org/0000-0001-9888-7954">Go to: </a> Sveinung Gundersen</h3>
-                
-                
-                
-                
+           <div>
+            <h3><a href="https://orcid.org/0000-0001-9888-7954">Go to: </a> Sveinung Gundersen</h3>
+            
+            
+            
+            
         <div id="https://orcid.org/0000-0001-9888-7954">
             
             <table class="table metadata table-striped" >
@@ -4670,28 +4905,29 @@ While providing the formal specification for RO-Crate, this document also aims t
             <th style="text-align:left;" class="prop">@id</th>
             <td style='text-align:left'><a href="https://orcid.org/0000-0001-9888-7954">https://orcid.org/0000-0001-9888-7954</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">name</th>
+            <th style="text-align:left;" class="prop">name<span>&nbsp;</span><a href="http://schema.org/name">[?]</a></th>
             <td style='text-align:left'><span>Sveinung Gundersen</span></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">@type</th>
             <td style='text-align:left'><span>Person</span></td>
             </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
-            <th style="text-align:left;" class="prop">author</th>
+            <th style="text-align:left;" class="prop">author<span>&nbsp;</span><a href="http://schema.org/author">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//w3id.org/ro/crate/1.2">RO-Crate specification 1.2</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">member</th>
+            <th style="text-align:left;" class="prop">member<span>&nbsp;</span><a href="http://schema.org/member">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//www.researchobject.org/ro-crate/community">RO-Crate Community</a></td>
             </tr></tbody>
             </table>
         </div>
-            </div>
+
+        </div>
         <hr/><br/><br/>
-            <div>
-                <h3><a href="https://orcid.org/0000-0001-9156-9478">Go to: </a> Muhammad Radifar</h3>
-                
-                
-                
-                
+           <div>
+            <h3><a href="https://orcid.org/0000-0001-9156-9478">Go to: </a> Muhammad Radifar</h3>
+            
+            
+            
+            
         <div id="https://orcid.org/0000-0001-9156-9478">
             
             <table class="table metadata table-striped" >
@@ -4699,28 +4935,29 @@ While providing the formal specification for RO-Crate, this document also aims t
             <th style="text-align:left;" class="prop">@id</th>
             <td style='text-align:left'><a href="https://orcid.org/0000-0001-9156-9478">https://orcid.org/0000-0001-9156-9478</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">name</th>
+            <th style="text-align:left;" class="prop">name<span>&nbsp;</span><a href="http://schema.org/name">[?]</a></th>
             <td style='text-align:left'><span>Muhammad Radifar</span></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">@type</th>
             <td style='text-align:left'><span>Person</span></td>
             </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
-            <th style="text-align:left;" class="prop">author</th>
+            <th style="text-align:left;" class="prop">author<span>&nbsp;</span><a href="http://schema.org/author">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//w3id.org/ro/crate/1.2">RO-Crate specification 1.2</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">member</th>
+            <th style="text-align:left;" class="prop">member<span>&nbsp;</span><a href="http://schema.org/member">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//www.researchobject.org/ro-crate/community">RO-Crate Community</a></td>
             </tr></tbody>
             </table>
         </div>
-            </div>
+
+        </div>
         <hr/><br/><br/>
-            <div>
-                <h3><a href="https://orcid.org/0000-0002-0003-2024">Go to: </a> Rudolf Wittner</h3>
-                
-                
-                
-                
+           <div>
+            <h3><a href="https://orcid.org/0000-0002-0003-2024">Go to: </a> Rudolf Wittner</h3>
+            
+            
+            
+            
         <div id="https://orcid.org/0000-0002-0003-2024">
             
             <table class="table metadata table-striped" >
@@ -4728,28 +4965,29 @@ While providing the formal specification for RO-Crate, this document also aims t
             <th style="text-align:left;" class="prop">@id</th>
             <td style='text-align:left'><a href="https://orcid.org/0000-0002-0003-2024">https://orcid.org/0000-0002-0003-2024</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">name</th>
+            <th style="text-align:left;" class="prop">name<span>&nbsp;</span><a href="http://schema.org/name">[?]</a></th>
             <td style='text-align:left'><span>Rudolf Wittner</span></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">@type</th>
             <td style='text-align:left'><span>Person</span></td>
             </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
-            <th style="text-align:left;" class="prop">author</th>
+            <th style="text-align:left;" class="prop">author<span>&nbsp;</span><a href="http://schema.org/author">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//w3id.org/ro/crate/1.2">RO-Crate specification 1.2</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">member</th>
+            <th style="text-align:left;" class="prop">member<span>&nbsp;</span><a href="http://schema.org/member">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//www.researchobject.org/ro-crate/community">RO-Crate Community</a></td>
             </tr></tbody>
             </table>
         </div>
-            </div>
+
+        </div>
         <hr/><br/><br/>
-            <div>
-                <h3><a href="https://orcid.org/0000-0002-4565-9760">Go to: </a> Oliver Woolland</h3>
-                
-                
-                
-                
+           <div>
+            <h3><a href="https://orcid.org/0000-0002-4565-9760">Go to: </a> Oliver Woolland</h3>
+            
+            
+            
+            
         <div id="https://orcid.org/0000-0002-4565-9760">
             
             <table class="table metadata table-striped" >
@@ -4757,28 +4995,29 @@ While providing the formal specification for RO-Crate, this document also aims t
             <th style="text-align:left;" class="prop">@id</th>
             <td style='text-align:left'><a href="https://orcid.org/0000-0002-4565-9760">https://orcid.org/0000-0002-4565-9760</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">name</th>
+            <th style="text-align:left;" class="prop">name<span>&nbsp;</span><a href="http://schema.org/name">[?]</a></th>
             <td style='text-align:left'><span>Oliver Woolland</span></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">@type</th>
             <td style='text-align:left'><span>Person</span></td>
             </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
-            <th style="text-align:left;" class="prop">author</th>
+            <th style="text-align:left;" class="prop">author<span>&nbsp;</span><a href="http://schema.org/author">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//w3id.org/ro/crate/1.2">RO-Crate specification 1.2</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">member</th>
+            <th style="text-align:left;" class="prop">member<span>&nbsp;</span><a href="http://schema.org/member">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//www.researchobject.org/ro-crate/community">RO-Crate Community</a></td>
             </tr></tbody>
             </table>
         </div>
-            </div>
+
+        </div>
         <hr/><br/><br/>
-            <div>
-                <h3><a href="https://orcid.org/0000-0002-8940-4946">Go to: </a> Paul De Geest</h3>
-                
-                
-                
-                
+           <div>
+            <h3><a href="https://orcid.org/0000-0002-8940-4946">Go to: </a> Paul De Geest</h3>
+            
+            
+            
+            
         <div id="https://orcid.org/0000-0002-8940-4946">
             
             <table class="table metadata table-striped" >
@@ -4786,28 +5025,29 @@ While providing the formal specification for RO-Crate, this document also aims t
             <th style="text-align:left;" class="prop">@id</th>
             <td style='text-align:left'><a href="https://orcid.org/0000-0002-8940-4946">https://orcid.org/0000-0002-8940-4946</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">name</th>
+            <th style="text-align:left;" class="prop">name<span>&nbsp;</span><a href="http://schema.org/name">[?]</a></th>
             <td style='text-align:left'><span>Paul De Geest</span></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">@type</th>
             <td style='text-align:left'><span>Person</span></td>
             </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
-            <th style="text-align:left;" class="prop">author</th>
+            <th style="text-align:left;" class="prop">author<span>&nbsp;</span><a href="http://schema.org/author">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//w3id.org/ro/crate/1.2">RO-Crate specification 1.2</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">member</th>
+            <th style="text-align:left;" class="prop">member<span>&nbsp;</span><a href="http://schema.org/member">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//www.researchobject.org/ro-crate/community">RO-Crate Community</a></td>
             </tr></tbody>
             </table>
         </div>
-            </div>
+
+        </div>
         <hr/><br/><br/>
-            <div>
-                <h3><a href="https://orcid.org/0000-0002-2257-9127">Go to: </a> Douglas Fils</h3>
-                
-                
-                
-                
+           <div>
+            <h3><a href="https://orcid.org/0000-0002-2257-9127">Go to: </a> Douglas Fils</h3>
+            
+            
+            
+            
         <div id="https://orcid.org/0000-0002-2257-9127">
             
             <table class="table metadata table-striped" >
@@ -4815,28 +5055,29 @@ While providing the formal specification for RO-Crate, this document also aims t
             <th style="text-align:left;" class="prop">@id</th>
             <td style='text-align:left'><a href="https://orcid.org/0000-0002-2257-9127">https://orcid.org/0000-0002-2257-9127</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">name</th>
+            <th style="text-align:left;" class="prop">name<span>&nbsp;</span><a href="http://schema.org/name">[?]</a></th>
             <td style='text-align:left'><span>Douglas Fils</span></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">@type</th>
             <td style='text-align:left'><span>Person</span></td>
             </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
-            <th style="text-align:left;" class="prop">author</th>
+            <th style="text-align:left;" class="prop">author<span>&nbsp;</span><a href="http://schema.org/author">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//w3id.org/ro/crate/1.2">RO-Crate specification 1.2</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">member</th>
+            <th style="text-align:left;" class="prop">member<span>&nbsp;</span><a href="http://schema.org/member">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//www.researchobject.org/ro-crate/community">RO-Crate Community</a></td>
             </tr></tbody>
             </table>
         </div>
-            </div>
+
+        </div>
         <hr/><br/><br/>
-            <div>
-                <h3><a href="https://orcid.org/0000-0002-5526-7138">Go to: </a> Florian Wetzels</h3>
-                
-                
-                
-                
+           <div>
+            <h3><a href="https://orcid.org/0000-0002-5526-7138">Go to: </a> Florian Wetzels</h3>
+            
+            
+            
+            
         <div id="https://orcid.org/0000-0002-5526-7138">
             
             <table class="table metadata table-striped" >
@@ -4844,28 +5085,29 @@ While providing the formal specification for RO-Crate, this document also aims t
             <th style="text-align:left;" class="prop">@id</th>
             <td style='text-align:left'><a href="https://orcid.org/0000-0002-5526-7138">https://orcid.org/0000-0002-5526-7138</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">name</th>
+            <th style="text-align:left;" class="prop">name<span>&nbsp;</span><a href="http://schema.org/name">[?]</a></th>
             <td style='text-align:left'><span>Florian Wetzels</span></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">@type</th>
             <td style='text-align:left'><span>Person</span></td>
             </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
-            <th style="text-align:left;" class="prop">author</th>
+            <th style="text-align:left;" class="prop">author<span>&nbsp;</span><a href="http://schema.org/author">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//w3id.org/ro/crate/1.2">RO-Crate specification 1.2</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">member</th>
+            <th style="text-align:left;" class="prop">member<span>&nbsp;</span><a href="http://schema.org/member">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//www.researchobject.org/ro-crate/community">RO-Crate Community</a></td>
             </tr></tbody>
             </table>
         </div>
-            </div>
+
+        </div>
         <hr/><br/><br/>
-            <div>
-                <h3><a href="https://orcid.org/0000-0003-0606-2512">Go to: </a> Raül Sirvent</h3>
-                
-                
-                
-                
+           <div>
+            <h3><a href="https://orcid.org/0000-0003-0606-2512">Go to: </a> Raül Sirvent</h3>
+            
+            
+            
+            
         <div id="https://orcid.org/0000-0003-0606-2512">
             
             <table class="table metadata table-striped" >
@@ -4873,28 +5115,29 @@ While providing the formal specification for RO-Crate, this document also aims t
             <th style="text-align:left;" class="prop">@id</th>
             <td style='text-align:left'><a href="https://orcid.org/0000-0003-0606-2512">https://orcid.org/0000-0003-0606-2512</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">name</th>
+            <th style="text-align:left;" class="prop">name<span>&nbsp;</span><a href="http://schema.org/name">[?]</a></th>
             <td style='text-align:left'><span>Raül Sirvent</span></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">@type</th>
             <td style='text-align:left'><span>Person</span></td>
             </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
-            <th style="text-align:left;" class="prop">author</th>
+            <th style="text-align:left;" class="prop">author<span>&nbsp;</span><a href="http://schema.org/author">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//w3id.org/ro/crate/1.2">RO-Crate specification 1.2</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">member</th>
+            <th style="text-align:left;" class="prop">member<span>&nbsp;</span><a href="http://schema.org/member">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//www.researchobject.org/ro-crate/community">RO-Crate Community</a></td>
             </tr></tbody>
             </table>
         </div>
-            </div>
+
+        </div>
         <hr/><br/><br/>
-            <div>
-                <h3><a href="https://orcid.org/0000-0001-9228-2882">Go to: </a> Abigail Miller</h3>
-                
-                
-                
-                
+           <div>
+            <h3><a href="https://orcid.org/0000-0001-9228-2882">Go to: </a> Abigail Miller</h3>
+            
+            
+            
+            
         <div id="https://orcid.org/0000-0001-9228-2882">
             
             <table class="table metadata table-striped" >
@@ -4902,28 +5145,29 @@ While providing the formal specification for RO-Crate, this document also aims t
             <th style="text-align:left;" class="prop">@id</th>
             <td style='text-align:left'><a href="https://orcid.org/0000-0001-9228-2882">https://orcid.org/0000-0001-9228-2882</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">name</th>
+            <th style="text-align:left;" class="prop">name<span>&nbsp;</span><a href="http://schema.org/name">[?]</a></th>
             <td style='text-align:left'><span>Abigail Miller</span></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">@type</th>
             <td style='text-align:left'><span>Person</span></td>
             </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
-            <th style="text-align:left;" class="prop">author</th>
+            <th style="text-align:left;" class="prop">author<span>&nbsp;</span><a href="http://schema.org/author">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//w3id.org/ro/crate/1.2">RO-Crate specification 1.2</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">member</th>
+            <th style="text-align:left;" class="prop">member<span>&nbsp;</span><a href="http://schema.org/member">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//www.researchobject.org/ro-crate/community">RO-Crate Community</a></td>
             </tr></tbody>
             </table>
         </div>
-            </div>
+
+        </div>
         <hr/><br/><br/>
-            <div>
-                <h3><a href="https://orcid.org/0000-0003-0617-9219">Go to: </a> Jake Emerson</h3>
-                
-                
-                
-                
+           <div>
+            <h3><a href="https://orcid.org/0000-0003-0617-9219">Go to: </a> Jake Emerson</h3>
+            
+            
+            
+            
         <div id="https://orcid.org/0000-0003-0617-9219">
             
             <table class="table metadata table-striped" >
@@ -4931,28 +5175,29 @@ While providing the formal specification for RO-Crate, this document also aims t
             <th style="text-align:left;" class="prop">@id</th>
             <td style='text-align:left'><a href="https://orcid.org/0000-0003-0617-9219">https://orcid.org/0000-0003-0617-9219</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">name</th>
+            <th style="text-align:left;" class="prop">name<span>&nbsp;</span><a href="http://schema.org/name">[?]</a></th>
             <td style='text-align:left'><span>Jake Emerson</span></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">@type</th>
             <td style='text-align:left'><span>Person</span></td>
             </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
-            <th style="text-align:left;" class="prop">author</th>
+            <th style="text-align:left;" class="prop">author<span>&nbsp;</span><a href="http://schema.org/author">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//w3id.org/ro/crate/1.2">RO-Crate specification 1.2</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">member</th>
+            <th style="text-align:left;" class="prop">member<span>&nbsp;</span><a href="http://schema.org/member">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//www.researchobject.org/ro-crate/community">RO-Crate Community</a></td>
             </tr></tbody>
             </table>
         </div>
-            </div>
+
+        </div>
         <hr/><br/><br/>
-            <div>
-                <h3><a href="https://orcid.org/0000-0002-0679-4361">Go to: </a> Davide Fucci</h3>
-                
-                
-                
-                
+           <div>
+            <h3><a href="https://orcid.org/0000-0002-0679-4361">Go to: </a> Davide Fucci</h3>
+            
+            
+            
+            
         <div id="https://orcid.org/0000-0002-0679-4361">
             
             <table class="table metadata table-striped" >
@@ -4960,28 +5205,29 @@ While providing the formal specification for RO-Crate, this document also aims t
             <th style="text-align:left;" class="prop">@id</th>
             <td style='text-align:left'><a href="https://orcid.org/0000-0002-0679-4361">https://orcid.org/0000-0002-0679-4361</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">name</th>
+            <th style="text-align:left;" class="prop">name<span>&nbsp;</span><a href="http://schema.org/name">[?]</a></th>
             <td style='text-align:left'><span>Davide Fucci</span></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">@type</th>
             <td style='text-align:left'><span>Person</span></td>
             </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
-            <th style="text-align:left;" class="prop">author</th>
+            <th style="text-align:left;" class="prop">author<span>&nbsp;</span><a href="http://schema.org/author">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//w3id.org/ro/crate/1.2">RO-Crate specification 1.2</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">member</th>
+            <th style="text-align:left;" class="prop">member<span>&nbsp;</span><a href="http://schema.org/member">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//www.researchobject.org/ro-crate/community">RO-Crate Community</a></td>
             </tr></tbody>
             </table>
         </div>
-            </div>
+
+        </div>
         <hr/><br/><br/>
-            <div>
-                <h3><a href="https://orcid.org/0000-0001-8250-4074">Go to: </a> Bruno P. Kinoshita</h3>
-                
-                
-                
-                
+           <div>
+            <h3><a href="https://orcid.org/0000-0001-8250-4074">Go to: </a> Bruno P. Kinoshita</h3>
+            
+            
+            
+            
         <div id="https://orcid.org/0000-0001-8250-4074">
             
             <table class="table metadata table-striped" >
@@ -4989,28 +5235,29 @@ While providing the formal specification for RO-Crate, this document also aims t
             <th style="text-align:left;" class="prop">@id</th>
             <td style='text-align:left'><a href="https://orcid.org/0000-0001-8250-4074">https://orcid.org/0000-0001-8250-4074</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">name</th>
+            <th style="text-align:left;" class="prop">name<span>&nbsp;</span><a href="http://schema.org/name">[?]</a></th>
             <td style='text-align:left'><span>Bruno P. Kinoshita</span></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">@type</th>
             <td style='text-align:left'><span>Person</span></td>
             </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
-            <th style="text-align:left;" class="prop">author</th>
+            <th style="text-align:left;" class="prop">author<span>&nbsp;</span><a href="http://schema.org/author">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//w3id.org/ro/crate/1.2">RO-Crate specification 1.2</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">member</th>
+            <th style="text-align:left;" class="prop">member<span>&nbsp;</span><a href="http://schema.org/member">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//www.researchobject.org/ro-crate/community">RO-Crate Community</a></td>
             </tr></tbody>
             </table>
         </div>
-            </div>
+
+        </div>
         <hr/><br/><br/>
-            <div>
-                <h3><a href="https://orcid.org/0000-0003-1361-7301">Go to: </a> Maciek Bąk</h3>
-                
-                
-                
-                
+           <div>
+            <h3><a href="https://orcid.org/0000-0003-1361-7301">Go to: </a> Maciek Bąk</h3>
+            
+            
+            
+            
         <div id="https://orcid.org/0000-0003-1361-7301">
             
             <table class="table metadata table-striped" >
@@ -5018,28 +5265,29 @@ While providing the formal specification for RO-Crate, this document also aims t
             <th style="text-align:left;" class="prop">@id</th>
             <td style='text-align:left'><a href="https://orcid.org/0000-0003-1361-7301">https://orcid.org/0000-0003-1361-7301</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">name</th>
+            <th style="text-align:left;" class="prop">name<span>&nbsp;</span><a href="http://schema.org/name">[?]</a></th>
             <td style='text-align:left'><span>Maciek Bąk</span></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">@type</th>
             <td style='text-align:left'><span>Person</span></td>
             </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
-            <th style="text-align:left;" class="prop">author</th>
+            <th style="text-align:left;" class="prop">author<span>&nbsp;</span><a href="http://schema.org/author">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//w3id.org/ro/crate/1.2">RO-Crate specification 1.2</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">member</th>
+            <th style="text-align:left;" class="prop">member<span>&nbsp;</span><a href="http://schema.org/member">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//www.researchobject.org/ro-crate/community">RO-Crate Community</a></td>
             </tr></tbody>
             </table>
         </div>
-            </div>
+
+        </div>
         <hr/><br/><br/>
-            <div>
-                <h3><a href="https://orcid.org/0000-0003-3234-6762">Go to: </a> Jens Hollunder</h3>
-                
-                
-                
-                
+           <div>
+            <h3><a href="https://orcid.org/0000-0003-3234-6762">Go to: </a> Jens Hollunder</h3>
+            
+            
+            
+            
         <div id="https://orcid.org/0000-0003-3234-6762">
             
             <table class="table metadata table-striped" >
@@ -5047,28 +5295,29 @@ While providing the formal specification for RO-Crate, this document also aims t
             <th style="text-align:left;" class="prop">@id</th>
             <td style='text-align:left'><a href="https://orcid.org/0000-0003-3234-6762">https://orcid.org/0000-0003-3234-6762</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">name</th>
+            <th style="text-align:left;" class="prop">name<span>&nbsp;</span><a href="http://schema.org/name">[?]</a></th>
             <td style='text-align:left'><span>Jens Hollunder</span></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">@type</th>
             <td style='text-align:left'><span>Person</span></td>
             </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
-            <th style="text-align:left;" class="prop">author</th>
+            <th style="text-align:left;" class="prop">author<span>&nbsp;</span><a href="http://schema.org/author">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//w3id.org/ro/crate/1.2">RO-Crate specification 1.2</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">member</th>
+            <th style="text-align:left;" class="prop">member<span>&nbsp;</span><a href="http://schema.org/member">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//www.researchobject.org/ro-crate/community">RO-Crate Community</a></td>
             </tr></tbody>
             </table>
         </div>
-            </div>
+
+        </div>
         <hr/><br/><br/>
-            <div>
-                <h3><a href="https://orcid.org/0000-0003-4216-302X">Go to: </a> Martin Weise</h3>
-                
-                
-                
-                
+           <div>
+            <h3><a href="https://orcid.org/0000-0003-4216-302X">Go to: </a> Martin Weise</h3>
+            
+            
+            
+            
         <div id="https://orcid.org/0000-0003-4216-302X">
             
             <table class="table metadata table-striped" >
@@ -5076,28 +5325,29 @@ While providing the formal specification for RO-Crate, this document also aims t
             <th style="text-align:left;" class="prop">@id</th>
             <td style='text-align:left'><a href="https://orcid.org/0000-0003-4216-302X">https://orcid.org/0000-0003-4216-302X</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">name</th>
+            <th style="text-align:left;" class="prop">name<span>&nbsp;</span><a href="http://schema.org/name">[?]</a></th>
             <td style='text-align:left'><span>Martin Weise</span></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">@type</th>
             <td style='text-align:left'><span>Person</span></td>
             </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
-            <th style="text-align:left;" class="prop">author</th>
+            <th style="text-align:left;" class="prop">author<span>&nbsp;</span><a href="http://schema.org/author">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//w3id.org/ro/crate/1.2">RO-Crate specification 1.2</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">member</th>
+            <th style="text-align:left;" class="prop">member<span>&nbsp;</span><a href="http://schema.org/member">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//www.researchobject.org/ro-crate/community">RO-Crate Community</a></td>
             </tr></tbody>
             </table>
         </div>
-            </div>
+
+        </div>
         <hr/><br/><br/>
-            <div>
-                <h3><a href="https://orcid.org/0000-0002-1880-0597">Go to: </a> Vartika Bisht</h3>
-                
-                
-                
-                
+           <div>
+            <h3><a href="https://orcid.org/0000-0002-1880-0597">Go to: </a> Vartika Bisht</h3>
+            
+            
+            
+            
         <div id="https://orcid.org/0000-0002-1880-0597">
             
             <table class="table metadata table-striped" >
@@ -5105,28 +5355,29 @@ While providing the formal specification for RO-Crate, this document also aims t
             <th style="text-align:left;" class="prop">@id</th>
             <td style='text-align:left'><a href="https://orcid.org/0000-0002-1880-0597">https://orcid.org/0000-0002-1880-0597</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">name</th>
+            <th style="text-align:left;" class="prop">name<span>&nbsp;</span><a href="http://schema.org/name">[?]</a></th>
             <td style='text-align:left'><span>Vartika Bisht</span></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">@type</th>
             <td style='text-align:left'><span>Person</span></td>
             </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
-            <th style="text-align:left;" class="prop">author</th>
+            <th style="text-align:left;" class="prop">author<span>&nbsp;</span><a href="http://schema.org/author">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//w3id.org/ro/crate/1.2">RO-Crate specification 1.2</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">member</th>
+            <th style="text-align:left;" class="prop">member<span>&nbsp;</span><a href="http://schema.org/member">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//www.researchobject.org/ro-crate/community">RO-Crate Community</a></td>
             </tr></tbody>
             </table>
         </div>
-            </div>
+
+        </div>
         <hr/><br/><br/>
-            <div>
-                <h3><a href="https://orcid.org/0000-0001-6712-6335">Go to: </a> Toshiyuki Nishiyama Hiraki</h3>
-                
-                
-                
-                
+           <div>
+            <h3><a href="https://orcid.org/0000-0001-6712-6335">Go to: </a> Toshiyuki Nishiyama Hiraki</h3>
+            
+            
+            
+            
         <div id="https://orcid.org/0000-0001-6712-6335">
             
             <table class="table metadata table-striped" >
@@ -5134,28 +5385,29 @@ While providing the formal specification for RO-Crate, this document also aims t
             <th style="text-align:left;" class="prop">@id</th>
             <td style='text-align:left'><a href="https://orcid.org/0000-0001-6712-6335">https://orcid.org/0000-0001-6712-6335</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">name</th>
+            <th style="text-align:left;" class="prop">name<span>&nbsp;</span><a href="http://schema.org/name">[?]</a></th>
             <td style='text-align:left'><span>Toshiyuki Nishiyama Hiraki</span></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">@type</th>
             <td style='text-align:left'><span>Person</span></td>
             </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
-            <th style="text-align:left;" class="prop">author</th>
+            <th style="text-align:left;" class="prop">author<span>&nbsp;</span><a href="http://schema.org/author">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//w3id.org/ro/crate/1.2">RO-Crate specification 1.2</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">member</th>
+            <th style="text-align:left;" class="prop">member<span>&nbsp;</span><a href="http://schema.org/member">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//www.researchobject.org/ro-crate/community">RO-Crate Community</a></td>
             </tr></tbody>
             </table>
         </div>
-            </div>
+
+        </div>
         <hr/><br/><br/>
-            <div>
-                <h3><a href="https://orcid.org/0000-0002-5934-8998">Go to: </a> Bram Ulrichts</h3>
-                
-                
-                
-                
+           <div>
+            <h3><a href="https://orcid.org/0000-0002-5934-8998">Go to: </a> Bram Ulrichts</h3>
+            
+            
+            
+            
         <div id="https://orcid.org/0000-0002-5934-8998">
             
             <table class="table metadata table-striped" >
@@ -5163,28 +5415,29 @@ While providing the formal specification for RO-Crate, this document also aims t
             <th style="text-align:left;" class="prop">@id</th>
             <td style='text-align:left'><a href="https://orcid.org/0000-0002-5934-8998">https://orcid.org/0000-0002-5934-8998</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">name</th>
+            <th style="text-align:left;" class="prop">name<span>&nbsp;</span><a href="http://schema.org/name">[?]</a></th>
             <td style='text-align:left'><span>Bram Ulrichts</span></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">@type</th>
             <td style='text-align:left'><span>Person</span></td>
             </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
-            <th style="text-align:left;" class="prop">author</th>
+            <th style="text-align:left;" class="prop">author<span>&nbsp;</span><a href="http://schema.org/author">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//w3id.org/ro/crate/1.2">RO-Crate specification 1.2</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">member</th>
+            <th style="text-align:left;" class="prop">member<span>&nbsp;</span><a href="http://schema.org/member">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//www.researchobject.org/ro-crate/community">RO-Crate Community</a></td>
             </tr></tbody>
             </table>
         </div>
-            </div>
+
+        </div>
         <hr/><br/><br/>
-            <div>
-                <h3><a href="https://orcid.org/0000-0001-9261-8390">Go to: </a> Michael Falk</h3>
-                
-                
-                
-                
+           <div>
+            <h3><a href="https://orcid.org/0000-0001-9261-8390">Go to: </a> Michael Falk</h3>
+            
+            
+            
+            
         <div id="https://orcid.org/0000-0001-9261-8390">
             
             <table class="table metadata table-striped" >
@@ -5192,28 +5445,29 @@ While providing the formal specification for RO-Crate, this document also aims t
             <th style="text-align:left;" class="prop">@id</th>
             <td style='text-align:left'><a href="https://orcid.org/0000-0001-9261-8390">https://orcid.org/0000-0001-9261-8390</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">name</th>
+            <th style="text-align:left;" class="prop">name<span>&nbsp;</span><a href="http://schema.org/name">[?]</a></th>
             <td style='text-align:left'><span>Michael Falk</span></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">@type</th>
             <td style='text-align:left'><span>Person</span></td>
             </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
-            <th style="text-align:left;" class="prop">author</th>
+            <th style="text-align:left;" class="prop">author<span>&nbsp;</span><a href="http://schema.org/author">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//w3id.org/ro/crate/1.2">RO-Crate specification 1.2</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">member</th>
+            <th style="text-align:left;" class="prop">member<span>&nbsp;</span><a href="http://schema.org/member">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//www.researchobject.org/ro-crate/community">RO-Crate Community</a></td>
             </tr></tbody>
             </table>
         </div>
-            </div>
+
+        </div>
         <hr/><br/><br/>
-            <div>
-                <h3><a href="https://orcid.org/0000-0002-0035-6475">Go to: </a> Eli Chadwick</h3>
-                
-                
-                
-                
+           <div>
+            <h3><a href="https://orcid.org/0000-0002-0035-6475">Go to: </a> Eli Chadwick</h3>
+            
+            
+            
+            
         <div id="https://orcid.org/0000-0002-0035-6475">
             
             <table class="table metadata table-striped" >
@@ -5221,28 +5475,29 @@ While providing the formal specification for RO-Crate, this document also aims t
             <th style="text-align:left;" class="prop">@id</th>
             <td style='text-align:left'><a href="https://orcid.org/0000-0002-0035-6475">https://orcid.org/0000-0002-0035-6475</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">name</th>
+            <th style="text-align:left;" class="prop">name<span>&nbsp;</span><a href="http://schema.org/name">[?]</a></th>
             <td style='text-align:left'><span>Eli Chadwick</span></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">@type</th>
             <td style='text-align:left'><span>Person</span></td>
             </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
-            <th style="text-align:left;" class="prop">author</th>
+            <th style="text-align:left;" class="prop">author<span>&nbsp;</span><a href="http://schema.org/author">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//w3id.org/ro/crate/1.2">RO-Crate specification 1.2</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">member</th>
+            <th style="text-align:left;" class="prop">member<span>&nbsp;</span><a href="http://schema.org/member">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//www.researchobject.org/ro-crate/community">RO-Crate Community</a></td>
             </tr></tbody>
             </table>
         </div>
-            </div>
+
+        </div>
         <hr/><br/><br/>
-            <div>
-                <h3><a href="https://orcid.org/0000-0001-9447-460X">Go to: </a> Daniel Bauer</h3>
-                
-                
-                
-                
+           <div>
+            <h3><a href="https://orcid.org/0000-0001-9447-460X">Go to: </a> Daniel Bauer</h3>
+            
+            
+            
+            
         <div id="https://orcid.org/0000-0001-9447-460X">
             
             <table class="table metadata table-striped" >
@@ -5250,28 +5505,29 @@ While providing the formal specification for RO-Crate, this document also aims t
             <th style="text-align:left;" class="prop">@id</th>
             <td style='text-align:left'><a href="https://orcid.org/0000-0001-9447-460X">https://orcid.org/0000-0001-9447-460X</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">name</th>
+            <th style="text-align:left;" class="prop">name<span>&nbsp;</span><a href="http://schema.org/name">[?]</a></th>
             <td style='text-align:left'><span>Daniel Bauer</span></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">@type</th>
             <td style='text-align:left'><span>Person</span></td>
             </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
-            <th style="text-align:left;" class="prop">author</th>
+            <th style="text-align:left;" class="prop">author<span>&nbsp;</span><a href="http://schema.org/author">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//w3id.org/ro/crate/1.2">RO-Crate specification 1.2</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">member</th>
+            <th style="text-align:left;" class="prop">member<span>&nbsp;</span><a href="http://schema.org/member">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//www.researchobject.org/ro-crate/community">RO-Crate Community</a></td>
             </tr></tbody>
             </table>
         </div>
-            </div>
+
+        </div>
         <hr/><br/><br/>
-            <div>
-                <h3><a href="https://orcid.org/0000-0001-7760-1240">Go to: </a> James Love</h3>
-                
-                
-                
-                
+           <div>
+            <h3><a href="https://orcid.org/0000-0001-7760-1240">Go to: </a> James Love</h3>
+            
+            
+            
+            
         <div id="https://orcid.org/0000-0001-7760-1240">
             
             <table class="table metadata table-striped" >
@@ -5279,28 +5535,29 @@ While providing the formal specification for RO-Crate, this document also aims t
             <th style="text-align:left;" class="prop">@id</th>
             <td style='text-align:left'><a href="https://orcid.org/0000-0001-7760-1240">https://orcid.org/0000-0001-7760-1240</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">name</th>
+            <th style="text-align:left;" class="prop">name<span>&nbsp;</span><a href="http://schema.org/name">[?]</a></th>
             <td style='text-align:left'><span>James Love</span></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">@type</th>
             <td style='text-align:left'><span>Person</span></td>
             </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
-            <th style="text-align:left;" class="prop">author</th>
+            <th style="text-align:left;" class="prop">author<span>&nbsp;</span><a href="http://schema.org/author">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//w3id.org/ro/crate/1.2">RO-Crate specification 1.2</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">member</th>
+            <th style="text-align:left;" class="prop">member<span>&nbsp;</span><a href="http://schema.org/member">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//www.researchobject.org/ro-crate/community">RO-Crate Community</a></td>
             </tr></tbody>
             </table>
         </div>
-            </div>
+
+        </div>
         <hr/><br/><br/>
-            <div>
-                <h3><a href="https://orcid.org/0000-0001-9925-1560">Go to: </a> Eleni Adamidi</h3>
-                
-                
-                
-                
+           <div>
+            <h3><a href="https://orcid.org/0000-0001-9925-1560">Go to: </a> Eleni Adamidi</h3>
+            
+            
+            
+            
         <div id="https://orcid.org/0000-0001-9925-1560">
             
             <table class="table metadata table-striped" >
@@ -5308,28 +5565,29 @@ While providing the formal specification for RO-Crate, this document also aims t
             <th style="text-align:left;" class="prop">@id</th>
             <td style='text-align:left'><a href="https://orcid.org/0000-0001-9925-1560">https://orcid.org/0000-0001-9925-1560</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">name</th>
+            <th style="text-align:left;" class="prop">name<span>&nbsp;</span><a href="http://schema.org/name">[?]</a></th>
             <td style='text-align:left'><span>Eleni Adamidi</span></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">@type</th>
             <td style='text-align:left'><span>Person</span></td>
             </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
-            <th style="text-align:left;" class="prop">author</th>
+            <th style="text-align:left;" class="prop">author<span>&nbsp;</span><a href="http://schema.org/author">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//w3id.org/ro/crate/1.2">RO-Crate specification 1.2</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">member</th>
+            <th style="text-align:left;" class="prop">member<span>&nbsp;</span><a href="http://schema.org/member">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//www.researchobject.org/ro-crate/community">RO-Crate Community</a></td>
             </tr></tbody>
             </table>
         </div>
-            </div>
+
+        </div>
         <hr/><br/><br/>
-            <div>
-                <h3><a href="https://orcid.org/0000-0003-4028-811X">Go to: </a> Josh Moore</h3>
-                
-                
-                
-                
+           <div>
+            <h3><a href="https://orcid.org/0000-0003-4028-811X">Go to: </a> Josh Moore</h3>
+            
+            
+            
+            
         <div id="https://orcid.org/0000-0003-4028-811X">
             
             <table class="table metadata table-striped" >
@@ -5337,28 +5595,29 @@ While providing the formal specification for RO-Crate, this document also aims t
             <th style="text-align:left;" class="prop">@id</th>
             <td style='text-align:left'><a href="https://orcid.org/0000-0003-4028-811X">https://orcid.org/0000-0003-4028-811X</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">name</th>
+            <th style="text-align:left;" class="prop">name<span>&nbsp;</span><a href="http://schema.org/name">[?]</a></th>
             <td style='text-align:left'><span>Josh Moore</span></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">@type</th>
             <td style='text-align:left'><span>Person</span></td>
             </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
-            <th style="text-align:left;" class="prop">author</th>
+            <th style="text-align:left;" class="prop">author<span>&nbsp;</span><a href="http://schema.org/author">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//w3id.org/ro/crate/1.2">RO-Crate specification 1.2</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">member</th>
+            <th style="text-align:left;" class="prop">member<span>&nbsp;</span><a href="http://schema.org/member">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//www.researchobject.org/ro-crate/community">RO-Crate Community</a></td>
             </tr></tbody>
             </table>
         </div>
-            </div>
+
+        </div>
         <hr/><br/><br/>
-            <div>
-                <h3><a href="https://orcid.org/0000-0003-2196-5015">Go to: </a> Lars Schöbitz</h3>
-                
-                
-                
-                
+           <div>
+            <h3><a href="https://orcid.org/0000-0003-2196-5015">Go to: </a> Lars Schöbitz</h3>
+            
+            
+            
+            
         <div id="https://orcid.org/0000-0003-2196-5015">
             
             <table class="table metadata table-striped" >
@@ -5366,28 +5625,29 @@ While providing the formal specification for RO-Crate, this document also aims t
             <th style="text-align:left;" class="prop">@id</th>
             <td style='text-align:left'><a href="https://orcid.org/0000-0003-2196-5015">https://orcid.org/0000-0003-2196-5015</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">name</th>
+            <th style="text-align:left;" class="prop">name<span>&nbsp;</span><a href="http://schema.org/name">[?]</a></th>
             <td style='text-align:left'><span>Lars Schöbitz</span></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">@type</th>
             <td style='text-align:left'><span>Person</span></td>
             </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
-            <th style="text-align:left;" class="prop">author</th>
+            <th style="text-align:left;" class="prop">author<span>&nbsp;</span><a href="http://schema.org/author">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//w3id.org/ro/crate/1.2">RO-Crate specification 1.2</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">member</th>
+            <th style="text-align:left;" class="prop">member<span>&nbsp;</span><a href="http://schema.org/member">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//www.researchobject.org/ro-crate/community">RO-Crate Community</a></td>
             </tr></tbody>
             </table>
         </div>
-            </div>
+
+        </div>
         <hr/><br/><br/>
-            <div>
-                <h3><a href="https://orcid.org/0009-0002-6541-4637">Go to: </a> Andreas Meier</h3>
-                
-                
-                
-                
+           <div>
+            <h3><a href="https://orcid.org/0009-0002-6541-4637">Go to: </a> Andreas Meier</h3>
+            
+            
+            
+            
         <div id="https://orcid.org/0009-0002-6541-4637">
             
             <table class="table metadata table-striped" >
@@ -5395,28 +5655,29 @@ While providing the formal specification for RO-Crate, this document also aims t
             <th style="text-align:left;" class="prop">@id</th>
             <td style='text-align:left'><a href="https://orcid.org/0009-0002-6541-4637">https://orcid.org/0009-0002-6541-4637</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">name</th>
+            <th style="text-align:left;" class="prop">name<span>&nbsp;</span><a href="http://schema.org/name">[?]</a></th>
             <td style='text-align:left'><span>Andreas Meier</span></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">@type</th>
             <td style='text-align:left'><span>Person</span></td>
             </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
-            <th style="text-align:left;" class="prop">author</th>
+            <th style="text-align:left;" class="prop">author<span>&nbsp;</span><a href="http://schema.org/author">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//w3id.org/ro/crate/1.2">RO-Crate specification 1.2</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">member</th>
+            <th style="text-align:left;" class="prop">member<span>&nbsp;</span><a href="http://schema.org/member">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//www.researchobject.org/ro-crate/community">RO-Crate Community</a></td>
             </tr></tbody>
             </table>
         </div>
-            </div>
+
+        </div>
         <hr/><br/><br/>
-            <div>
-                <h3><a href="https://orcid.org/0009-0002-8209-1999">Go to: </a> Juan Fuentes</h3>
-                
-                
-                
-                
+           <div>
+            <h3><a href="https://orcid.org/0009-0002-8209-1999">Go to: </a> Juan Fuentes</h3>
+            
+            
+            
+            
         <div id="https://orcid.org/0009-0002-8209-1999">
             
             <table class="table metadata table-striped" >
@@ -5424,28 +5685,29 @@ While providing the formal specification for RO-Crate, this document also aims t
             <th style="text-align:left;" class="prop">@id</th>
             <td style='text-align:left'><a href="https://orcid.org/0009-0002-8209-1999">https://orcid.org/0009-0002-8209-1999</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">name</th>
+            <th style="text-align:left;" class="prop">name<span>&nbsp;</span><a href="http://schema.org/name">[?]</a></th>
             <td style='text-align:left'><span>Juan Fuentes</span></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">@type</th>
             <td style='text-align:left'><span>Person</span></td>
             </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
-            <th style="text-align:left;" class="prop">author</th>
+            <th style="text-align:left;" class="prop">author<span>&nbsp;</span><a href="http://schema.org/author">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//w3id.org/ro/crate/1.2">RO-Crate specification 1.2</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">member</th>
+            <th style="text-align:left;" class="prop">member<span>&nbsp;</span><a href="http://schema.org/member">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//www.researchobject.org/ro-crate/community">RO-Crate Community</a></td>
             </tr></tbody>
             </table>
         </div>
-            </div>
+
+        </div>
         <hr/><br/><br/>
-            <div>
-                <h3><a href="https://orcid.org/0000-0001-7218-0176">Go to: </a> Edan Bainglass</h3>
-                
-                
-                
-                
+           <div>
+            <h3><a href="https://orcid.org/0000-0001-7218-0176">Go to: </a> Edan Bainglass</h3>
+            
+            
+            
+            
         <div id="https://orcid.org/0000-0001-7218-0176">
             
             <table class="table metadata table-striped" >
@@ -5453,28 +5715,29 @@ While providing the formal specification for RO-Crate, this document also aims t
             <th style="text-align:left;" class="prop">@id</th>
             <td style='text-align:left'><a href="https://orcid.org/0000-0001-7218-0176">https://orcid.org/0000-0001-7218-0176</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">name</th>
+            <th style="text-align:left;" class="prop">name<span>&nbsp;</span><a href="http://schema.org/name">[?]</a></th>
             <td style='text-align:left'><span>Edan Bainglass</span></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">@type</th>
             <td style='text-align:left'><span>Person</span></td>
             </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
-            <th style="text-align:left;" class="prop">author</th>
+            <th style="text-align:left;" class="prop">author<span>&nbsp;</span><a href="http://schema.org/author">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//w3id.org/ro/crate/1.2">RO-Crate specification 1.2</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">member</th>
+            <th style="text-align:left;" class="prop">member<span>&nbsp;</span><a href="http://schema.org/member">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//www.researchobject.org/ro-crate/community">RO-Crate Community</a></td>
             </tr></tbody>
             </table>
         </div>
-            </div>
+
+        </div>
         <hr/><br/><br/>
-            <div>
-                <h3><a href="https://orcid.org/0000-0003-3482-0325">Go to: </a> Balazs E. Pataki</h3>
-                
-                
-                
-                
+           <div>
+            <h3><a href="https://orcid.org/0000-0003-3482-0325">Go to: </a> Balazs E. Pataki</h3>
+            
+            
+            
+            
         <div id="https://orcid.org/0000-0003-3482-0325">
             
             <table class="table metadata table-striped" >
@@ -5482,28 +5745,29 @@ While providing the formal specification for RO-Crate, this document also aims t
             <th style="text-align:left;" class="prop">@id</th>
             <td style='text-align:left'><a href="https://orcid.org/0000-0003-3482-0325">https://orcid.org/0000-0003-3482-0325</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">name</th>
+            <th style="text-align:left;" class="prop">name<span>&nbsp;</span><a href="http://schema.org/name">[?]</a></th>
             <td style='text-align:left'><span>Balazs E. Pataki</span></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">@type</th>
             <td style='text-align:left'><span>Person</span></td>
             </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
-            <th style="text-align:left;" class="prop">author</th>
+            <th style="text-align:left;" class="prop">author<span>&nbsp;</span><a href="http://schema.org/author">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//w3id.org/ro/crate/1.2">RO-Crate specification 1.2</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">member</th>
+            <th style="text-align:left;" class="prop">member<span>&nbsp;</span><a href="http://schema.org/member">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//www.researchobject.org/ro-crate/community">RO-Crate Community</a></td>
             </tr></tbody>
             </table>
         </div>
-            </div>
+
+        </div>
         <hr/><br/><br/>
-            <div>
-                <h3><a href="https://doi.org/10.3233/DS-210053">Go to: </a> Packaging research artefacts with RO-Crate</h3>
-                
-                
-                
-                
+           <div>
+            <h3><a href="https://doi.org/10.3233/DS-210053">Go to: </a> Packaging research artefacts with RO-Crate</h3>
+            
+            
+            
+            
         <div id="https://doi.org/10.3233/DS-210053">
             
             <table class="table metadata table-striped" >
@@ -5511,19 +5775,19 @@ While providing the formal specification for RO-Crate, this document also aims t
             <th style="text-align:left;" class="prop">@id</th>
             <td style='text-align:left'><a href="https://doi.org/10.3233/DS-210053">https://doi.org/10.3233/DS-210053</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">name</th>
+            <th style="text-align:left;" class="prop">name<span>&nbsp;</span><a href="http://schema.org/name">[?]</a></th>
             <td style='text-align:left'><span>Packaging research artefacts with RO-Crate</span></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">@type</th>
             <td style='text-align:left'><span>ScholarlyArticle</span></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">isPartOf</th>
+            <th style="text-align:left;" class="prop">isPartOf<span>&nbsp;</span><a href="http://schema.org/isPartOf">[?]</a></th>
             <td style='text-align:left'><a href="#http%3A//datasciencehub.net/">Data Science</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">datePublished</th>
+            <th style="text-align:left;" class="prop">datePublished<span>&nbsp;</span><a href="http://schema.org/datePublished">[?]</a></th>
             <td style='text-align:left'><span>2022-01-04T13:00:00Z</span></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">author</th>
+            <th style="text-align:left;" class="prop">author<span>&nbsp;</span><a href="http://schema.org/author">[?]</a></th>
             <td style='text-align:left'><ul>
                         <li><a href="#https%3A//orcid.org/0000-0001-9842-9718">Stian Soiland-Reyes</a></li>
                         
@@ -5558,22 +5822,23 @@ While providing the formal specification for RO-Crate, this document also aims t
                         <li><a href="#https%3A//orcid.org/0000-0003-1219-2137">Carole Goble</a></li>
                         </ul></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">mainEntityOfPage</th>
+            <th style="text-align:left;" class="prop">mainEntityOfPage<span>&nbsp;</span><a href="http://schema.org/mainEntityOfPage">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//w3id.org/ro/doi/10.5281/zenodo.5146227">Packaging research artefacts with RO-Crate (RO-Crate)</a></td>
             </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
-            <th style="text-align:left;" class="prop">citation</th>
+            <th style="text-align:left;" class="prop">citation<span>&nbsp;</span><a href="http://schema.org/citation">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//w3id.org/ro/crate/1.2">RO-Crate specification 1.2</a></td>
             </tr></tbody>
             </table>
         </div>
-            </div>
+
+        </div>
         <hr/><br/><br/>
-            <div>
-                <h3><a href="https://www.researchobject.org/ro-crate/1.2/">Go to: </a> RO-Crate Metadata Specification 1.2</h3>
-                
-                
-                
-                
+           <div>
+            <h3><a href="https://www.researchobject.org/ro-crate/1.2/">Go to: </a> RO-Crate Metadata Specification 1.2</h3>
+            
+            
+            
+            
         <div id="https://www.researchobject.org/ro-crate/1.2/">
             
             <table class="table metadata table-striped" >
@@ -5581,7 +5846,7 @@ While providing the formal specification for RO-Crate, this document also aims t
             <th style="text-align:left;" class="prop">@id</th>
             <td style='text-align:left'><a href="https://www.researchobject.org/ro-crate/1.2/">https://www.researchobject.org/ro-crate/1.2/</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">name</th>
+            <th style="text-align:left;" class="prop">name<span>&nbsp;</span><a href="http://schema.org/name">[?]</a></th>
             <td style='text-align:left'><span>RO-Crate Metadata Specification 1.2</span></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">@type</th>
@@ -5591,30 +5856,30 @@ While providing the formal specification for RO-Crate, this document also aims t
                         <li><span>File</span></li>
                         </ul></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">encodingFormat</th>
+            <th style="text-align:left;" class="prop">encodingFormat<span>&nbsp;</span><a href="http://schema.org/encodingFormat">[?]</a></th>
             <td style='text-align:left'><ul>
                         <li><span>text/html</span></li>
                         
                         <li><a href="#https%3A//www.nationalarchives.gov.uk/PRONOM/fmt/471">Hypertext Markup Language 5</a></li>
                         </ul></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">encoding</th>
+            <th style="text-align:left;" class="prop">encoding<span>&nbsp;</span><a href="http://schema.org/encoding">[?]</a></th>
             <td style='text-align:left'><ul>
                         <li><a href="#https%3A//github.com/ResearchObject/ro-crate/releases/download/1.2.0/ro-crate-1.2.0.html">RO-Crate Metadata Specification 1.2 (single-page HTML)</a></li>
                         
                         <li><a href="#https%3A//github.com/ResearchObject/ro-crate/releases/download/1.2.0/ro-crate-1.2.0.pdf">RO-Crate Metadata Specification 1.2 (PDF)</a></li>
                         </ul></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">identifier</th>
+            <th style="text-align:left;" class="prop">identifier<span>&nbsp;</span><a href="http://schema.org/identifier">[?]</a></th>
             <td style='text-align:left'>undefined: doi:10.5281/zenodo.13751027</td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">sameAs</th>
+            <th style="text-align:left;" class="prop">sameAs<span>&nbsp;</span><a href="http://schema.org/sameAs">[?]</a></th>
             <td style='text-align:left'><a href="https://zenodo.org/record/13751027/files/ro-crate-1.2.0.html">https://zenodo.org/record/13751027/files/ro-crate-1.2.0.html</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">version</th>
+            <th style="text-align:left;" class="prop">version<span>&nbsp;</span><a href="http://schema.org/version">[?]</a></th>
             <td style='text-align:left'><span>1.2.0</span></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">hasPart</th>
+            <th style="text-align:left;" class="prop">hasPart<span>&nbsp;</span><a href="http://schema.org/hasPart">[?]</a></th>
             <td style='text-align:left'><ul>
                         <li><a href="#https%3A//www.researchobject.org/ro-crate/1.2/introduction.html">Introduction</a></li>
                         
@@ -5649,10 +5914,10 @@ While providing the formal specification for RO-Crate, this document also aims t
                         <li><a href="#https%3A//www.researchobject.org/ro-crate/1.2/appendix/relative-uris.html">Handling relative URI references</a></li>
                         </ul></td>
             </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
-            <th style="text-align:left;" class="prop">hasPart</th>
+            <th style="text-align:left;" class="prop">hasPart<span>&nbsp;</span><a href="http://schema.org/hasPart">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//w3id.org/ro/crate/1.2">RO-Crate specification 1.2</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">isBasedOn</th>
+            <th style="text-align:left;" class="prop">isBasedOn<span>&nbsp;</span><a href="http://schema.org/isBasedOn">[?]</a></th>
             <td style='text-align:left'><ul>
                         <li><a href="#https%3A//github.com/ResearchObject/ro-crate/releases/download/1.2.0/ro-crate-1.2.0.html">RO-Crate Metadata Specification 1.2 (single-page HTML)</a></li>
                         
@@ -5661,14 +5926,15 @@ While providing the formal specification for RO-Crate, this document also aims t
             </tr></tbody>
             </table>
         </div>
-            </div>
+
+        </div>
         <hr/><br/><br/>
-            <div>
-                <h3><a href="https://w3id.org/ro/crate/1.2/context">Go to: </a> RO-Crate JSON-LD Context</h3>
-                
-                
-                
-                
+           <div>
+            <h3><a href="https://w3id.org/ro/crate/1.2/context">Go to: </a> RO-Crate JSON-LD Context</h3>
+            
+            
+            
+            
         <div id="https://w3id.org/ro/crate/1.2/context">
             
             <table class="table metadata table-striped" >
@@ -5676,19 +5942,19 @@ While providing the formal specification for RO-Crate, this document also aims t
             <th style="text-align:left;" class="prop">@id</th>
             <td style='text-align:left'><a href="https://w3id.org/ro/crate/1.2/context">https://w3id.org/ro/crate/1.2/context</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">name</th>
+            <th style="text-align:left;" class="prop">name<span>&nbsp;</span><a href="http://schema.org/name">[?]</a></th>
             <td style='text-align:left'><span>RO-Crate JSON-LD Context</span></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">@type</th>
             <td style='text-align:left'><span>File</span></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">encodingFormat</th>
+            <th style="text-align:left;" class="prop">encodingFormat<span>&nbsp;</span><a href="http://schema.org/encodingFormat">[?]</a></th>
             <td style='text-align:left'><span>application/ld+json</span></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">conformsTo</th>
+            <th style="text-align:left;" class="prop">conformsTo<span>&nbsp;</span><a href="http://purl.org/dc/terms/conformsTo">[?]</a></th>
             <td style='text-align:left'><a href="#http%3A//www.w3.org/ns/json-ld%23Context">JSON-LD Context</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">isBasedOn</th>
+            <th style="text-align:left;" class="prop">isBasedOn<span>&nbsp;</span><a href="http://schema.org/isBasedOn">[?]</a></th>
             <td style='text-align:left'><ul>
                         <li><a href="#https%3A//schema.org/docs/releases.html%23v22.0">Schema.org vocabulary (http prefix)</a></li>
                         
@@ -5699,10 +5965,10 @@ While providing the formal specification for RO-Crate, this document also aims t
                         <li><a href="#https%3A//bioschemas.org/profiles/FormalParameter/1.0-RELEASE">FormalParameter Profile</a></li>
                         </ul></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">license</th>
+            <th style="text-align:left;" class="prop">license<span>&nbsp;</span><a href="http://schema.org/license">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//creativecommons.org/publicdomain/zero/1.0/">Creative Commons Zero v1.0 Universal</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">sameAs</th>
+            <th style="text-align:left;" class="prop">sameAs<span>&nbsp;</span><a href="http://schema.org/sameAs">[?]</a></th>
             <td style='text-align:left'><ul>
                         <li><a href="https://zenodo.org/record/13751027/files/ro-crate-context-1.2.0.jsonld">https://zenodo.org/record/13751027/files/ro-crate-context-1.2.0.jsonld</a></li>
                         
@@ -5711,22 +5977,23 @@ While providing the formal specification for RO-Crate, this document also aims t
                         <li><a href="https://www.researchobject.org/ro-crate/1.2/context.jsonld">https://www.researchobject.org/ro-crate/1.2/context.jsonld</a></li>
                         </ul></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">version</th>
+            <th style="text-align:left;" class="prop">version<span>&nbsp;</span><a href="http://schema.org/version">[?]</a></th>
             <td style='text-align:left'><span>1.2.0</span></td>
             </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
-            <th style="text-align:left;" class="prop">hasPart</th>
+            <th style="text-align:left;" class="prop">hasPart<span>&nbsp;</span><a href="http://schema.org/hasPart">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//w3id.org/ro/crate/1.2">RO-Crate specification 1.2</a></td>
             </tr></tbody>
             </table>
         </div>
-            </div>
+
+        </div>
         <hr/><br/><br/>
-            <div>
-                <h3><a href="https://www.researchobject.org/ro-crate/1.2/examples/rainfall-1.2.0/">Go to: </a> Example dataset for RO-Crate specification</h3>
-                
-                
-                
-                
+           <div>
+            <h3><a href="https://www.researchobject.org/ro-crate/1.2/examples/rainfall-1.2.0/">Go to: </a> Example dataset for RO-Crate specification</h3>
+            
+            
+            
+            
         <div id="https://www.researchobject.org/ro-crate/1.2/examples/rainfall-1.2.0/">
             
             <table class="table metadata table-striped" >
@@ -5734,41 +6001,42 @@ While providing the formal specification for RO-Crate, this document also aims t
             <th style="text-align:left;" class="prop">@id</th>
             <td style='text-align:left'><a href="https://www.researchobject.org/ro-crate/1.2/examples/rainfall-1.2.0/">https://www.researchobject.org/ro-crate/1.2/examples/rainfall-1.2.0/</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">name</th>
+            <th style="text-align:left;" class="prop">name<span>&nbsp;</span><a href="http://schema.org/name">[?]</a></th>
             <td style='text-align:left'><span>Example dataset for RO-Crate specification</span></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">@type</th>
             <td style='text-align:left'><span>Dataset</span></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">conformsTo</th>
+            <th style="text-align:left;" class="prop">conformsTo<span>&nbsp;</span><a href="http://purl.org/dc/terms/conformsTo">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//w3id.org/ro/crate/1.2">RO-Crate specification 1.2</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">license</th>
+            <th style="text-align:left;" class="prop">license<span>&nbsp;</span><a href="http://schema.org/license">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//creativecommons.org/publicdomain/zero/1.0/">Creative Commons Zero v1.0 Universal</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">subjectOf</th>
+            <th style="text-align:left;" class="prop">subjectOf<span>&nbsp;</span><a href="http://schema.org/subjectOf">[?]</a></th>
             <td style='text-align:left'><ul>
                         <li><a href="https://www.researchobject.org/ro-crate/1.2/examples/rainfall-1.2.0/ro-crate-metadata.json">https://www.researchobject.org/ro-crate/1.2/examples/rainfall-1.2.0/ro-crate-metadata.json</a></li>
                         
                         <li><a href="https://www.researchobject.org/ro-crate/1.2/examples/rainfall-1.2.0/ro-crate-preview.html">https://www.researchobject.org/ro-crate/1.2/examples/rainfall-1.2.0/ro-crate-preview.html</a></li>
                         </ul></td>
             </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
-            <th style="text-align:left;" class="prop">hasPart</th>
+            <th style="text-align:left;" class="prop">hasPart<span>&nbsp;</span><a href="http://schema.org/hasPart">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//w3id.org/ro/crate/1.2">RO-Crate specification 1.2</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">hasArtifact</th>
+            <th style="text-align:left;" class="prop">hasArtifact<span>&nbsp;</span><a href="http://www.w3.org/ns/dx/prof/hasArtifact">[?]</a></th>
             <td style='text-align:left'><a href="#%23example-rainfall">#example-rainfall</a></td>
             </tr></tbody>
             </table>
         </div>
-            </div>
+
+        </div>
         <hr/><br/><br/>
-            <div>
-                <h3><a href="https://github.com/ResearchObject/ro-crate/releases/download/1.2.0/ro-crate-1.2.0.html">Go to: </a> RO-Crate Metadata Specification 1.2 (single-page HTML)</h3>
-                
-                
-                
-                
+           <div>
+            <h3><a href="https://github.com/ResearchObject/ro-crate/releases/download/1.2.0/ro-crate-1.2.0.html">Go to: </a> RO-Crate Metadata Specification 1.2 (single-page HTML)</h3>
+            
+            
+            
+            
         <div id="https://github.com/ResearchObject/ro-crate/releases/download/1.2.0/ro-crate-1.2.0.html">
             
             <table class="table metadata table-striped" >
@@ -5776,20 +6044,20 @@ While providing the formal specification for RO-Crate, this document also aims t
             <th style="text-align:left;" class="prop">@id</th>
             <td style='text-align:left'><a href="https://github.com/ResearchObject/ro-crate/releases/download/1.2.0/ro-crate-1.2.0.html">https://github.com/ResearchObject/ro-crate/releases/download/1.2.0/ro-crate-1.2.0.html</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">name</th>
+            <th style="text-align:left;" class="prop">name<span>&nbsp;</span><a href="http://schema.org/name">[?]</a></th>
             <td style='text-align:left'><span>RO-Crate Metadata Specification 1.2 (single-page HTML)</span></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">@type</th>
             <td style='text-align:left'><span>CreativeWork</span></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">encodingFormat</th>
+            <th style="text-align:left;" class="prop">encodingFormat<span>&nbsp;</span><a href="http://schema.org/encodingFormat">[?]</a></th>
             <td style='text-align:left'><ul>
                         <li><span>text/html</span></li>
                         
                         <li><a href="#https%3A//www.nationalarchives.gov.uk/PRONOM/fmt/471">Hypertext Markup Language 5</a></li>
                         </ul></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">isBasedOn</th>
+            <th style="text-align:left;" class="prop">isBasedOn<span>&nbsp;</span><a href="http://schema.org/isBasedOn">[?]</a></th>
             <td style='text-align:left'><ul>
                         <li><a href="#https%3A//www.researchobject.org/ro-crate/1.2/">RO-Crate Metadata Specification 1.2</a></li>
                         
@@ -5828,31 +6096,32 @@ While providing the formal specification for RO-Crate, this document also aims t
                         <li><a href="#https%3A//www.researchobject.org/ro-crate/1.2/appendix/relative-uris.html">Handling relative URI references</a></li>
                         </ul></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">sameAs</th>
+            <th style="text-align:left;" class="prop">sameAs<span>&nbsp;</span><a href="http://schema.org/sameAs">[?]</a></th>
             <td style='text-align:left'><a href="https://zenodo.org/record/13751027/files/ro-crate-1.2.0.html">https://zenodo.org/record/13751027/files/ro-crate-1.2.0.html</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">version</th>
+            <th style="text-align:left;" class="prop">version<span>&nbsp;</span><a href="http://schema.org/version">[?]</a></th>
             <td style='text-align:left'><span>1.2.0</span></td>
             </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
-            <th style="text-align:left;" class="prop">hasPart</th>
+            <th style="text-align:left;" class="prop">hasPart<span>&nbsp;</span><a href="http://schema.org/hasPart">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//w3id.org/ro/crate/1.2">RO-Crate specification 1.2</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">encoding</th>
+            <th style="text-align:left;" class="prop">encoding<span>&nbsp;</span><a href="http://schema.org/encoding">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//www.researchobject.org/ro-crate/1.2/">RO-Crate Metadata Specification 1.2</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">hasArtifact</th>
+            <th style="text-align:left;" class="prop">hasArtifact<span>&nbsp;</span><a href="http://www.w3.org/ns/dx/prof/hasArtifact">[?]</a></th>
             <td style='text-align:left'><a href="#%23specification">#specification</a></td>
             </tr></tbody>
             </table>
         </div>
-            </div>
+
+        </div>
         <hr/><br/><br/>
-            <div>
-                <h3><a href="https://github.com/ResearchObject/ro-crate/releases/download/1.2.0/ro-crate-1.2.0.pdf">Go to: </a> RO-Crate Metadata Specification 1.2 (PDF)</h3>
-                
-                
-                
-                
+           <div>
+            <h3><a href="https://github.com/ResearchObject/ro-crate/releases/download/1.2.0/ro-crate-1.2.0.pdf">Go to: </a> RO-Crate Metadata Specification 1.2 (PDF)</h3>
+            
+            
+            
+            
         <div id="https://github.com/ResearchObject/ro-crate/releases/download/1.2.0/ro-crate-1.2.0.pdf">
             
             <table class="table metadata table-striped" >
@@ -5860,20 +6129,20 @@ While providing the formal specification for RO-Crate, this document also aims t
             <th style="text-align:left;" class="prop">@id</th>
             <td style='text-align:left'><a href="https://github.com/ResearchObject/ro-crate/releases/download/1.2.0/ro-crate-1.2.0.pdf">https://github.com/ResearchObject/ro-crate/releases/download/1.2.0/ro-crate-1.2.0.pdf</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">name</th>
+            <th style="text-align:left;" class="prop">name<span>&nbsp;</span><a href="http://schema.org/name">[?]</a></th>
             <td style='text-align:left'><span>RO-Crate Metadata Specification 1.2 (PDF)</span></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">@type</th>
             <td style='text-align:left'><span>CreativeWork</span></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">encodingFormat</th>
+            <th style="text-align:left;" class="prop">encodingFormat<span>&nbsp;</span><a href="http://schema.org/encodingFormat">[?]</a></th>
             <td style='text-align:left'><ul>
                         <li><span>application/pdf</span></li>
                         
                         <li><a href="#https%3A//www.nationalarchives.gov.uk/PRONOM/fmt/18">Acrobat PDF 1.4 - Portable Document Format</a></li>
                         </ul></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">isBasedOn</th>
+            <th style="text-align:left;" class="prop">isBasedOn<span>&nbsp;</span><a href="http://schema.org/isBasedOn">[?]</a></th>
             <td style='text-align:left'><ul>
                         <li><a href="#https%3A//www.researchobject.org/ro-crate/1.2/">RO-Crate Metadata Specification 1.2</a></li>
                         
@@ -5912,28 +6181,29 @@ While providing the formal specification for RO-Crate, this document also aims t
                         <li><a href="#https%3A//www.researchobject.org/ro-crate/1.2/appendix/relative-uris.html">Handling relative URI references</a></li>
                         </ul></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">sameAs</th>
+            <th style="text-align:left;" class="prop">sameAs<span>&nbsp;</span><a href="http://schema.org/sameAs">[?]</a></th>
             <td style='text-align:left'><a href="https://zenodo.org/record/13751027/files/ro-crate-1.2.pdf">https://zenodo.org/record/13751027/files/ro-crate-1.2.pdf</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">version</th>
+            <th style="text-align:left;" class="prop">version<span>&nbsp;</span><a href="http://schema.org/version">[?]</a></th>
             <td style='text-align:left'><span>1.2.0</span></td>
             </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
-            <th style="text-align:left;" class="prop">hasPart</th>
+            <th style="text-align:left;" class="prop">hasPart<span>&nbsp;</span><a href="http://schema.org/hasPart">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//w3id.org/ro/crate/1.2">RO-Crate specification 1.2</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">encoding</th>
+            <th style="text-align:left;" class="prop">encoding<span>&nbsp;</span><a href="http://schema.org/encoding">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//www.researchobject.org/ro-crate/1.2/">RO-Crate Metadata Specification 1.2</a></td>
             </tr></tbody>
             </table>
         </div>
-            </div>
+
+        </div>
         <hr/><br/><br/>
-            <div>
-                <h3><a href="http://www.w3.org/ns/dx/prof#ResourceDescriptor">Go to: </a> Resource descriptor</h3>
-                
-                
-                
-                
+           <div>
+            <h3><a href="http://www.w3.org/ns/dx/prof#ResourceDescriptor">Go to: </a> Resource descriptor</h3>
+            
+            
+            
+            
         <div id="http://www.w3.org/ns/dx/prof#ResourceDescriptor">
             
             <table class="table metadata table-striped" >
@@ -5941,7 +6211,7 @@ While providing the formal specification for RO-Crate, this document also aims t
             <th style="text-align:left;" class="prop">@id</th>
             <td style='text-align:left'><a href="http://www.w3.org/ns/dx/prof#ResourceDescriptor">http://www.w3.org/ns/dx/prof#ResourceDescriptor</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">name</th>
+            <th style="text-align:left;" class="prop">name<span>&nbsp;</span><a href="http://schema.org/name">[?]</a></th>
             <td style='text-align:left'><span>Resource descriptor</span></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">@type</th>
@@ -5951,28 +6221,29 @@ While providing the formal specification for RO-Crate, this document also aims t
                         <li><span>Class</span></li>
                         </ul></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">inDefinedTermSet</th>
+            <th style="text-align:left;" class="prop">inDefinedTermSet<span>&nbsp;</span><a href="http://schema.org/inDefinedTermSet">[?]</a></th>
             <td style='text-align:left'><a href="#http%3A//www.w3.org/ns/dx/prof">Profiles Vocabulary</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">sameAs</th>
+            <th style="text-align:left;" class="prop">sameAs<span>&nbsp;</span><a href="http://schema.org/sameAs">[?]</a></th>
             <td style='text-align:left'><a href="https://www.w3.org/TR/2019/NOTE-dx-prof-20191218/#Class:ResourceDescriptor">https://www.w3.org/TR/2019/NOTE-dx-prof-20191218/#Class:ResourceDescriptor</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">termCode</th>
+            <th style="text-align:left;" class="prop">termCode<span>&nbsp;</span><a href="http://schema.org/termCode">[?]</a></th>
             <td style='text-align:left'><span>ResourceDescriptor</span></td>
             </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
-            <th style="text-align:left;" class="prop">hasPart</th>
+            <th style="text-align:left;" class="prop">hasPart<span>&nbsp;</span><a href="http://schema.org/hasPart">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//w3id.org/ro/crate/1.2">RO-Crate specification 1.2</a></td>
             </tr></tbody>
             </table>
         </div>
-            </div>
+
+        </div>
         <hr/><br/><br/>
-            <div>
-                <h3><a href="http://www.w3.org/ns/dx/prof#ResourceRole">Go to: </a> Resource role</h3>
-                
-                
-                
-                
+           <div>
+            <h3><a href="http://www.w3.org/ns/dx/prof#ResourceRole">Go to: </a> Resource role</h3>
+            
+            
+            
+            
         <div id="http://www.w3.org/ns/dx/prof#ResourceRole">
             
             <table class="table metadata table-striped" >
@@ -5980,7 +6251,7 @@ While providing the formal specification for RO-Crate, this document also aims t
             <th style="text-align:left;" class="prop">@id</th>
             <td style='text-align:left'><a href="http://www.w3.org/ns/dx/prof#ResourceRole">http://www.w3.org/ns/dx/prof#ResourceRole</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">name</th>
+            <th style="text-align:left;" class="prop">name<span>&nbsp;</span><a href="http://schema.org/name">[?]</a></th>
             <td style='text-align:left'><span>Resource role</span></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">@type</th>
@@ -5990,28 +6261,29 @@ While providing the formal specification for RO-Crate, this document also aims t
                         <li><span>Class</span></li>
                         </ul></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">inDefinedTermSet</th>
+            <th style="text-align:left;" class="prop">inDefinedTermSet<span>&nbsp;</span><a href="http://schema.org/inDefinedTermSet">[?]</a></th>
             <td style='text-align:left'><a href="#http%3A//www.w3.org/ns/dx/prof">Profiles Vocabulary</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">sameAs</th>
+            <th style="text-align:left;" class="prop">sameAs<span>&nbsp;</span><a href="http://schema.org/sameAs">[?]</a></th>
             <td style='text-align:left'><a href="https://www.w3.org/TR/2019/NOTE-dx-prof-20191218/#Class:ResourceRole">https://www.w3.org/TR/2019/NOTE-dx-prof-20191218/#Class:ResourceRole</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">termCode</th>
+            <th style="text-align:left;" class="prop">termCode<span>&nbsp;</span><a href="http://schema.org/termCode">[?]</a></th>
             <td style='text-align:left'><span>ResourceRole</span></td>
             </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
-            <th style="text-align:left;" class="prop">hasPart</th>
+            <th style="text-align:left;" class="prop">hasPart<span>&nbsp;</span><a href="http://schema.org/hasPart">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//w3id.org/ro/crate/1.2">RO-Crate specification 1.2</a></td>
             </tr></tbody>
             </table>
         </div>
-            </div>
+
+        </div>
         <hr/><br/><br/>
-            <div>
-                <h3><a href="http://www.w3.org/ns/dx/prof#Profile">Go to: </a> Profile</h3>
-                
-                
-                
-                
+           <div>
+            <h3><a href="http://www.w3.org/ns/dx/prof#Profile">Go to: </a> Profile</h3>
+            
+            
+            
+            
         <div id="http://www.w3.org/ns/dx/prof#Profile">
             
             <table class="table metadata table-striped" >
@@ -6019,7 +6291,7 @@ While providing the formal specification for RO-Crate, this document also aims t
             <th style="text-align:left;" class="prop">@id</th>
             <td style='text-align:left'><a href="http://www.w3.org/ns/dx/prof#Profile">http://www.w3.org/ns/dx/prof#Profile</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">name</th>
+            <th style="text-align:left;" class="prop">name<span>&nbsp;</span><a href="http://schema.org/name">[?]</a></th>
             <td style='text-align:left'><span>Profile</span></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">@type</th>
@@ -6029,28 +6301,29 @@ While providing the formal specification for RO-Crate, this document also aims t
                         <li><span>Class</span></li>
                         </ul></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">inDefinedTermSet</th>
+            <th style="text-align:left;" class="prop">inDefinedTermSet<span>&nbsp;</span><a href="http://schema.org/inDefinedTermSet">[?]</a></th>
             <td style='text-align:left'><a href="#http%3A//www.w3.org/ns/dx/prof">Profiles Vocabulary</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">sameAs</th>
+            <th style="text-align:left;" class="prop">sameAs<span>&nbsp;</span><a href="http://schema.org/sameAs">[?]</a></th>
             <td style='text-align:left'><a href="https://www.w3.org/TR/2019/NOTE-dx-prof-20191218/#Class:Profile">https://www.w3.org/TR/2019/NOTE-dx-prof-20191218/#Class:Profile</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">termCode</th>
+            <th style="text-align:left;" class="prop">termCode<span>&nbsp;</span><a href="http://schema.org/termCode">[?]</a></th>
             <td style='text-align:left'><span>Profile</span></td>
             </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
-            <th style="text-align:left;" class="prop">hasPart</th>
+            <th style="text-align:left;" class="prop">hasPart<span>&nbsp;</span><a href="http://schema.org/hasPart">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//w3id.org/ro/crate/1.2">RO-Crate specification 1.2</a></td>
             </tr></tbody>
             </table>
         </div>
-            </div>
+
+        </div>
         <hr/><br/><br/>
-            <div>
-                <h3><a href="http://www.w3.org/ns/dx/prof#hasArtifact">Go to: </a> has artifact</h3>
-                
-                
-                
-                
+           <div>
+            <h3><a href="http://www.w3.org/ns/dx/prof#hasArtifact">Go to: </a> has artifact</h3>
+            
+            
+            
+            
         <div id="http://www.w3.org/ns/dx/prof#hasArtifact">
             
             <table class="table metadata table-striped" >
@@ -6058,7 +6331,7 @@ While providing the formal specification for RO-Crate, this document also aims t
             <th style="text-align:left;" class="prop">@id</th>
             <td style='text-align:left'><a href="http://www.w3.org/ns/dx/prof#hasArtifact">http://www.w3.org/ns/dx/prof#hasArtifact</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">name</th>
+            <th style="text-align:left;" class="prop">name<span>&nbsp;</span><a href="http://schema.org/name">[?]</a></th>
             <td style='text-align:left'><span>has artifact</span></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">@type</th>
@@ -6068,28 +6341,29 @@ While providing the formal specification for RO-Crate, this document also aims t
                         <li><span>Property</span></li>
                         </ul></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">inDefinedTermSet</th>
+            <th style="text-align:left;" class="prop">inDefinedTermSet<span>&nbsp;</span><a href="http://schema.org/inDefinedTermSet">[?]</a></th>
             <td style='text-align:left'><a href="#http%3A//www.w3.org/ns/dx/prof">Profiles Vocabulary</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">sameAs</th>
+            <th style="text-align:left;" class="prop">sameAs<span>&nbsp;</span><a href="http://schema.org/sameAs">[?]</a></th>
             <td style='text-align:left'><a href="https://www.w3.org/TR/2019/NOTE-dx-prof-20191218/#Property:hasArtifact">https://www.w3.org/TR/2019/NOTE-dx-prof-20191218/#Property:hasArtifact</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">termCode</th>
+            <th style="text-align:left;" class="prop">termCode<span>&nbsp;</span><a href="http://schema.org/termCode">[?]</a></th>
             <td style='text-align:left'><span>hasArtifact</span></td>
             </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
-            <th style="text-align:left;" class="prop">hasPart</th>
+            <th style="text-align:left;" class="prop">hasPart<span>&nbsp;</span><a href="http://schema.org/hasPart">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//w3id.org/ro/crate/1.2">RO-Crate specification 1.2</a></td>
             </tr></tbody>
             </table>
         </div>
-            </div>
+
+        </div>
         <hr/><br/><br/>
-            <div>
-                <h3><a href="http://www.w3.org/ns/dx/prof#hasResource">Go to: </a> has resource</h3>
-                
-                
-                
-                
+           <div>
+            <h3><a href="http://www.w3.org/ns/dx/prof#hasResource">Go to: </a> has resource</h3>
+            
+            
+            
+            
         <div id="http://www.w3.org/ns/dx/prof#hasResource">
             
             <table class="table metadata table-striped" >
@@ -6097,7 +6371,7 @@ While providing the formal specification for RO-Crate, this document also aims t
             <th style="text-align:left;" class="prop">@id</th>
             <td style='text-align:left'><a href="http://www.w3.org/ns/dx/prof#hasResource">http://www.w3.org/ns/dx/prof#hasResource</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">name</th>
+            <th style="text-align:left;" class="prop">name<span>&nbsp;</span><a href="http://schema.org/name">[?]</a></th>
             <td style='text-align:left'><span>has resource</span></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">@type</th>
@@ -6107,28 +6381,29 @@ While providing the formal specification for RO-Crate, this document also aims t
                         <li><span>Property</span></li>
                         </ul></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">inDefinedTermSet</th>
+            <th style="text-align:left;" class="prop">inDefinedTermSet<span>&nbsp;</span><a href="http://schema.org/inDefinedTermSet">[?]</a></th>
             <td style='text-align:left'><a href="#http%3A//www.w3.org/ns/dx/prof">Profiles Vocabulary</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">sameAs</th>
+            <th style="text-align:left;" class="prop">sameAs<span>&nbsp;</span><a href="http://schema.org/sameAs">[?]</a></th>
             <td style='text-align:left'><a href="https://www.w3.org/TR/2019/NOTE-dx-prof-20191218/#Property:hasResource">https://www.w3.org/TR/2019/NOTE-dx-prof-20191218/#Property:hasResource</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">termCode</th>
+            <th style="text-align:left;" class="prop">termCode<span>&nbsp;</span><a href="http://schema.org/termCode">[?]</a></th>
             <td style='text-align:left'><span>hasResource</span></td>
             </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
-            <th style="text-align:left;" class="prop">hasPart</th>
+            <th style="text-align:left;" class="prop">hasPart<span>&nbsp;</span><a href="http://schema.org/hasPart">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//w3id.org/ro/crate/1.2">RO-Crate specification 1.2</a></td>
             </tr></tbody>
             </table>
         </div>
-            </div>
+
+        </div>
         <hr/><br/><br/>
-            <div>
-                <h3><a href="http://www.w3.org/ns/dx/prof#hasRole">Go to: </a> has role</h3>
-                
-                
-                
-                
+           <div>
+            <h3><a href="http://www.w3.org/ns/dx/prof#hasRole">Go to: </a> has role</h3>
+            
+            
+            
+            
         <div id="http://www.w3.org/ns/dx/prof#hasRole">
             
             <table class="table metadata table-striped" >
@@ -6136,7 +6411,7 @@ While providing the formal specification for RO-Crate, this document also aims t
             <th style="text-align:left;" class="prop">@id</th>
             <td style='text-align:left'><a href="http://www.w3.org/ns/dx/prof#hasRole">http://www.w3.org/ns/dx/prof#hasRole</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">name</th>
+            <th style="text-align:left;" class="prop">name<span>&nbsp;</span><a href="http://schema.org/name">[?]</a></th>
             <td style='text-align:left'><span>has role</span></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">@type</th>
@@ -6146,28 +6421,29 @@ While providing the formal specification for RO-Crate, this document also aims t
                         <li><span>Property</span></li>
                         </ul></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">inDefinedTermSet</th>
+            <th style="text-align:left;" class="prop">inDefinedTermSet<span>&nbsp;</span><a href="http://schema.org/inDefinedTermSet">[?]</a></th>
             <td style='text-align:left'><a href="#http%3A//www.w3.org/ns/dx/prof">Profiles Vocabulary</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">sameAs</th>
+            <th style="text-align:left;" class="prop">sameAs<span>&nbsp;</span><a href="http://schema.org/sameAs">[?]</a></th>
             <td style='text-align:left'><a href="https://www.w3.org/TR/2019/NOTE-dx-prof-20191218/#Property:hasRole">https://www.w3.org/TR/2019/NOTE-dx-prof-20191218/#Property:hasRole</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">termCode</th>
+            <th style="text-align:left;" class="prop">termCode<span>&nbsp;</span><a href="http://schema.org/termCode">[?]</a></th>
             <td style='text-align:left'><span>hasRole</span></td>
             </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
-            <th style="text-align:left;" class="prop">hasPart</th>
+            <th style="text-align:left;" class="prop">hasPart<span>&nbsp;</span><a href="http://schema.org/hasPart">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//w3id.org/ro/crate/1.2">RO-Crate specification 1.2</a></td>
             </tr></tbody>
             </table>
         </div>
-            </div>
+
+        </div>
         <hr/><br/><br/>
-            <div>
-                <h3><a href="http://www.iana.org/assignments/relation/cite-as">Go to: </a> Cite as</h3>
-                
-                
-                
-                
+           <div>
+            <h3><a href="http://www.iana.org/assignments/relation/cite-as">Go to: </a> Cite as</h3>
+            
+            
+            
+            
         <div id="http://www.iana.org/assignments/relation/cite-as">
             
             <table class="table metadata table-striped" >
@@ -6175,7 +6451,7 @@ While providing the formal specification for RO-Crate, this document also aims t
             <th style="text-align:left;" class="prop">@id</th>
             <td style='text-align:left'><a href="http://www.iana.org/assignments/relation/cite-as">http://www.iana.org/assignments/relation/cite-as</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">name</th>
+            <th style="text-align:left;" class="prop">name<span>&nbsp;</span><a href="http://schema.org/name">[?]</a></th>
             <td style='text-align:left'><span>Cite as</span></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">@type</th>
@@ -6185,28 +6461,29 @@ While providing the formal specification for RO-Crate, this document also aims t
                         <li><span>Property</span></li>
                         </ul></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">inDefinedTermSet</th>
+            <th style="text-align:left;" class="prop">inDefinedTermSet<span>&nbsp;</span><a href="http://schema.org/inDefinedTermSet">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//www.iana.org/assignments/link-relations/">IANA Link Relations</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">termCode</th>
+            <th style="text-align:left;" class="prop">termCode<span>&nbsp;</span><a href="http://schema.org/termCode">[?]</a></th>
             <td style='text-align:left'><span>cite-as</span></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">url</th>
+            <th style="text-align:left;" class="prop">url<span>&nbsp;</span><a href="http://schema.org/url">[?]</a></th>
             <td style='text-align:left'><a href="https://doi.org/10.17487/RFC8574">https://doi.org/10.17487/RFC8574</a></td>
             </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
-            <th style="text-align:left;" class="prop">hasPart</th>
+            <th style="text-align:left;" class="prop">hasPart<span>&nbsp;</span><a href="http://schema.org/hasPart">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//w3id.org/ro/crate/1.2">RO-Crate specification 1.2</a></td>
             </tr></tbody>
             </table>
         </div>
-            </div>
+
+        </div>
         <hr/><br/><br/>
-            <div>
-                <h3><a href="http://pcdm.org/models#Object">Go to: </a> Repository object</h3>
-                
-                
-                
-                
+           <div>
+            <h3><a href="http://pcdm.org/models#Object">Go to: </a> Repository object</h3>
+            
+            
+            
+            
         <div id="http://pcdm.org/models#Object">
             
             <table class="table metadata table-striped" >
@@ -6214,7 +6491,7 @@ While providing the formal specification for RO-Crate, this document also aims t
             <th style="text-align:left;" class="prop">@id</th>
             <td style='text-align:left'><a href="http://pcdm.org/models#Object">http://pcdm.org/models#Object</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">name</th>
+            <th style="text-align:left;" class="prop">name<span>&nbsp;</span><a href="http://schema.org/name">[?]</a></th>
             <td style='text-align:left'><span>Repository object</span></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">@type</th>
@@ -6224,25 +6501,26 @@ While providing the formal specification for RO-Crate, this document also aims t
                         <li><span>Class</span></li>
                         </ul></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">inDefinedTermSet</th>
+            <th style="text-align:left;" class="prop">inDefinedTermSet<span>&nbsp;</span><a href="http://schema.org/inDefinedTermSet">[?]</a></th>
             <td style='text-align:left'><a href="#http%3A//pcdm.org/models%23">Portland Common Data Model</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">termCode</th>
+            <th style="text-align:left;" class="prop">termCode<span>&nbsp;</span><a href="http://schema.org/termCode">[?]</a></th>
             <td style='text-align:left'><span>RepositoryObject</span></td>
             </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
-            <th style="text-align:left;" class="prop">hasPart</th>
+            <th style="text-align:left;" class="prop">hasPart<span>&nbsp;</span><a href="http://schema.org/hasPart">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//w3id.org/ro/crate/1.2">RO-Crate specification 1.2</a></td>
             </tr></tbody>
             </table>
         </div>
-            </div>
+
+        </div>
         <hr/><br/><br/>
-            <div>
-                <h3><a href="http://pcdm.org/models#Collection">Go to: </a> Repository collection</h3>
-                
-                
-                
-                
+           <div>
+            <h3><a href="http://pcdm.org/models#Collection">Go to: </a> Repository collection</h3>
+            
+            
+            
+            
         <div id="http://pcdm.org/models#Collection">
             
             <table class="table metadata table-striped" >
@@ -6250,7 +6528,7 @@ While providing the formal specification for RO-Crate, this document also aims t
             <th style="text-align:left;" class="prop">@id</th>
             <td style='text-align:left'><a href="http://pcdm.org/models#Collection">http://pcdm.org/models#Collection</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">name</th>
+            <th style="text-align:left;" class="prop">name<span>&nbsp;</span><a href="http://schema.org/name">[?]</a></th>
             <td style='text-align:left'><span>Repository collection</span></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">@type</th>
@@ -6260,25 +6538,26 @@ While providing the formal specification for RO-Crate, this document also aims t
                         <li><span>Class</span></li>
                         </ul></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">inDefinedTermSet</th>
+            <th style="text-align:left;" class="prop">inDefinedTermSet<span>&nbsp;</span><a href="http://schema.org/inDefinedTermSet">[?]</a></th>
             <td style='text-align:left'><a href="#http%3A//pcdm.org/models%23">Portland Common Data Model</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">termCode</th>
+            <th style="text-align:left;" class="prop">termCode<span>&nbsp;</span><a href="http://schema.org/termCode">[?]</a></th>
             <td style='text-align:left'><span>RepositoryCollection</span></td>
             </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
-            <th style="text-align:left;" class="prop">hasPart</th>
+            <th style="text-align:left;" class="prop">hasPart<span>&nbsp;</span><a href="http://schema.org/hasPart">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//w3id.org/ro/crate/1.2">RO-Crate specification 1.2</a></td>
             </tr></tbody>
             </table>
         </div>
-            </div>
+
+        </div>
         <hr/><br/><br/>
-            <div>
-                <h3><a href="http://pcdm.org/models#File">Go to: </a> Repository file</h3>
-                
-                
-                
-                
+           <div>
+            <h3><a href="http://pcdm.org/models#File">Go to: </a> Repository file</h3>
+            
+            
+            
+            
         <div id="http://pcdm.org/models#File">
             
             <table class="table metadata table-striped" >
@@ -6286,7 +6565,7 @@ While providing the formal specification for RO-Crate, this document also aims t
             <th style="text-align:left;" class="prop">@id</th>
             <td style='text-align:left'><a href="http://pcdm.org/models#File">http://pcdm.org/models#File</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">name</th>
+            <th style="text-align:left;" class="prop">name<span>&nbsp;</span><a href="http://schema.org/name">[?]</a></th>
             <td style='text-align:left'><span>Repository file</span></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">@type</th>
@@ -6296,25 +6575,26 @@ While providing the formal specification for RO-Crate, this document also aims t
                         <li><span>Class</span></li>
                         </ul></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">inDefinedTermSet</th>
+            <th style="text-align:left;" class="prop">inDefinedTermSet<span>&nbsp;</span><a href="http://schema.org/inDefinedTermSet">[?]</a></th>
             <td style='text-align:left'><a href="#http%3A//pcdm.org/models%23">Portland Common Data Model</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">termCode</th>
+            <th style="text-align:left;" class="prop">termCode<span>&nbsp;</span><a href="http://schema.org/termCode">[?]</a></th>
             <td style='text-align:left'><span>RepositoryFile</span></td>
             </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
-            <th style="text-align:left;" class="prop">hasPart</th>
+            <th style="text-align:left;" class="prop">hasPart<span>&nbsp;</span><a href="http://schema.org/hasPart">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//w3id.org/ro/crate/1.2">RO-Crate specification 1.2</a></td>
             </tr></tbody>
             </table>
         </div>
-            </div>
+
+        </div>
         <hr/><br/><br/>
-            <div>
-                <h3><a href="http://pcdm.org/models#hasMember">Go to: </a> has member</h3>
-                
-                
-                
-                
+           <div>
+            <h3><a href="http://pcdm.org/models#hasMember">Go to: </a> has member</h3>
+            
+            
+            
+            
         <div id="http://pcdm.org/models#hasMember">
             
             <table class="table metadata table-striped" >
@@ -6322,7 +6602,7 @@ While providing the formal specification for RO-Crate, this document also aims t
             <th style="text-align:left;" class="prop">@id</th>
             <td style='text-align:left'><a href="http://pcdm.org/models#hasMember">http://pcdm.org/models#hasMember</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">name</th>
+            <th style="text-align:left;" class="prop">name<span>&nbsp;</span><a href="http://schema.org/name">[?]</a></th>
             <td style='text-align:left'><span>has member</span></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">@type</th>
@@ -6332,25 +6612,26 @@ While providing the formal specification for RO-Crate, this document also aims t
                         <li><span>Property</span></li>
                         </ul></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">inDefinedTermSet</th>
+            <th style="text-align:left;" class="prop">inDefinedTermSet<span>&nbsp;</span><a href="http://schema.org/inDefinedTermSet">[?]</a></th>
             <td style='text-align:left'><a href="#http%3A//pcdm.org/models%23">Portland Common Data Model</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">termCode</th>
+            <th style="text-align:left;" class="prop">termCode<span>&nbsp;</span><a href="http://schema.org/termCode">[?]</a></th>
             <td style='text-align:left'><span>hasMember</span></td>
             </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
-            <th style="text-align:left;" class="prop">hasPart</th>
+            <th style="text-align:left;" class="prop">hasPart<span>&nbsp;</span><a href="http://schema.org/hasPart">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//w3id.org/ro/crate/1.2">RO-Crate specification 1.2</a></td>
             </tr></tbody>
             </table>
         </div>
-            </div>
+
+        </div>
         <hr/><br/><br/>
-            <div>
-                <h3><a href="http://pcdm.org/models#hasFile">Go to: </a> has file</h3>
-                
-                
-                
-                
+           <div>
+            <h3><a href="http://pcdm.org/models#hasFile">Go to: </a> has file</h3>
+            
+            
+            
+            
         <div id="http://pcdm.org/models#hasFile">
             
             <table class="table metadata table-striped" >
@@ -6358,7 +6639,7 @@ While providing the formal specification for RO-Crate, this document also aims t
             <th style="text-align:left;" class="prop">@id</th>
             <td style='text-align:left'><a href="http://pcdm.org/models#hasFile">http://pcdm.org/models#hasFile</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">name</th>
+            <th style="text-align:left;" class="prop">name<span>&nbsp;</span><a href="http://schema.org/name">[?]</a></th>
             <td style='text-align:left'><span>has file</span></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">@type</th>
@@ -6368,25 +6649,26 @@ While providing the formal specification for RO-Crate, this document also aims t
                         <li><span>Property</span></li>
                         </ul></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">inDefinedTermSet</th>
+            <th style="text-align:left;" class="prop">inDefinedTermSet<span>&nbsp;</span><a href="http://schema.org/inDefinedTermSet">[?]</a></th>
             <td style='text-align:left'><a href="#http%3A//pcdm.org/models%23">Portland Common Data Model</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">termCode</th>
+            <th style="text-align:left;" class="prop">termCode<span>&nbsp;</span><a href="http://schema.org/termCode">[?]</a></th>
             <td style='text-align:left'><span>hasFile</span></td>
             </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
-            <th style="text-align:left;" class="prop">hasPart</th>
+            <th style="text-align:left;" class="prop">hasPart<span>&nbsp;</span><a href="http://schema.org/hasPart">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//w3id.org/ro/crate/1.2">RO-Crate specification 1.2</a></td>
             </tr></tbody>
             </table>
         </div>
-            </div>
+
+        </div>
         <hr/><br/><br/>
-            <div>
-                <h3><a href="http://www.w3.org/1999/02/22-rdf-syntax-ns#Class">Go to: </a> Class (rdfs)</h3>
-                
-                
-                
-                
+           <div>
+            <h3><a href="http://www.w3.org/1999/02/22-rdf-syntax-ns#Class">Go to: </a> Class (rdfs)</h3>
+            
+            
+            
+            
         <div id="http://www.w3.org/1999/02/22-rdf-syntax-ns#Class">
             
             <table class="table metadata table-striped" >
@@ -6394,7 +6676,7 @@ While providing the formal specification for RO-Crate, this document also aims t
             <th style="text-align:left;" class="prop">@id</th>
             <td style='text-align:left'><a href="http://www.w3.org/1999/02/22-rdf-syntax-ns#Class">http://www.w3.org/1999/02/22-rdf-syntax-ns#Class</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">name</th>
+            <th style="text-align:left;" class="prop">name<span>&nbsp;</span><a href="http://schema.org/name">[?]</a></th>
             <td style='text-align:left'><span>Class (rdfs)</span></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">@type</th>
@@ -6404,28 +6686,54 @@ While providing the formal specification for RO-Crate, this document also aims t
                         <li><span>rdfs:Class</span></li>
                         </ul></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">description</th>
+            <th style="text-align:left;" class="prop">description<span>&nbsp;</span><a href="http://schema.org/description">[?]</a></th>
             <td style='text-align:left'><span>Class definition</span></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">inDefinedTermSet</th>
+            <th style="text-align:left;" class="prop">inDefinedTermSet<span>&nbsp;</span><a href="http://schema.org/inDefinedTermSet">[?]</a></th>
             <td style='text-align:left'><a href="#http%3A//www.w3.org/1999/02/22-rdf-syntax-ns%23">http://www.w3.org/1999/02/22-rdf-syntax-ns#</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">url</th>
+            <th style="text-align:left;" class="prop">termCode<span>&nbsp;</span><a href="http://schema.org/termCode">[?]</a></th>
+            <td style='text-align:left'><span>rdfs:Class</span></td>
+            </tr><tr>
+            <th style="text-align:left;" class="prop">url<span>&nbsp;</span><a href="http://schema.org/url">[?]</a></th>
             <td style='text-align:left'><a href="https://www.w3.org/TR/rdf-schema/#ch_class">https://www.w3.org/TR/rdf-schema/#ch_class</a></td>
             </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
-            <th style="text-align:left;" class="prop">hasPart</th>
+            <th style="text-align:left;" class="prop">hasPart<span>&nbsp;</span><a href="http://schema.org/hasPart">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//w3id.org/ro/crate/1.2">RO-Crate specification 1.2</a></td>
+            </tr><tr>
+            <th style="text-align:left;" class="prop">domainIncludes<span>&nbsp;</span><a href="http://schema.org/domainIncludes">[?]</a></th>
+            <td style='text-align:left'><ul>
+                        <li><a href="#http%3A//www.w3.org/1999/02/22-rdf-syntax-ns%23subClassOf">subClassOf (rdfs)</a></li>
+                        
+                        <li><a href="#http%3A//www.w3.org/1999/02/22-rdf-syntax-ns%23label">label (rdfs)</a></li>
+                        
+                        <li><a href="#http%3A//www.w3.org/1999/02/22-rdf-syntax-ns%23comment">comment (rdfs)</a></li>
+                        
+                        <li><a href="#http%3A//schema.org/domainIncludes">domainIncludes</a></li>
+                        
+                        <li><a href="#http%3A//schema.org/rangeIncludes">rangeIncludes</a></li>
+                        </ul></td>
+            </tr><tr>
+            <th style="text-align:left;" class="prop">rangeIncludes<span>&nbsp;</span><a href="http://schema.org/rangeIncludes">[?]</a></th>
+            <td style='text-align:left'><ul>
+                        <li><a href="#http%3A//www.w3.org/1999/02/22-rdf-syntax-ns%23subClassOf">subClassOf (rdfs)</a></li>
+                        
+                        <li><a href="#http%3A//schema.org/domainIncludes">domainIncludes</a></li>
+                        
+                        <li><a href="#http%3A//schema.org/rangeIncludes">rangeIncludes</a></li>
+                        </ul></td>
             </tr></tbody>
             </table>
         </div>
-            </div>
+
+        </div>
         <hr/><br/><br/>
-            <div>
-                <h3><a href="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property">Go to: </a> Property (rdfs)</h3>
-                
-                
-                
-                
+           <div>
+            <h3><a href="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property">Go to: </a> Property (rdfs)</h3>
+            
+            
+            
+            
         <div id="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property">
             
             <table class="table metadata table-striped" >
@@ -6433,7 +6741,7 @@ While providing the formal specification for RO-Crate, this document also aims t
             <th style="text-align:left;" class="prop">@id</th>
             <td style='text-align:left'><a href="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property">http://www.w3.org/1999/02/22-rdf-syntax-ns#Property</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">name</th>
+            <th style="text-align:left;" class="prop">name<span>&nbsp;</span><a href="http://schema.org/name">[?]</a></th>
             <td style='text-align:left'><span>Property (rdfs)</span></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">@type</th>
@@ -6443,28 +6751,248 @@ While providing the formal specification for RO-Crate, this document also aims t
                         <li><span>rdfs:Class</span></li>
                         </ul></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">description</th>
-            <td style='text-align:left'><span>Property definition, typically with domainIncludes and rangeIncludes</span></td>
+            <th style="text-align:left;" class="prop">description<span>&nbsp;</span><a href="http://schema.org/description">[?]</a></th>
+            <td style='text-align:left'><span>Property definition, in schema.org style schema typically with domainIncludes and rangeIncludes</span></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">inDefinedTermSet</th>
+            <th style="text-align:left;" class="prop">inDefinedTermSet<span>&nbsp;</span><a href="http://schema.org/inDefinedTermSet">[?]</a></th>
             <td style='text-align:left'><a href="#http%3A//www.w3.org/1999/02/22-rdf-syntax-ns%23">http://www.w3.org/1999/02/22-rdf-syntax-ns#</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">url</th>
+            <th style="text-align:left;" class="prop">termCode<span>&nbsp;</span><a href="http://schema.org/termCode">[?]</a></th>
+            <td style='text-align:left'><span>rdfs:Property</span></td>
+            </tr><tr>
+            <th style="text-align:left;" class="prop">url<span>&nbsp;</span><a href="http://schema.org/url">[?]</a></th>
             <td style='text-align:left'><a href="https://www.w3.org/TR/rdf-schema/#ch_property">https://www.w3.org/TR/rdf-schema/#ch_property</a></td>
             </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
-            <th style="text-align:left;" class="prop">hasPart</th>
+            <th style="text-align:left;" class="prop">hasPart<span>&nbsp;</span><a href="http://schema.org/hasPart">[?]</a></th>
+            <td style='text-align:left'><a href="#https%3A//w3id.org/ro/crate/1.2">RO-Crate specification 1.2</a></td>
+            </tr><tr>
+            <th style="text-align:left;" class="prop">domainIncludes<span>&nbsp;</span><a href="http://schema.org/domainIncludes">[?]</a></th>
+            <td style='text-align:left'><ul>
+                        <li><a href="#http%3A//www.w3.org/1999/02/22-rdf-syntax-ns%23subPropertyOf">subPropertyOf (rdfs)</a></li>
+                        
+                        <li><a href="#http%3A//www.w3.org/1999/02/22-rdf-syntax-ns%23label">label (rdfs)</a></li>
+                        
+                        <li><a href="#http%3A//www.w3.org/1999/02/22-rdf-syntax-ns%23comment">comment (rdfs)</a></li>
+                        </ul></td>
+            </tr><tr>
+            <th style="text-align:left;" class="prop">rangeIncludes<span>&nbsp;</span><a href="http://schema.org/rangeIncludes">[?]</a></th>
+            <td style='text-align:left'><a href="#http%3A//www.w3.org/1999/02/22-rdf-syntax-ns%23subPropertyOf">subPropertyOf (rdfs)</a></td>
+            </tr></tbody>
+            </table>
+        </div>
+
+        </div>
+        <hr/><br/><br/>
+           <div>
+            <h3><a href="http://www.w3.org/1999/02/22-rdf-syntax-ns#subClassOf">Go to: </a> subClassOf (rdfs)</h3>
+            
+            
+            
+            
+        <div id="http://www.w3.org/1999/02/22-rdf-syntax-ns#subClassOf">
+            
+            <table class="table metadata table-striped" >
+                <tbody><tr>
+            <th style="text-align:left;" class="prop">@id</th>
+            <td style='text-align:left'><a href="http://www.w3.org/1999/02/22-rdf-syntax-ns#subClassOf">http://www.w3.org/1999/02/22-rdf-syntax-ns#subClassOf</a></td>
+            </tr><tr>
+            <th style="text-align:left;" class="prop">name<span>&nbsp;</span><a href="http://schema.org/name">[?]</a></th>
+            <td style='text-align:left'><span>subClassOf (rdfs)</span></td>
+            </tr><tr>
+            <th style="text-align:left;" class="prop">@type</th>
+            <td style='text-align:left'><ul>
+                        <li><span>DefinedTerm</span></li>
+                        
+                        <li><span>rdfs:Property</span></li>
+                        </ul></td>
+            </tr><tr>
+            <th style="text-align:left;" class="prop">description<span>&nbsp;</span><a href="http://schema.org/description">[?]</a></th>
+            <td style='text-align:left'><span>A subclass is a specialisation of another class</span></td>
+            </tr><tr>
+            <th style="text-align:left;" class="prop">inDefinedTermSet<span>&nbsp;</span><a href="http://schema.org/inDefinedTermSet">[?]</a></th>
+            <td style='text-align:left'><a href="#http%3A//www.w3.org/1999/02/22-rdf-syntax-ns%23">http://www.w3.org/1999/02/22-rdf-syntax-ns#</a></td>
+            </tr><tr>
+            <th style="text-align:left;" class="prop">domainIncludes<span>&nbsp;</span><a href="http://schema.org/domainIncludes">[?]</a></th>
+            <td style='text-align:left'><a href="#http%3A//www.w3.org/1999/02/22-rdf-syntax-ns%23Class">Class (rdfs)</a></td>
+            </tr><tr>
+            <th style="text-align:left;" class="prop">rangeIncludes<span>&nbsp;</span><a href="http://schema.org/rangeIncludes">[?]</a></th>
+            <td style='text-align:left'><a href="#http%3A//www.w3.org/1999/02/22-rdf-syntax-ns%23Class">Class (rdfs)</a></td>
+            </tr><tr>
+            <th style="text-align:left;" class="prop">termCode<span>&nbsp;</span><a href="http://schema.org/termCode">[?]</a></th>
+            <td style='text-align:left'><span>rdfs:subClassOf</span></td>
+            </tr><tr>
+            <th style="text-align:left;" class="prop">url<span>&nbsp;</span><a href="http://schema.org/url">[?]</a></th>
+            <td style='text-align:left'><a href="https://www.w3.org/TR/rdf-schema/#ch_subclassof">https://www.w3.org/TR/rdf-schema/#ch_subclassof</a></td>
+            </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
+            <th style="text-align:left;" class="prop">hasPart<span>&nbsp;</span><a href="http://schema.org/hasPart">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//w3id.org/ro/crate/1.2">RO-Crate specification 1.2</a></td>
             </tr></tbody>
             </table>
         </div>
-            </div>
+
+        </div>
         <hr/><br/><br/>
-            <div>
-                <h3><a href="http://schema.org/Class">Go to: </a> Class (schema.org)</h3>
-                
-                
-                
-                
+           <div>
+            <h3><a href="http://www.w3.org/1999/02/22-rdf-syntax-ns#subPropertyOf">Go to: </a> subPropertyOf (rdfs)</h3>
+            
+            
+            
+            
+        <div id="http://www.w3.org/1999/02/22-rdf-syntax-ns#subPropertyOf">
+            
+            <table class="table metadata table-striped" >
+                <tbody><tr>
+            <th style="text-align:left;" class="prop">@id</th>
+            <td style='text-align:left'><a href="http://www.w3.org/1999/02/22-rdf-syntax-ns#subPropertyOf">http://www.w3.org/1999/02/22-rdf-syntax-ns#subPropertyOf</a></td>
+            </tr><tr>
+            <th style="text-align:left;" class="prop">name<span>&nbsp;</span><a href="http://schema.org/name">[?]</a></th>
+            <td style='text-align:left'><span>subPropertyOf (rdfs)</span></td>
+            </tr><tr>
+            <th style="text-align:left;" class="prop">@type</th>
+            <td style='text-align:left'><ul>
+                        <li><span>DefinedTerm</span></li>
+                        
+                        <li><span>rdfs:Property</span></li>
+                        </ul></td>
+            </tr><tr>
+            <th style="text-align:left;" class="prop">description<span>&nbsp;</span><a href="http://schema.org/description">[?]</a></th>
+            <td style='text-align:left'><span>A subproperty is a specialisation of another property</span></td>
+            </tr><tr>
+            <th style="text-align:left;" class="prop">inDefinedTermSet<span>&nbsp;</span><a href="http://schema.org/inDefinedTermSet">[?]</a></th>
+            <td style='text-align:left'><a href="#http%3A//www.w3.org/1999/02/22-rdf-syntax-ns%23">http://www.w3.org/1999/02/22-rdf-syntax-ns#</a></td>
+            </tr><tr>
+            <th style="text-align:left;" class="prop">termCode<span>&nbsp;</span><a href="http://schema.org/termCode">[?]</a></th>
+            <td style='text-align:left'><span>rdfs:subPropertyOf</span></td>
+            </tr><tr>
+            <th style="text-align:left;" class="prop">domainIncludes<span>&nbsp;</span><a href="http://schema.org/domainIncludes">[?]</a></th>
+            <td style='text-align:left'><a href="#http%3A//www.w3.org/1999/02/22-rdf-syntax-ns%23Property">Property (rdfs)</a></td>
+            </tr><tr>
+            <th style="text-align:left;" class="prop">rangeIncludes<span>&nbsp;</span><a href="http://schema.org/rangeIncludes">[?]</a></th>
+            <td style='text-align:left'><a href="#http%3A//www.w3.org/1999/02/22-rdf-syntax-ns%23Property">Property (rdfs)</a></td>
+            </tr><tr>
+            <th style="text-align:left;" class="prop">url<span>&nbsp;</span><a href="http://schema.org/url">[?]</a></th>
+            <td style='text-align:left'><a href="https://www.w3.org/TR/rdf-schema/#ch_subpropertyof">https://www.w3.org/TR/rdf-schema/#ch_subpropertyof</a></td>
+            </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
+            <th style="text-align:left;" class="prop">hasPart<span>&nbsp;</span><a href="http://schema.org/hasPart">[?]</a></th>
+            <td style='text-align:left'><a href="#https%3A//w3id.org/ro/crate/1.2">RO-Crate specification 1.2</a></td>
+            </tr></tbody>
+            </table>
+        </div>
+
+        </div>
+        <hr/><br/><br/>
+           <div>
+            <h3><a href="http://www.w3.org/1999/02/22-rdf-syntax-ns#label">Go to: </a> label (rdfs)</h3>
+            
+            
+            
+            
+        <div id="http://www.w3.org/1999/02/22-rdf-syntax-ns#label">
+            
+            <table class="table metadata table-striped" >
+                <tbody><tr>
+            <th style="text-align:left;" class="prop">@id</th>
+            <td style='text-align:left'><a href="http://www.w3.org/1999/02/22-rdf-syntax-ns#label">http://www.w3.org/1999/02/22-rdf-syntax-ns#label</a></td>
+            </tr><tr>
+            <th style="text-align:left;" class="prop">name<span>&nbsp;</span><a href="http://schema.org/name">[?]</a></th>
+            <td style='text-align:left'><span>label (rdfs)</span></td>
+            </tr><tr>
+            <th style="text-align:left;" class="prop">@type</th>
+            <td style='text-align:left'><ul>
+                        <li><span>DefinedTerm</span></li>
+                        
+                        <li><span>rdfs:Property</span></li>
+                        </ul></td>
+            </tr><tr>
+            <th style="text-align:left;" class="prop">description<span>&nbsp;</span><a href="http://schema.org/description">[?]</a></th>
+            <td style='text-align:left'><span>A human-readable name of the property/class defined with RDFS, equivalent to 'name' in schema.org</span></td>
+            </tr><tr>
+            <th style="text-align:left;" class="prop">inDefinedTermSet<span>&nbsp;</span><a href="http://schema.org/inDefinedTermSet">[?]</a></th>
+            <td style='text-align:left'><a href="#http%3A//www.w3.org/1999/02/22-rdf-syntax-ns%23">http://www.w3.org/1999/02/22-rdf-syntax-ns#</a></td>
+            </tr><tr>
+            <th style="text-align:left;" class="prop">domainIncludes<span>&nbsp;</span><a href="http://schema.org/domainIncludes">[?]</a></th>
+            <td style='text-align:left'><ul>
+                        <li><a href="#http%3A//www.w3.org/1999/02/22-rdf-syntax-ns%23Property">Property (rdfs)</a></li>
+                        
+                        <li><a href="#http%3A//www.w3.org/1999/02/22-rdf-syntax-ns%23Class">Class (rdfs)</a></li>
+                        </ul></td>
+            </tr><tr>
+            <th style="text-align:left;" class="prop">rangeIncludes<span>&nbsp;</span><a href="http://schema.org/rangeIncludes">[?]</a></th>
+            <td style='text-align:left'><a href="http://schema.org/Text">http://schema.org/Text</a></td>
+            </tr><tr>
+            <th style="text-align:left;" class="prop">termCode<span>&nbsp;</span><a href="http://schema.org/termCode">[?]</a></th>
+            <td style='text-align:left'><span>rdfs:label</span></td>
+            </tr><tr>
+            <th style="text-align:left;" class="prop">url<span>&nbsp;</span><a href="http://schema.org/url">[?]</a></th>
+            <td style='text-align:left'><a href="https://www.w3.org/TR/rdf-schema/#ch_label">https://www.w3.org/TR/rdf-schema/#ch_label</a></td>
+            </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
+            <th style="text-align:left;" class="prop">hasPart<span>&nbsp;</span><a href="http://schema.org/hasPart">[?]</a></th>
+            <td style='text-align:left'><a href="#https%3A//w3id.org/ro/crate/1.2">RO-Crate specification 1.2</a></td>
+            </tr></tbody>
+            </table>
+        </div>
+
+        </div>
+        <hr/><br/><br/>
+           <div>
+            <h3><a href="http://www.w3.org/1999/02/22-rdf-syntax-ns#comment">Go to: </a> comment (rdfs)</h3>
+            
+            
+            
+            
+        <div id="http://www.w3.org/1999/02/22-rdf-syntax-ns#comment">
+            
+            <table class="table metadata table-striped" >
+                <tbody><tr>
+            <th style="text-align:left;" class="prop">@id</th>
+            <td style='text-align:left'><a href="http://www.w3.org/1999/02/22-rdf-syntax-ns#comment">http://www.w3.org/1999/02/22-rdf-syntax-ns#comment</a></td>
+            </tr><tr>
+            <th style="text-align:left;" class="prop">name<span>&nbsp;</span><a href="http://schema.org/name">[?]</a></th>
+            <td style='text-align:left'><span>comment (rdfs)</span></td>
+            </tr><tr>
+            <th style="text-align:left;" class="prop">@type</th>
+            <td style='text-align:left'><ul>
+                        <li><span>DefinedTerm</span></li>
+                        
+                        <li><span>rdfs:Property</span></li>
+                        </ul></td>
+            </tr><tr>
+            <th style="text-align:left;" class="prop">description<span>&nbsp;</span><a href="http://schema.org/description">[?]</a></th>
+            <td style='text-align:left'><span>A human-readable description of the property/class defined with RDFS, equivalent to 'description' in schema.org</span></td>
+            </tr><tr>
+            <th style="text-align:left;" class="prop">inDefinedTermSet<span>&nbsp;</span><a href="http://schema.org/inDefinedTermSet">[?]</a></th>
+            <td style='text-align:left'><a href="#http%3A//www.w3.org/1999/02/22-rdf-syntax-ns%23">http://www.w3.org/1999/02/22-rdf-syntax-ns#</a></td>
+            </tr><tr>
+            <th style="text-align:left;" class="prop">domainIncludes<span>&nbsp;</span><a href="http://schema.org/domainIncludes">[?]</a></th>
+            <td style='text-align:left'><ul>
+                        <li><a href="#http%3A//www.w3.org/1999/02/22-rdf-syntax-ns%23Property">Property (rdfs)</a></li>
+                        
+                        <li><a href="#http%3A//www.w3.org/1999/02/22-rdf-syntax-ns%23Class">Class (rdfs)</a></li>
+                        </ul></td>
+            </tr><tr>
+            <th style="text-align:left;" class="prop">rangeIncludes<span>&nbsp;</span><a href="http://schema.org/rangeIncludes">[?]</a></th>
+            <td style='text-align:left'><a href="http://schema.org/Text">http://schema.org/Text</a></td>
+            </tr><tr>
+            <th style="text-align:left;" class="prop">termCode<span>&nbsp;</span><a href="http://schema.org/termCode">[?]</a></th>
+            <td style='text-align:left'><span>rdfs:comment</span></td>
+            </tr><tr>
+            <th style="text-align:left;" class="prop">url<span>&nbsp;</span><a href="http://schema.org/url">[?]</a></th>
+            <td style='text-align:left'><a href="https://www.w3.org/TR/rdf-schema/#ch_comment">https://www.w3.org/TR/rdf-schema/#ch_comment</a></td>
+            </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
+            <th style="text-align:left;" class="prop">hasPart<span>&nbsp;</span><a href="http://schema.org/hasPart">[?]</a></th>
+            <td style='text-align:left'><a href="#https%3A//w3id.org/ro/crate/1.2">RO-Crate specification 1.2</a></td>
+            </tr></tbody>
+            </table>
+        </div>
+
+        </div>
+        <hr/><br/><br/>
+           <div>
+            <h3><a href="http://schema.org/Class">Go to: </a> Class (schema.org)</h3>
+            
+            
+            
+            
         <div id="http://schema.org/Class">
             
             <table class="table metadata table-striped" >
@@ -6472,7 +7000,7 @@ While providing the formal specification for RO-Crate, this document also aims t
             <th style="text-align:left;" class="prop">@id</th>
             <td style='text-align:left'><a href="http://schema.org/Class">http://schema.org/Class</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">name</th>
+            <th style="text-align:left;" class="prop">name<span>&nbsp;</span><a href="http://schema.org/name">[?]</a></th>
             <td style='text-align:left'><span>Class (schema.org)</span></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">@type</th>
@@ -6482,25 +7010,40 @@ While providing the formal specification for RO-Crate, this document also aims t
                         <li><span>Class</span></li>
                         </ul></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">description</th>
+            <th style="text-align:left;" class="prop">description<span>&nbsp;</span><a href="http://schema.org/description">[?]</a></th>
             <td style='text-align:left'><span>Class reference, as indicated by @id url or inDefinedTermSet</span></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">inDefinedTermSet</th>
+            <th style="text-align:left;" class="prop">inDefinedTermSet<span>&nbsp;</span><a href="http://schema.org/inDefinedTermSet">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//schema.org/docs/releases.html%23v22.0">Schema.org vocabulary (http prefix)</a></td>
             </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
-            <th style="text-align:left;" class="prop">hasPart</th>
+            <th style="text-align:left;" class="prop">hasPart<span>&nbsp;</span><a href="http://schema.org/hasPart">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//w3id.org/ro/crate/1.2">RO-Crate specification 1.2</a></td>
+            </tr><tr>
+            <th style="text-align:left;" class="prop">domainIncludes<span>&nbsp;</span><a href="http://schema.org/domainIncludes">[?]</a></th>
+            <td style='text-align:left'><ul>
+                        <li><a href="#http%3A//schema.org/domainIncludes">domainIncludes</a></li>
+                        
+                        <li><a href="#http%3A//schema.org/rangeIncludes">rangeIncludes</a></li>
+                        </ul></td>
+            </tr><tr>
+            <th style="text-align:left;" class="prop">rangeIncludes<span>&nbsp;</span><a href="http://schema.org/rangeIncludes">[?]</a></th>
+            <td style='text-align:left'><ul>
+                        <li><a href="#http%3A//schema.org/domainIncludes">domainIncludes</a></li>
+                        
+                        <li><a href="#http%3A//schema.org/rangeIncludes">rangeIncludes</a></li>
+                        </ul></td>
             </tr></tbody>
             </table>
         </div>
-            </div>
+
+        </div>
         <hr/><br/><br/>
-            <div>
-                <h3><a href="http://schema.org/Property">Go to: </a> Property (schema.org)</h3>
-                
-                
-                
-                
+           <div>
+            <h3><a href="http://schema.org/Property">Go to: </a> Property (schema.org)</h3>
+            
+            
+            
+            
         <div id="http://schema.org/Property">
             
             <table class="table metadata table-striped" >
@@ -6508,7 +7051,7 @@ While providing the formal specification for RO-Crate, this document also aims t
             <th style="text-align:left;" class="prop">@id</th>
             <td style='text-align:left'><a href="http://schema.org/Property">http://schema.org/Property</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">name</th>
+            <th style="text-align:left;" class="prop">name<span>&nbsp;</span><a href="http://schema.org/name">[?]</a></th>
             <td style='text-align:left'><span>Property (schema.org)</span></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">@type</th>
@@ -6518,25 +7061,134 @@ While providing the formal specification for RO-Crate, this document also aims t
                         <li><span>Class</span></li>
                         </ul></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">description</th>
+            <th style="text-align:left;" class="prop">description<span>&nbsp;</span><a href="http://schema.org/description">[?]</a></th>
             <td style='text-align:left'><span>Property reference, as indicated by @id url or inDefinedTermSet</span></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">inDefinedTermSet</th>
+            <th style="text-align:left;" class="prop">inDefinedTermSet<span>&nbsp;</span><a href="http://schema.org/inDefinedTermSet">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//schema.org/docs/releases.html%23v22.0">Schema.org vocabulary (http prefix)</a></td>
             </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
-            <th style="text-align:left;" class="prop">hasPart</th>
+            <th style="text-align:left;" class="prop">hasPart<span>&nbsp;</span><a href="http://schema.org/hasPart">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//w3id.org/ro/crate/1.2">RO-Crate specification 1.2</a></td>
             </tr></tbody>
             </table>
         </div>
-            </div>
+
+        </div>
         <hr/><br/><br/>
-            <div>
-                <h3><a href="http://www.opengis.net/ont/geosparql#Geometry">Go to: </a> Geometry</h3>
-                
-                
-                
-                
+           <div>
+            <h3><a href="http://schema.org/rangeIncludes">Go to: </a> rangeIncludes</h3>
+            
+            
+            
+            
+        <div id="http://schema.org/rangeIncludes">
+            
+            <table class="table metadata table-striped" >
+                <tbody><tr>
+            <th style="text-align:left;" class="prop">@id</th>
+            <td style='text-align:left'><a href="http://schema.org/rangeIncludes">http://schema.org/rangeIncludes</a></td>
+            </tr><tr>
+            <th style="text-align:left;" class="prop">name<span>&nbsp;</span><a href="http://schema.org/name">[?]</a></th>
+            <td style='text-align:left'><span>rangeIncludes</span></td>
+            </tr><tr>
+            <th style="text-align:left;" class="prop">@type</th>
+            <td style='text-align:left'><ul>
+                        <li><span>DefinedTerm</span></li>
+                        
+                        <li><span>rdfs:Property</span></li>
+                        </ul></td>
+            </tr><tr>
+            <th style="text-align:left;" class="prop">description<span>&nbsp;</span><a href="http://schema.org/description">[?]</a></th>
+            <td style='text-align:left'><span>The range of a property includes the given types, meaning instances of these types may be the target of this property. Equivalent to rdfs:range but allowing multiple disjoint types. For datatype properties, point to subclasses of http://schema.org/DataType e.g. for a string, http://schema.org/Text</span></td>
+            </tr><tr>
+            <th style="text-align:left;" class="prop">inDefinedTermSet<span>&nbsp;</span><a href="http://schema.org/inDefinedTermSet">[?]</a></th>
+            <td style='text-align:left'><a href="#https%3A//schema.org/docs/releases.html%23v22.0">Schema.org vocabulary (http prefix)</a></td>
+            </tr><tr>
+            <th style="text-align:left;" class="prop">domainIncludes<span>&nbsp;</span><a href="http://schema.org/domainIncludes">[?]</a></th>
+            <td style='text-align:left'><ul>
+                        <li><a href="#http%3A//schema.org/Class">Class (schema.org)</a></li>
+                        
+                        <li><a href="#http%3A//www.w3.org/1999/02/22-rdf-syntax-ns%23Class">Class (rdfs)</a></li>
+                        </ul></td>
+            </tr><tr>
+            <th style="text-align:left;" class="prop">rangeIncludes<span>&nbsp;</span><a href="http://schema.org/rangeIncludes">[?]</a></th>
+            <td style='text-align:left'><ul>
+                        <li><a href="#http%3A//schema.org/Class">Class (schema.org)</a></li>
+                        
+                        <li><a href="#http%3A//www.w3.org/1999/02/22-rdf-syntax-ns%23Class">Class (rdfs)</a></li>
+                        </ul></td>
+            </tr><tr>
+            <th style="text-align:left;" class="prop">termCode<span>&nbsp;</span><a href="http://schema.org/termCode">[?]</a></th>
+            <td style='text-align:left'><span>rangeIncludes</span></td>
+            </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
+            <th style="text-align:left;" class="prop">hasPart<span>&nbsp;</span><a href="http://schema.org/hasPart">[?]</a></th>
+            <td style='text-align:left'><a href="#https%3A//w3id.org/ro/crate/1.2">RO-Crate specification 1.2</a></td>
+            </tr></tbody>
+            </table>
+        </div>
+
+        </div>
+        <hr/><br/><br/>
+           <div>
+            <h3><a href="http://schema.org/domainIncludes">Go to: </a> domainIncludes</h3>
+            
+            
+            
+            
+        <div id="http://schema.org/domainIncludes">
+            
+            <table class="table metadata table-striped" >
+                <tbody><tr>
+            <th style="text-align:left;" class="prop">@id</th>
+            <td style='text-align:left'><a href="http://schema.org/domainIncludes">http://schema.org/domainIncludes</a></td>
+            </tr><tr>
+            <th style="text-align:left;" class="prop">name<span>&nbsp;</span><a href="http://schema.org/name">[?]</a></th>
+            <td style='text-align:left'><span>domainIncludes</span></td>
+            </tr><tr>
+            <th style="text-align:left;" class="prop">@type</th>
+            <td style='text-align:left'><ul>
+                        <li><span>DefinedTerm</span></li>
+                        
+                        <li><span>rdfs:Property</span></li>
+                        </ul></td>
+            </tr><tr>
+            <th style="text-align:left;" class="prop">description<span>&nbsp;</span><a href="http://schema.org/description">[?]</a></th>
+            <td style='text-align:left'><span>The domain of a property includes the given classes, meaning the property may be used on instances of these classes. Equivalent to rdfs:domain but allowing multiple disjoint classes.</span></td>
+            </tr><tr>
+            <th style="text-align:left;" class="prop">inDefinedTermSet<span>&nbsp;</span><a href="http://schema.org/inDefinedTermSet">[?]</a></th>
+            <td style='text-align:left'><a href="#https%3A//schema.org/docs/releases.html%23v22.0">Schema.org vocabulary (http prefix)</a></td>
+            </tr><tr>
+            <th style="text-align:left;" class="prop">termCode<span>&nbsp;</span><a href="http://schema.org/termCode">[?]</a></th>
+            <td style='text-align:left'><span>domainIncludes</span></td>
+            </tr><tr>
+            <th style="text-align:left;" class="prop">domainIncludes<span>&nbsp;</span><a href="http://schema.org/domainIncludes">[?]</a></th>
+            <td style='text-align:left'><ul>
+                        <li><a href="#http%3A//schema.org/Class">Class (schema.org)</a></li>
+                        
+                        <li><a href="#http%3A//www.w3.org/1999/02/22-rdf-syntax-ns%23Class">Class (rdfs)</a></li>
+                        </ul></td>
+            </tr><tr>
+            <th style="text-align:left;" class="prop">rangeIncludes<span>&nbsp;</span><a href="http://schema.org/rangeIncludes">[?]</a></th>
+            <td style='text-align:left'><ul>
+                        <li><a href="#http%3A//schema.org/Class">Class (schema.org)</a></li>
+                        
+                        <li><a href="#http%3A//www.w3.org/1999/02/22-rdf-syntax-ns%23Class">Class (rdfs)</a></li>
+                        </ul></td>
+            </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
+            <th style="text-align:left;" class="prop">hasPart<span>&nbsp;</span><a href="http://schema.org/hasPart">[?]</a></th>
+            <td style='text-align:left'><a href="#https%3A//w3id.org/ro/crate/1.2">RO-Crate specification 1.2</a></td>
+            </tr></tbody>
+            </table>
+        </div>
+
+        </div>
+        <hr/><br/><br/>
+           <div>
+            <h3><a href="http://www.opengis.net/ont/geosparql#Geometry">Go to: </a> Geometry</h3>
+            
+            
+            
+            
         <div id="http://www.opengis.net/ont/geosparql#Geometry">
             
             <table class="table metadata table-striped" >
@@ -6544,37 +7196,38 @@ While providing the formal specification for RO-Crate, this document also aims t
             <th style="text-align:left;" class="prop">@id</th>
             <td style='text-align:left'><a href="http://www.opengis.net/ont/geosparql#Geometry">http://www.opengis.net/ont/geosparql#Geometry</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">name</th>
+            <th style="text-align:left;" class="prop">name<span>&nbsp;</span><a href="http://schema.org/name">[?]</a></th>
             <td style='text-align:left'><span>Geometry</span></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">@type</th>
             <td style='text-align:left'><span>DefinedTerm</span></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">description</th>
+            <th style="text-align:left;" class="prop">description<span>&nbsp;</span><a href="http://schema.org/description">[?]</a></th>
             <td style='text-align:left'><span>A coherent set of direct positions in space. The positions are held within a Spatial Reference System (SRS).</span></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">termCode</th>
+            <th style="text-align:left;" class="prop">termCode<span>&nbsp;</span><a href="http://schema.org/termCode">[?]</a></th>
             <td style='text-align:left'><span>Geometry</span></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">sameAs</th>
+            <th style="text-align:left;" class="prop">sameAs<span>&nbsp;</span><a href="http://schema.org/sameAs">[?]</a></th>
             <td style='text-align:left'><a href="https://opengeospatial.github.io/ogc-geosparql/geosparql11/#Geometry">https://opengeospatial.github.io/ogc-geosparql/geosparql11/#Geometry</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">inDefinedTermSet</th>
+            <th style="text-align:left;" class="prop">inDefinedTermSet<span>&nbsp;</span><a href="http://schema.org/inDefinedTermSet">[?]</a></th>
             <td style='text-align:left'><a href="#http%3A//www.opengis.net/ont/geosparql%23">GeoSPARQL ontology</a></td>
             </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
-            <th style="text-align:left;" class="prop">hasPart</th>
+            <th style="text-align:left;" class="prop">hasPart<span>&nbsp;</span><a href="http://schema.org/hasPart">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//w3id.org/ro/crate/1.2">RO-Crate specification 1.2</a></td>
             </tr></tbody>
             </table>
         </div>
-            </div>
+
+        </div>
         <hr/><br/><br/>
-            <div>
-                <h3><a href="http://www.opengis.net/ont/geosparql#asWKT">Go to: </a> Geometry</h3>
-                
-                
-                
-                
+           <div>
+            <h3><a href="http://www.opengis.net/ont/geosparql#asWKT">Go to: </a> Geometry</h3>
+            
+            
+            
+            
         <div id="http://www.opengis.net/ont/geosparql#asWKT">
             
             <table class="table metadata table-striped" >
@@ -6582,40 +7235,41 @@ While providing the formal specification for RO-Crate, this document also aims t
             <th style="text-align:left;" class="prop">@id</th>
             <td style='text-align:left'><a href="http://www.opengis.net/ont/geosparql#asWKT">http://www.opengis.net/ont/geosparql#asWKT</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">name</th>
+            <th style="text-align:left;" class="prop">name<span>&nbsp;</span><a href="http://schema.org/name">[?]</a></th>
             <td style='text-align:left'><span>Geometry</span></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">@type</th>
             <td style='text-align:left'><span>DefinedTerm</span></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">description</th>
+            <th style="text-align:left;" class="prop">description<span>&nbsp;</span><a href="http://schema.org/description">[?]</a></th>
             <td style='text-align:left'><span>The WKT (Well-Known Text) serialization (ISO13249) of a Geometry.</span></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">termCode</th>
+            <th style="text-align:left;" class="prop">termCode<span>&nbsp;</span><a href="http://schema.org/termCode">[?]</a></th>
             <td style='text-align:left'><span>asWKT</span></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">citation</th>
+            <th style="text-align:left;" class="prop">citation<span>&nbsp;</span><a href="http://schema.org/citation">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//portal.ogc.org/files/%3Fartifact_id%3D25355">OpenGIS Implementation Specification for Geographic information – Simple feature access – Part 1: Common architecture</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">sameAs</th>
+            <th style="text-align:left;" class="prop">sameAs<span>&nbsp;</span><a href="http://schema.org/sameAs">[?]</a></th>
             <td style='text-align:left'><a href="https://opengeospatial.github.io/ogc-geosparql/geosparql11/#asWKT">https://opengeospatial.github.io/ogc-geosparql/geosparql11/#asWKT</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">inDefinedTermSet</th>
+            <th style="text-align:left;" class="prop">inDefinedTermSet<span>&nbsp;</span><a href="http://schema.org/inDefinedTermSet">[?]</a></th>
             <td style='text-align:left'><a href="#http%3A//www.opengis.net/ont/geosparql%23">GeoSPARQL ontology</a></td>
             </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
-            <th style="text-align:left;" class="prop">hasPart</th>
+            <th style="text-align:left;" class="prop">hasPart<span>&nbsp;</span><a href="http://schema.org/hasPart">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//w3id.org/ro/crate/1.2">RO-Crate specification 1.2</a></td>
             </tr></tbody>
             </table>
         </div>
-            </div>
+
+        </div>
         <hr/><br/><br/>
-            <div>
-                <h3><a href="https://codemeta.github.io/terms/">Go to: </a> Codemeta Terms</h3>
-                
-                
-                
-                
+           <div>
+            <h3><a href="https://codemeta.github.io/terms/">Go to: </a> Codemeta Terms</h3>
+            
+            
+            
+            
         <div id="https://codemeta.github.io/terms/">
             
             <table class="table metadata table-striped" >
@@ -6623,7 +7277,7 @@ While providing the formal specification for RO-Crate, this document also aims t
             <th style="text-align:left;" class="prop">@id</th>
             <td style='text-align:left'><a href="https://codemeta.github.io/terms/">https://codemeta.github.io/terms/</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">name</th>
+            <th style="text-align:left;" class="prop">name<span>&nbsp;</span><a href="http://schema.org/name">[?]</a></th>
             <td style='text-align:left'><span>Codemeta Terms</span></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">@type</th>
@@ -6633,16 +7287,16 @@ While providing the formal specification for RO-Crate, this document also aims t
                         <li><span>Profile</span></li>
                         </ul></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">isPartOf</th>
+            <th style="text-align:left;" class="prop">isPartOf<span>&nbsp;</span><a href="http://schema.org/isPartOf">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//w3id.org/codemeta/3.0">CodeMeta Terms profile</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">url</th>
+            <th style="text-align:left;" class="prop">url<span>&nbsp;</span><a href="http://schema.org/url">[?]</a></th>
             <td style='text-align:left'><a href="https://codemeta.github.io/terms/">https://codemeta.github.io/terms/</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">version</th>
+            <th style="text-align:left;" class="prop">version<span>&nbsp;</span><a href="http://schema.org/version">[?]</a></th>
             <td style='text-align:left'><span>3.0</span></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">hasDefinedTerm</th>
+            <th style="text-align:left;" class="prop">hasDefinedTerm<span>&nbsp;</span><a href="http://schema.org/hasDefinedTerm">[?]</a></th>
             <td style='text-align:left'><ul>
                         <li><a href="#https%3A//codemeta.github.io/terms/softwareSuggestions">softwareSuggestions</a></li>
                         
@@ -6665,22 +7319,23 @@ While providing the formal specification for RO-Crate, this document also aims t
                         <li><a href="#https%3A//codemeta.github.io/terms/isSourceCodeOf">isSourceCodeOf</a></li>
                         </ul></td>
             </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
-            <th style="text-align:left;" class="prop">hasPart</th>
+            <th style="text-align:left;" class="prop">hasPart<span>&nbsp;</span><a href="http://schema.org/hasPart">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//w3id.org/ro/crate/1.2">RO-Crate specification 1.2</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">hasArtifact</th>
+            <th style="text-align:left;" class="prop">hasArtifact<span>&nbsp;</span><a href="http://www.w3.org/ns/dx/prof/hasArtifact">[?]</a></th>
             <td style='text-align:left'><a href="#%23vocabulary-codemeta">#vocabulary-codemeta</a></td>
             </tr></tbody>
             </table>
         </div>
-            </div>
+
+        </div>
         <hr/><br/><br/>
-            <div>
-                <h3><a href="https://bioschemas.org/FormalParameter">Go to: </a> FormalParameter</h3>
-                
-                
-                
-                
+           <div>
+            <h3><a href="https://bioschemas.org/FormalParameter">Go to: </a> FormalParameter</h3>
+            
+            
+            
+            
         <div id="https://bioschemas.org/FormalParameter">
             
             <table class="table metadata table-striped" >
@@ -6688,7 +7343,7 @@ While providing the formal specification for RO-Crate, this document also aims t
             <th style="text-align:left;" class="prop">@id</th>
             <td style='text-align:left'><a href="https://bioschemas.org/FormalParameter">https://bioschemas.org/FormalParameter</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">name</th>
+            <th style="text-align:left;" class="prop">name<span>&nbsp;</span><a href="http://schema.org/name">[?]</a></th>
             <td style='text-align:left'><span>FormalParameter</span></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">@type</th>
@@ -6698,13 +7353,13 @@ While providing the formal specification for RO-Crate, this document also aims t
                         <li><span>rdfs:Class</span></li>
                         </ul></td>
             </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
-            <th style="text-align:left;" class="prop">hasPart</th>
+            <th style="text-align:left;" class="prop">hasPart<span>&nbsp;</span><a href="http://schema.org/hasPart">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//w3id.org/ro/crate/1.2">RO-Crate specification 1.2</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">about</th>
+            <th style="text-align:left;" class="prop">about<span>&nbsp;</span><a href="http://schema.org/about">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//bioschemas.org/profiles/FormalParameter/1.0-RELEASE">FormalParameter Profile</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">rangeIncludes</th>
+            <th style="text-align:left;" class="prop">rangeIncludes<span>&nbsp;</span><a href="http://schema.org/rangeIncludes">[?]</a></th>
             <td style='text-align:left'><ul>
                         <li><a href="#https%3A//bioschemas.org/properties/input">input</a></li>
                         
@@ -6713,14 +7368,15 @@ While providing the formal specification for RO-Crate, this document also aims t
             </tr></tbody>
             </table>
         </div>
-            </div>
+
+        </div>
         <hr/><br/><br/>
-            <div>
-                <h3><a href="https://bioschemas.org/ComputationalWorkflow">Go to: </a> ComputationalWorkflow</h3>
-                
-                
-                
-                
+           <div>
+            <h3><a href="https://bioschemas.org/ComputationalWorkflow">Go to: </a> ComputationalWorkflow</h3>
+            
+            
+            
+            
         <div id="https://bioschemas.org/ComputationalWorkflow">
             
             <table class="table metadata table-striped" >
@@ -6728,7 +7384,7 @@ While providing the formal specification for RO-Crate, this document also aims t
             <th style="text-align:left;" class="prop">@id</th>
             <td style='text-align:left'><a href="https://bioschemas.org/ComputationalWorkflow">https://bioschemas.org/ComputationalWorkflow</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">name</th>
+            <th style="text-align:left;" class="prop">name<span>&nbsp;</span><a href="http://schema.org/name">[?]</a></th>
             <td style='text-align:left'><span>ComputationalWorkflow</span></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">@type</th>
@@ -6738,13 +7394,13 @@ While providing the formal specification for RO-Crate, this document also aims t
                         <li><span>rdfs:Class</span></li>
                         </ul></td>
             </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
-            <th style="text-align:left;" class="prop">hasPart</th>
+            <th style="text-align:left;" class="prop">hasPart<span>&nbsp;</span><a href="http://schema.org/hasPart">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//w3id.org/ro/crate/1.2">RO-Crate specification 1.2</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">about</th>
+            <th style="text-align:left;" class="prop">about<span>&nbsp;</span><a href="http://schema.org/about">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//bioschemas.org/profiles/ComputationalWorkflow/1.0-RELEASE">ComputationalWorkflow profile</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">domainIncludes</th>
+            <th style="text-align:left;" class="prop">domainIncludes<span>&nbsp;</span><a href="http://schema.org/domainIncludes">[?]</a></th>
             <td style='text-align:left'><ul>
                         <li><a href="#http%3A//schema.org/defaultValue">defaultValue</a></li>
                         
@@ -6757,14 +7413,15 @@ While providing the formal specification for RO-Crate, this document also aims t
             </tr></tbody>
             </table>
         </div>
-            </div>
+
+        </div>
         <hr/><br/><br/>
-            <div>
-                <h3><a href="http://schema.org/defaultValue">Go to: </a> defaultValue</h3>
-                
-                
-                
-                
+           <div>
+            <h3><a href="http://schema.org/defaultValue">Go to: </a> defaultValue</h3>
+            
+            
+            
+            
         <div id="http://schema.org/defaultValue">
             
             <table class="table metadata table-striped" >
@@ -6772,7 +7429,7 @@ While providing the formal specification for RO-Crate, this document also aims t
             <th style="text-align:left;" class="prop">@id</th>
             <td style='text-align:left'><a href="http://schema.org/defaultValue">http://schema.org/defaultValue</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">name</th>
+            <th style="text-align:left;" class="prop">name<span>&nbsp;</span><a href="http://schema.org/name">[?]</a></th>
             <td style='text-align:left'><span>defaultValue</span></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">@type</th>
@@ -6782,29 +7439,30 @@ While providing the formal specification for RO-Crate, this document also aims t
                         <li><span>rdf:Property</span></li>
                         </ul></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">domainIncludes</th>
+            <th style="text-align:left;" class="prop">domainIncludes<span>&nbsp;</span><a href="http://schema.org/domainIncludes">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//bioschemas.org/ComputationalWorkflow">ComputationalWorkflow</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">rangeIncludes</th>
+            <th style="text-align:left;" class="prop">rangeIncludes<span>&nbsp;</span><a href="http://schema.org/rangeIncludes">[?]</a></th>
             <td style='text-align:left'><ul>
                         <li><a href="http://schema.org/Text">http://schema.org/Text</a></li>
                         
                         <li><a href="http://schema.org/Thing">http://schema.org/Thing</a></li>
                         </ul></td>
             </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
-            <th style="text-align:left;" class="prop">hasPart</th>
+            <th style="text-align:left;" class="prop">hasPart<span>&nbsp;</span><a href="http://schema.org/hasPart">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//w3id.org/ro/crate/1.2">RO-Crate specification 1.2</a></td>
             </tr></tbody>
             </table>
         </div>
-            </div>
+
+        </div>
         <hr/><br/><br/>
-            <div>
-                <h3><a href="http://schema.org/valueRequired">Go to: </a> valueRequired</h3>
-                
-                
-                
-                
+           <div>
+            <h3><a href="http://schema.org/valueRequired">Go to: </a> valueRequired</h3>
+            
+            
+            
+            
         <div id="http://schema.org/valueRequired">
             
             <table class="table metadata table-striped" >
@@ -6812,7 +7470,7 @@ While providing the formal specification for RO-Crate, this document also aims t
             <th style="text-align:left;" class="prop">@id</th>
             <td style='text-align:left'><a href="http://schema.org/valueRequired">http://schema.org/valueRequired</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">name</th>
+            <th style="text-align:left;" class="prop">name<span>&nbsp;</span><a href="http://schema.org/name">[?]</a></th>
             <td style='text-align:left'><span>valueRequired</span></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">@type</th>
@@ -6822,29 +7480,30 @@ While providing the formal specification for RO-Crate, this document also aims t
                         <li><span>rdf:Property</span></li>
                         </ul></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">domainIncludes</th>
+            <th style="text-align:left;" class="prop">domainIncludes<span>&nbsp;</span><a href="http://schema.org/domainIncludes">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//bioschemas.org/ComputationalWorkflow">ComputationalWorkflow</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">rangeIncludes</th>
+            <th style="text-align:left;" class="prop">rangeIncludes<span>&nbsp;</span><a href="http://schema.org/rangeIncludes">[?]</a></th>
             <td style='text-align:left'><ul>
                         <li><a href="http://schema.org/Text">http://schema.org/Text</a></li>
                         
                         <li><a href="http://schema.org/Thing">http://schema.org/Thing</a></li>
                         </ul></td>
             </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
-            <th style="text-align:left;" class="prop">hasPart</th>
+            <th style="text-align:left;" class="prop">hasPart<span>&nbsp;</span><a href="http://schema.org/hasPart">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//w3id.org/ro/crate/1.2">RO-Crate specification 1.2</a></td>
             </tr></tbody>
             </table>
         </div>
-            </div>
+
+        </div>
         <hr/><br/><br/>
-            <div>
-                <h3><a href="https://bioschemas.org/properties/input">Go to: </a> input</h3>
-                
-                
-                
-                
+           <div>
+            <h3><a href="https://bioschemas.org/properties/input">Go to: </a> input</h3>
+            
+            
+            
+            
         <div id="https://bioschemas.org/properties/input">
             
             <table class="table metadata table-striped" >
@@ -6852,7 +7511,7 @@ While providing the formal specification for RO-Crate, this document also aims t
             <th style="text-align:left;" class="prop">@id</th>
             <td style='text-align:left'><a href="https://bioschemas.org/properties/input">https://bioschemas.org/properties/input</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">name</th>
+            <th style="text-align:left;" class="prop">name<span>&nbsp;</span><a href="http://schema.org/name">[?]</a></th>
             <td style='text-align:left'><span>input</span></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">@type</th>
@@ -6862,31 +7521,32 @@ While providing the formal specification for RO-Crate, this document also aims t
                         <li><span>rdf:Property</span></li>
                         </ul></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">description</th>
+            <th style="text-align:left;" class="prop">description<span>&nbsp;</span><a href="http://schema.org/description">[?]</a></th>
             <td style='text-align:left'><span>Definition of an input parameter required to use the computational workflow</span></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">termCode</th>
+            <th style="text-align:left;" class="prop">termCode<span>&nbsp;</span><a href="http://schema.org/termCode">[?]</a></th>
             <td style='text-align:left'><span>input</span></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">domainIncludes</th>
+            <th style="text-align:left;" class="prop">domainIncludes<span>&nbsp;</span><a href="http://schema.org/domainIncludes">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//bioschemas.org/ComputationalWorkflow">ComputationalWorkflow</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">rangeIncludes</th>
+            <th style="text-align:left;" class="prop">rangeIncludes<span>&nbsp;</span><a href="http://schema.org/rangeIncludes">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//bioschemas.org/FormalParameter">FormalParameter</a></td>
             </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
-            <th style="text-align:left;" class="prop">hasPart</th>
+            <th style="text-align:left;" class="prop">hasPart<span>&nbsp;</span><a href="http://schema.org/hasPart">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//w3id.org/ro/crate/1.2">RO-Crate specification 1.2</a></td>
             </tr></tbody>
             </table>
         </div>
-            </div>
+
+        </div>
         <hr/><br/><br/>
-            <div>
-                <h3><a href="https://bioschemas.org/properties/output">Go to: </a> output</h3>
-                
-                
-                
-                
+           <div>
+            <h3><a href="https://bioschemas.org/properties/output">Go to: </a> output</h3>
+            
+            
+            
+            
         <div id="https://bioschemas.org/properties/output">
             
             <table class="table metadata table-striped" >
@@ -6894,7 +7554,7 @@ While providing the formal specification for RO-Crate, this document also aims t
             <th style="text-align:left;" class="prop">@id</th>
             <td style='text-align:left'><a href="https://bioschemas.org/properties/output">https://bioschemas.org/properties/output</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">name</th>
+            <th style="text-align:left;" class="prop">name<span>&nbsp;</span><a href="http://schema.org/name">[?]</a></th>
             <td style='text-align:left'><span>output</span></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">@type</th>
@@ -6904,31 +7564,32 @@ While providing the formal specification for RO-Crate, this document also aims t
                         <li><span>rdf:Property</span></li>
                         </ul></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">description</th>
+            <th style="text-align:left;" class="prop">description<span>&nbsp;</span><a href="http://schema.org/description">[?]</a></th>
             <td style='text-align:left'><span>Definition of an output produced by the workflow</span></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">termCode</th>
+            <th style="text-align:left;" class="prop">termCode<span>&nbsp;</span><a href="http://schema.org/termCode">[?]</a></th>
             <td style='text-align:left'><span>output</span></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">domainIncludes</th>
+            <th style="text-align:left;" class="prop">domainIncludes<span>&nbsp;</span><a href="http://schema.org/domainIncludes">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//bioschemas.org/ComputationalWorkflow">ComputationalWorkflow</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">rangeIncludes</th>
+            <th style="text-align:left;" class="prop">rangeIncludes<span>&nbsp;</span><a href="http://schema.org/rangeIncludes">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//bioschemas.org/FormalParameter">FormalParameter</a></td>
             </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
-            <th style="text-align:left;" class="prop">hasPart</th>
+            <th style="text-align:left;" class="prop">hasPart<span>&nbsp;</span><a href="http://schema.org/hasPart">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//w3id.org/ro/crate/1.2">RO-Crate specification 1.2</a></td>
             </tr></tbody>
             </table>
         </div>
-            </div>
+
+        </div>
         <hr/><br/><br/>
-            <div>
-                <h3><a href="http://purl.org/dc/terms/conformsTo">Go to: </a> conformsTo</h3>
-                
-                
-                
-                
+           <div>
+            <h3><a href="http://purl.org/dc/terms/conformsTo">Go to: </a> conformsTo</h3>
+            
+            
+            
+            
         <div id="http://purl.org/dc/terms/conformsTo">
             
             <table class="table metadata table-striped" >
@@ -6936,28 +7597,29 @@ While providing the formal specification for RO-Crate, this document also aims t
             <th style="text-align:left;" class="prop">@id</th>
             <td style='text-align:left'><a href="http://purl.org/dc/terms/conformsTo">http://purl.org/dc/terms/conformsTo</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">name</th>
+            <th style="text-align:left;" class="prop">name<span>&nbsp;</span><a href="http://schema.org/name">[?]</a></th>
             <td style='text-align:left'><span>conformsTo</span></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">@type</th>
             <td style='text-align:left'><span>DefinedTerm</span></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">termCode</th>
+            <th style="text-align:left;" class="prop">termCode<span>&nbsp;</span><a href="http://schema.org/termCode">[?]</a></th>
             <td style='text-align:left'><span>conformsTo</span></td>
             </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
-            <th style="text-align:left;" class="prop">hasPart</th>
+            <th style="text-align:left;" class="prop">hasPart<span>&nbsp;</span><a href="http://schema.org/hasPart">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//w3id.org/ro/crate/1.2">RO-Crate specification 1.2</a></td>
             </tr></tbody>
             </table>
         </div>
-            </div>
+
+        </div>
         <hr/><br/><br/>
-            <div>
-                <h3><a href="https://w3id.org/ro/terms#localPath">Go to: </a> localPath</h3>
-                
-                
-                
-                
+           <div>
+            <h3><a href="https://w3id.org/ro/terms#localPath">Go to: </a> localPath</h3>
+            
+            
+            
+            
         <div id="https://w3id.org/ro/terms#localPath">
             
             <table class="table metadata table-striped" >
@@ -6965,31 +7627,32 @@ While providing the formal specification for RO-Crate, this document also aims t
             <th style="text-align:left;" class="prop">@id</th>
             <td style='text-align:left'><a href="https://w3id.org/ro/terms#localPath">https://w3id.org/ro/terms#localPath</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">name</th>
+            <th style="text-align:left;" class="prop">name<span>&nbsp;</span><a href="http://schema.org/name">[?]</a></th>
             <td style='text-align:left'><span>localPath</span></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">@type</th>
             <td style='text-align:left'><span>DefinedTerm</span></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">description</th>
+            <th style="text-align:left;" class="prop">description<span>&nbsp;</span><a href="http://schema.org/description">[?]</a></th>
             <td style='text-align:left'><span>A recommended URI path to download this work to. Intended to be used on web-based data entities within RO-Crates.</span></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">termCode</th>
+            <th style="text-align:left;" class="prop">termCode<span>&nbsp;</span><a href="http://schema.org/termCode">[?]</a></th>
             <td style='text-align:left'><span>localPath</span></td>
             </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
-            <th style="text-align:left;" class="prop">hasPart</th>
+            <th style="text-align:left;" class="prop">hasPart<span>&nbsp;</span><a href="http://schema.org/hasPart">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//w3id.org/ro/crate/1.2">RO-Crate specification 1.2</a></td>
             </tr></tbody>
             </table>
         </div>
-            </div>
+
+        </div>
         <hr/><br/><br/>
-            <div>
-                <h3><a href="https://doi.org/10.5281/zenodo.13751027">Go to: </a> https://doi.org/10.5281/zenodo.13751027</h3>
-                
-                
-                
-                
+           <div>
+            <h3><a href="https://doi.org/10.5281/zenodo.13751027">Go to: </a> https://doi.org/10.5281/zenodo.13751027</h3>
+            
+            
+            
+            
         <div id="https://doi.org/10.5281/zenodo.13751027">
             
             <table class="table metadata table-striped" >
@@ -7000,16 +7663,16 @@ While providing the formal specification for RO-Crate, this document also aims t
             <th style="text-align:left;" class="prop">@type</th>
             <td style='text-align:left'><span>PropertyValue</span></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">propertyID</th>
+            <th style="text-align:left;" class="prop">propertyID<span>&nbsp;</span><a href="http://schema.org/propertyID">[?]</a></th>
             <td style='text-align:left'><a href="https://registry.identifiers.org/registry/doi">https://registry.identifiers.org/registry/doi</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">value</th>
+            <th style="text-align:left;" class="prop">value<span>&nbsp;</span><a href="http://schema.org/value">[?]</a></th>
             <td style='text-align:left'><span>doi:10.5281/zenodo.13751027</span></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">url</th>
+            <th style="text-align:left;" class="prop">url<span>&nbsp;</span><a href="http://schema.org/url">[?]</a></th>
             <td style='text-align:left'><a href="https://doi.org/10.5281/zenodo.13751027">https://doi.org/10.5281/zenodo.13751027</a></td>
             </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
-            <th style="text-align:left;" class="prop">identifier</th>
+            <th style="text-align:left;" class="prop">identifier<span>&nbsp;</span><a href="http://schema.org/identifier">[?]</a></th>
             <td style='text-align:left'><ul>
                         <li><a href="#https%3A//w3id.org/ro/crate/1.2">RO-Crate specification 1.2</a></li>
                         
@@ -7018,14 +7681,15 @@ While providing the formal specification for RO-Crate, this document also aims t
             </tr></tbody>
             </table>
         </div>
-            </div>
+
+        </div>
         <hr/><br/><br/>
-            <div>
-                <h3><a href="https://w3id.org/ro/crate/1.1">Go to: </a> RO-Crate specification 1.1</h3>
-                
-                
-                
-                
+           <div>
+            <h3><a href="https://w3id.org/ro/crate/1.1">Go to: </a> RO-Crate specification 1.1</h3>
+            
+            
+            
+            
         <div id="https://w3id.org/ro/crate/1.1">
             
             <table class="table metadata table-striped" >
@@ -7033,28 +7697,29 @@ While providing the formal specification for RO-Crate, this document also aims t
             <th style="text-align:left;" class="prop">@id</th>
             <td style='text-align:left'><a href="https://w3id.org/ro/crate/1.1">https://w3id.org/ro/crate/1.1</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">name</th>
+            <th style="text-align:left;" class="prop">name<span>&nbsp;</span><a href="http://schema.org/name">[?]</a></th>
             <td style='text-align:left'><span>RO-Crate specification 1.1</span></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">@type</th>
             <td style='text-align:left'><span>Dataset</span></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">version</th>
+            <th style="text-align:left;" class="prop">version<span>&nbsp;</span><a href="http://schema.org/version">[?]</a></th>
             <td style='text-align:left'><span>1.1.2</span></td>
             </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
-            <th style="text-align:left;" class="prop">isBasedOn</th>
+            <th style="text-align:left;" class="prop">isBasedOn<span>&nbsp;</span><a href="http://schema.org/isBasedOn">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//w3id.org/ro/crate/1.2">RO-Crate specification 1.2</a></td>
             </tr></tbody>
             </table>
         </div>
-            </div>
+
+        </div>
         <hr/><br/><br/>
-            <div>
-                <h3><a href="http://www.w3.org/TR/2014/REC-json-ld-20140116/">Go to: </a> JSON-LD 1.0</h3>
-                
-                
-                
-                
+           <div>
+            <h3><a href="http://www.w3.org/TR/2014/REC-json-ld-20140116/">Go to: </a> JSON-LD 1.0</h3>
+            
+            
+            
+            
         <div id="http://www.w3.org/TR/2014/REC-json-ld-20140116/">
             
             <table class="table metadata table-striped" >
@@ -7062,22 +7727,22 @@ While providing the formal specification for RO-Crate, this document also aims t
             <th style="text-align:left;" class="prop">@id</th>
             <td style='text-align:left'><a href="http://www.w3.org/TR/2014/REC-json-ld-20140116/">http://www.w3.org/TR/2014/REC-json-ld-20140116/</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">name</th>
+            <th style="text-align:left;" class="prop">name<span>&nbsp;</span><a href="http://schema.org/name">[?]</a></th>
             <td style='text-align:left'><span>JSON-LD 1.0</span></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">@type</th>
             <td style='text-align:left'><span>Standard</span></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">description</th>
+            <th style="text-align:left;" class="prop">description<span>&nbsp;</span><a href="http://schema.org/description">[?]</a></th>
             <td style='text-align:left'><span>A JSON-based Serialization for Linked Data</span></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">version</th>
+            <th style="text-align:left;" class="prop">version<span>&nbsp;</span><a href="http://schema.org/version">[?]</a></th>
             <td style='text-align:left'><span>1.0</span></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">sameAs</th>
+            <th style="text-align:left;" class="prop">sameAs<span>&nbsp;</span><a href="http://schema.org/sameAs">[?]</a></th>
             <td style='text-align:left'><a href="https://www.nationalarchives.gov.uk/PRONOM/fmt/880">https://www.nationalarchives.gov.uk/PRONOM/fmt/880</a></td>
             </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
-            <th style="text-align:left;" class="prop">isProfileOf</th>
+            <th style="text-align:left;" class="prop">isProfileOf<span>&nbsp;</span><a href="http://www.w3.org/ns/dx/prof/isProfileOf">[?]</a></th>
             <td style='text-align:left'><ul>
                         <li><a href="#https%3A//w3id.org/ro/crate/1.2">RO-Crate specification 1.2</a></li>
                         
@@ -7086,14 +7751,15 @@ While providing the formal specification for RO-Crate, this document also aims t
             </tr></tbody>
             </table>
         </div>
-            </div>
+
+        </div>
         <hr/><br/><br/>
-            <div>
-                <h3><a href="http://www.w3.org/ns/json-ld#flattened">Go to: </a> Flattened JSON-LD</h3>
-                
-                
-                
-                
+           <div>
+            <h3><a href="http://www.w3.org/ns/json-ld#flattened">Go to: </a> Flattened JSON-LD</h3>
+            
+            
+            
+            
         <div id="http://www.w3.org/ns/json-ld#flattened">
             
             <table class="table metadata table-striped" >
@@ -7101,34 +7767,35 @@ While providing the formal specification for RO-Crate, this document also aims t
             <th style="text-align:left;" class="prop">@id</th>
             <td style='text-align:left'><a href="http://www.w3.org/ns/json-ld#flattened">http://www.w3.org/ns/json-ld#flattened</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">name</th>
+            <th style="text-align:left;" class="prop">name<span>&nbsp;</span><a href="http://schema.org/name">[?]</a></th>
             <td style='text-align:left'><span>Flattened JSON-LD</span></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">@type</th>
             <td style='text-align:left'><span>Profile</span></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">isProfileOf</th>
+            <th style="text-align:left;" class="prop">isProfileOf<span>&nbsp;</span><a href="http://www.w3.org/ns/dx/prof/isProfileOf">[?]</a></th>
             <td style='text-align:left'><a href="#http%3A//www.w3.org/TR/2014/REC-json-ld-20140116/">JSON-LD 1.0</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">version</th>
+            <th style="text-align:left;" class="prop">version<span>&nbsp;</span><a href="http://schema.org/version">[?]</a></th>
             <td style='text-align:left'><span>1.0</span></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">url</th>
+            <th style="text-align:left;" class="prop">url<span>&nbsp;</span><a href="http://schema.org/url">[?]</a></th>
             <td style='text-align:left'><a href="https://www.w3.org/TR/json-ld1/#flattened-document-form">https://www.w3.org/TR/json-ld1/#flattened-document-form</a></td>
             </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
-            <th style="text-align:left;" class="prop">isProfileOf</th>
+            <th style="text-align:left;" class="prop">isProfileOf<span>&nbsp;</span><a href="http://www.w3.org/ns/dx/prof/isProfileOf">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//w3id.org/ro/crate/1.2">RO-Crate specification 1.2</a></td>
             </tr></tbody>
             </table>
         </div>
-            </div>
+
+        </div>
         <hr/><br/><br/>
-            <div>
-                <h3><a href="https://schema.org/docs/releases.html#v22.0">Go to: </a> Schema.org vocabulary (http prefix)</h3>
-                
-                
-                
-                
+           <div>
+            <h3><a href="https://schema.org/docs/releases.html#v22.0">Go to: </a> Schema.org vocabulary (http prefix)</h3>
+            
+            
+            
+            
         <div id="https://schema.org/docs/releases.html#v22.0">
             
             <table class="table metadata table-striped" >
@@ -7136,7 +7803,7 @@ While providing the formal specification for RO-Crate, this document also aims t
             <th style="text-align:left;" class="prop">@id</th>
             <td style='text-align:left'><a href="https://schema.org/docs/releases.html#v22.0">https://schema.org/docs/releases.html#v22.0</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">name</th>
+            <th style="text-align:left;" class="prop">name<span>&nbsp;</span><a href="http://schema.org/name">[?]</a></th>
             <td style='text-align:left'><span>Schema.org vocabulary (http prefix)</span></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">@type</th>
@@ -7149,38 +7816,43 @@ While providing the formal specification for RO-Crate, this document also aims t
             <th style="text-align:left;" class="prop">vann:preferredNamespaceUri</th>
             <td style='text-align:left'><a href="http://schema.org/">http://schema.org/</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">version</th>
+            <th style="text-align:left;" class="prop">version<span>&nbsp;</span><a href="http://schema.org/version">[?]</a></th>
             <td style='text-align:left'><span>22.0</span></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">url</th>
+            <th style="text-align:left;" class="prop">url<span>&nbsp;</span><a href="http://schema.org/url">[?]</a></th>
             <td style='text-align:left'><a href="https://schema.org/docs/developers.html">https://schema.org/docs/developers.html</a></td>
             </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
-            <th style="text-align:left;" class="prop">isProfileOf</th>
+            <th style="text-align:left;" class="prop">isProfileOf<span>&nbsp;</span><a href="http://www.w3.org/ns/dx/prof/isProfileOf">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//w3id.org/ro/crate/1.2">RO-Crate specification 1.2</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">inDefinedTermSet</th>
+            <th style="text-align:left;" class="prop">inDefinedTermSet<span>&nbsp;</span><a href="http://schema.org/inDefinedTermSet">[?]</a></th>
             <td style='text-align:left'><ul>
+                        <li><a href="#http%3A//schema.org/domainIncludes">domainIncludes</a></li>
+                        
+                        <li><a href="#http%3A//schema.org/rangeIncludes">rangeIncludes</a></li>
+                        
                         <li><a href="#http%3A//schema.org/Class">Class (schema.org)</a></li>
                         
                         <li><a href="#http%3A//schema.org/Property">Property (schema.org)</a></li>
                         </ul></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">isBasedOn</th>
+            <th style="text-align:left;" class="prop">isBasedOn<span>&nbsp;</span><a href="http://schema.org/isBasedOn">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//w3id.org/ro/crate/1.2/context">RO-Crate JSON-LD Context</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">hasArtifact</th>
+            <th style="text-align:left;" class="prop">hasArtifact<span>&nbsp;</span><a href="http://www.w3.org/ns/dx/prof/hasArtifact">[?]</a></th>
             <td style='text-align:left'><a href="#%23vocabulary-schema">#vocabulary-schema</a></td>
             </tr></tbody>
             </table>
         </div>
-            </div>
+
+        </div>
         <hr/><br/><br/>
-            <div>
-                <h3><a href="https://www.apache.org/licenses/LICENSE-2.0">Go to: </a> Apache License 2.0</h3>
-                
-                
-                
-                
+           <div>
+            <h3><a href="https://www.apache.org/licenses/LICENSE-2.0">Go to: </a> Apache License 2.0</h3>
+            
+            
+            
+            
         <div id="https://www.apache.org/licenses/LICENSE-2.0">
             
             <table class="table metadata table-striped" >
@@ -7188,31 +7860,32 @@ While providing the formal specification for RO-Crate, this document also aims t
             <th style="text-align:left;" class="prop">@id</th>
             <td style='text-align:left'><a href="https://www.apache.org/licenses/LICENSE-2.0">https://www.apache.org/licenses/LICENSE-2.0</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">name</th>
+            <th style="text-align:left;" class="prop">name<span>&nbsp;</span><a href="http://schema.org/name">[?]</a></th>
             <td style='text-align:left'><span>Apache License 2.0</span></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">@type</th>
             <td style='text-align:left'><span>CreativeWork</span></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">version</th>
+            <th style="text-align:left;" class="prop">version<span>&nbsp;</span><a href="http://schema.org/version">[?]</a></th>
             <td style='text-align:left'><span>2.0</span></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">identifier</th>
+            <th style="text-align:left;" class="prop">identifier<span>&nbsp;</span><a href="http://schema.org/identifier">[?]</a></th>
             <td style='text-align:left'>spdx: Apache-2.0</td>
             </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
-            <th style="text-align:left;" class="prop">license</th>
+            <th style="text-align:left;" class="prop">license<span>&nbsp;</span><a href="http://schema.org/license">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//w3id.org/ro/crate/1.2">RO-Crate specification 1.2</a></td>
             </tr></tbody>
             </table>
         </div>
-            </div>
+
+        </div>
         <hr/><br/><br/>
-            <div>
-                <h3><a href="https://www.researchobject.org/ro-crate/community">Go to: </a> RO-Crate Community</h3>
-                
-                
-                
-                
+           <div>
+            <h3><a href="https://www.researchobject.org/ro-crate/community">Go to: </a> RO-Crate Community</h3>
+            
+            
+            
+            
         <div id="https://www.researchobject.org/ro-crate/community">
             
             <table class="table metadata table-striped" >
@@ -7220,13 +7893,13 @@ While providing the formal specification for RO-Crate, this document also aims t
             <th style="text-align:left;" class="prop">@id</th>
             <td style='text-align:left'><a href="https://www.researchobject.org/ro-crate/community">https://www.researchobject.org/ro-crate/community</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">name</th>
+            <th style="text-align:left;" class="prop">name<span>&nbsp;</span><a href="http://schema.org/name">[?]</a></th>
             <td style='text-align:left'><span>RO-Crate Community</span></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">@type</th>
             <td style='text-align:left'><span>Project</span></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">member</th>
+            <th style="text-align:left;" class="prop">member<span>&nbsp;</span><a href="http://schema.org/member">[?]</a></th>
             <td style='text-align:left'>
                         <details style='margin-left: 3%'>
                             <summary>
@@ -7411,35 +8084,36 @@ While providing the formal specification for RO-Crate, this document also aims t
                         </details>
                 </td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">parentOrganization</th>
+            <th style="text-align:left;" class="prop">parentOrganization<span>&nbsp;</span><a href="http://schema.org/parentOrganization">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//www.researchobject.org/">ResearchObject.org</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">sdDatePublished</th>
+            <th style="text-align:left;" class="prop">sdDatePublished<span>&nbsp;</span><a href="http://schema.org/sdDatePublished">[?]</a></th>
             <td style='text-align:left'><span>2022-01-19T10:54:41Z</span></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">url</th>
+            <th style="text-align:left;" class="prop">url<span>&nbsp;</span><a href="http://schema.org/url">[?]</a></th>
             <td style='text-align:left'><a href="https://www.researchobject.org/ro-crate/community">https://www.researchobject.org/ro-crate/community</a></td>
             </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
-            <th style="text-align:left;" class="prop">maintainer</th>
+            <th style="text-align:left;" class="prop">maintainer<span>&nbsp;</span><a href="http://schema.org/maintainer">[?]</a></th>
             <td style='text-align:left'><ul>
                         <li><a href="#https%3A//w3id.org/ro/crate/1.2">RO-Crate specification 1.2</a></li>
                         
                         <li><a href="#https%3A//w3id.org/ro/crate/">Research Object Crate (RO-Crate) website</a></li>
                         </ul></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">author</th>
+            <th style="text-align:left;" class="prop">author<span>&nbsp;</span><a href="http://schema.org/author">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//doi.org/10.3233/DS-210053">Packaging research artefacts with RO-Crate</a></td>
             </tr></tbody>
             </table>
         </div>
-            </div>
+
+        </div>
         <hr/><br/><br/>
-            <div>
-                <h3><a href="https://www.researchobject.org/">Go to: </a> ResearchObject.org</h3>
-                
-                
-                
-                
+           <div>
+            <h3><a href="https://www.researchobject.org/">Go to: </a> ResearchObject.org</h3>
+            
+            
+            
+            
         <div id="https://www.researchobject.org/">
             
             <table class="table metadata table-striped" >
@@ -7447,35 +8121,36 @@ While providing the formal specification for RO-Crate, this document also aims t
             <th style="text-align:left;" class="prop">@id</th>
             <td style='text-align:left'><a href="https://www.researchobject.org/">https://www.researchobject.org/</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">name</th>
+            <th style="text-align:left;" class="prop">name<span>&nbsp;</span><a href="http://schema.org/name">[?]</a></th>
             <td style='text-align:left'><span>ResearchObject.org</span></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">@type</th>
             <td style='text-align:left'><span>Organization</span></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">url</th>
+            <th style="text-align:left;" class="prop">url<span>&nbsp;</span><a href="http://schema.org/url">[?]</a></th>
             <td style='text-align:left'><a href="https://www.researchobject.org/">https://www.researchobject.org/</a></td>
             </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
-            <th style="text-align:left;" class="prop">publisher</th>
+            <th style="text-align:left;" class="prop">publisher<span>&nbsp;</span><a href="http://schema.org/publisher">[?]</a></th>
             <td style='text-align:left'><ul>
                         <li><a href="#https%3A//w3id.org/ro/crate/1.2">RO-Crate specification 1.2</a></li>
                         
                         <li><a href="#https%3A//w3id.org/ro/crate/">Research Object Crate (RO-Crate) website</a></li>
                         </ul></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">parentOrganization</th>
+            <th style="text-align:left;" class="prop">parentOrganization<span>&nbsp;</span><a href="http://schema.org/parentOrganization">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//www.researchobject.org/ro-crate/community">RO-Crate Community</a></td>
             </tr></tbody>
             </table>
         </div>
-            </div>
+
+        </div>
         <hr/><br/><br/>
-            <div>
-                <h3> #vocabulary-schema</h3>
-                
-                
-                
-                
+           <div>
+            <h3> #vocabulary-schema</h3>
+            
+            
+            
+            
         <div id="#vocabulary-schema">
             
             <table class="table metadata table-striped" >
@@ -7486,25 +8161,26 @@ While providing the formal specification for RO-Crate, this document also aims t
             <th style="text-align:left;" class="prop">@type</th>
             <td style='text-align:left'><span>ResourceDescriptor</span></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">hasArtifact</th>
+            <th style="text-align:left;" class="prop">hasArtifact<span>&nbsp;</span><a href="http://www.w3.org/ns/dx/prof/hasArtifact">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//schema.org/docs/releases.html%23v22.0">Schema.org vocabulary (http prefix)</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">hasRole</th>
+            <th style="text-align:left;" class="prop">hasRole<span>&nbsp;</span><a href="http://www.w3.org/ns/dx/prof/hasRole">[?]</a></th>
             <td style='text-align:left'><a href="#http%3A//www.w3.org/ns/dx/prof/role/vocabulary">Vocabulary</a></td>
             </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
-            <th style="text-align:left;" class="prop">hasResource</th>
+            <th style="text-align:left;" class="prop">hasResource<span>&nbsp;</span><a href="http://www.w3.org/ns/dx/prof/hasResource">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//w3id.org/ro/crate/1.2">RO-Crate specification 1.2</a></td>
             </tr></tbody>
             </table>
         </div>
-            </div>
+
+        </div>
         <hr/><br/><br/>
-            <div>
-                <h3> #vocabulary-pcdm</h3>
-                
-                
-                
-                
+           <div>
+            <h3> #vocabulary-pcdm</h3>
+            
+            
+            
+            
         <div id="#vocabulary-pcdm">
             
             <table class="table metadata table-striped" >
@@ -7515,25 +8191,26 @@ While providing the formal specification for RO-Crate, this document also aims t
             <th style="text-align:left;" class="prop">@type</th>
             <td style='text-align:left'><span>ResourceDescriptor</span></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">hasArtifact</th>
+            <th style="text-align:left;" class="prop">hasArtifact<span>&nbsp;</span><a href="http://www.w3.org/ns/dx/prof/hasArtifact">[?]</a></th>
             <td style='text-align:left'><a href="http://pcdm.org/models">http://pcdm.org/models</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">hasRole</th>
+            <th style="text-align:left;" class="prop">hasRole<span>&nbsp;</span><a href="http://www.w3.org/ns/dx/prof/hasRole">[?]</a></th>
             <td style='text-align:left'><a href="#http%3A//www.w3.org/ns/dx/prof/role/vocabulary">Vocabulary</a></td>
             </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
-            <th style="text-align:left;" class="prop">hasResource</th>
+            <th style="text-align:left;" class="prop">hasResource<span>&nbsp;</span><a href="http://www.w3.org/ns/dx/prof/hasResource">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//w3id.org/ro/crate/1.2">RO-Crate specification 1.2</a></td>
             </tr></tbody>
             </table>
         </div>
-            </div>
+
+        </div>
         <hr/><br/><br/>
-            <div>
-                <h3> #vocabulary-prof</h3>
-                
-                
-                
-                
+           <div>
+            <h3> #vocabulary-prof</h3>
+            
+            
+            
+            
         <div id="#vocabulary-prof">
             
             <table class="table metadata table-striped" >
@@ -7544,25 +8221,26 @@ While providing the formal specification for RO-Crate, this document also aims t
             <th style="text-align:left;" class="prop">@type</th>
             <td style='text-align:left'><span>ResourceDescriptor</span></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">hasArtifact</th>
+            <th style="text-align:left;" class="prop">hasArtifact<span>&nbsp;</span><a href="http://www.w3.org/ns/dx/prof/hasArtifact">[?]</a></th>
             <td style='text-align:left'><a href="#http%3A//www.w3.org/ns/dx/prof">Profiles Vocabulary</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">hasRole</th>
+            <th style="text-align:left;" class="prop">hasRole<span>&nbsp;</span><a href="http://www.w3.org/ns/dx/prof/hasRole">[?]</a></th>
             <td style='text-align:left'><a href="#http%3A//www.w3.org/ns/dx/prof/role/vocabulary">Vocabulary</a></td>
             </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
-            <th style="text-align:left;" class="prop">hasResource</th>
+            <th style="text-align:left;" class="prop">hasResource<span>&nbsp;</span><a href="http://www.w3.org/ns/dx/prof/hasResource">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//w3id.org/ro/crate/1.2">RO-Crate specification 1.2</a></td>
             </tr></tbody>
             </table>
         </div>
-            </div>
+
+        </div>
         <hr/><br/><br/>
-            <div>
-                <h3> #vocabulary-prof-roles</h3>
-                
-                
-                
-                
+           <div>
+            <h3> #vocabulary-prof-roles</h3>
+            
+            
+            
+            
         <div id="#vocabulary-prof-roles">
             
             <table class="table metadata table-striped" >
@@ -7573,25 +8251,26 @@ While providing the formal specification for RO-Crate, this document also aims t
             <th style="text-align:left;" class="prop">@type</th>
             <td style='text-align:left'><span>ResourceDescriptor</span></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">hasArtifact</th>
+            <th style="text-align:left;" class="prop">hasArtifact<span>&nbsp;</span><a href="http://www.w3.org/ns/dx/prof/hasArtifact">[?]</a></th>
             <td style='text-align:left'><a href="http://pcdm.org/models">http://pcdm.org/models</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">hasRole</th>
+            <th style="text-align:left;" class="prop">hasRole<span>&nbsp;</span><a href="http://www.w3.org/ns/dx/prof/hasRole">[?]</a></th>
             <td style='text-align:left'><a href="#http%3A//www.w3.org/ns/dx/prof/role/vocabulary">Vocabulary</a></td>
             </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
-            <th style="text-align:left;" class="prop">hasResource</th>
+            <th style="text-align:left;" class="prop">hasResource<span>&nbsp;</span><a href="http://www.w3.org/ns/dx/prof/hasResource">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//w3id.org/ro/crate/1.2">RO-Crate specification 1.2</a></td>
             </tr></tbody>
             </table>
         </div>
-            </div>
+
+        </div>
         <hr/><br/><br/>
-            <div>
-                <h3> #vocabulary-rdfs</h3>
-                
-                
-                
-                
+           <div>
+            <h3> #vocabulary-rdfs</h3>
+            
+            
+            
+            
         <div id="#vocabulary-rdfs">
             
             <table class="table metadata table-striped" >
@@ -7602,25 +8281,26 @@ While providing the formal specification for RO-Crate, this document also aims t
             <th style="text-align:left;" class="prop">@type</th>
             <td style='text-align:left'><span>ResourceDescriptor</span></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">hasArtifact</th>
+            <th style="text-align:left;" class="prop">hasArtifact<span>&nbsp;</span><a href="http://www.w3.org/ns/dx/prof/hasArtifact">[?]</a></th>
             <td style='text-align:left'><a href="#http%3A//www.w3.org/1999/02/22-rdf-syntax-ns%23">http://www.w3.org/1999/02/22-rdf-syntax-ns#</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">hasRole</th>
+            <th style="text-align:left;" class="prop">hasRole<span>&nbsp;</span><a href="http://www.w3.org/ns/dx/prof/hasRole">[?]</a></th>
             <td style='text-align:left'><a href="#http%3A//www.w3.org/ns/dx/prof/role/vocabulary">Vocabulary</a></td>
             </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
-            <th style="text-align:left;" class="prop">hasResource</th>
+            <th style="text-align:left;" class="prop">hasResource<span>&nbsp;</span><a href="http://www.w3.org/ns/dx/prof/hasResource">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//w3id.org/ro/crate/1.2">RO-Crate specification 1.2</a></td>
             </tr></tbody>
             </table>
         </div>
-            </div>
+
+        </div>
         <hr/><br/><br/>
-            <div>
-                <h3> #vocabulary-geosparql</h3>
-                
-                
-                
-                
+           <div>
+            <h3> #vocabulary-geosparql</h3>
+            
+            
+            
+            
         <div id="#vocabulary-geosparql">
             
             <table class="table metadata table-striped" >
@@ -7631,25 +8311,26 @@ While providing the formal specification for RO-Crate, this document also aims t
             <th style="text-align:left;" class="prop">@type</th>
             <td style='text-align:left'><span>ResourceDescriptor</span></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">hasArtifact</th>
+            <th style="text-align:left;" class="prop">hasArtifact<span>&nbsp;</span><a href="http://www.w3.org/ns/dx/prof/hasArtifact">[?]</a></th>
             <td style='text-align:left'><a href="#http%3A//www.opengis.net/ont/geosparql%23">GeoSPARQL ontology</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">hasRole</th>
+            <th style="text-align:left;" class="prop">hasRole<span>&nbsp;</span><a href="http://www.w3.org/ns/dx/prof/hasRole">[?]</a></th>
             <td style='text-align:left'><a href="#http%3A//www.w3.org/ns/dx/prof/role/vocabulary">Vocabulary</a></td>
             </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
-            <th style="text-align:left;" class="prop">hasResource</th>
+            <th style="text-align:left;" class="prop">hasResource<span>&nbsp;</span><a href="http://www.w3.org/ns/dx/prof/hasResource">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//w3id.org/ro/crate/1.2">RO-Crate specification 1.2</a></td>
             </tr></tbody>
             </table>
         </div>
-            </div>
+
+        </div>
         <hr/><br/><br/>
-            <div>
-                <h3> #vocabulary-codemeta</h3>
-                
-                
-                
-                
+           <div>
+            <h3> #vocabulary-codemeta</h3>
+            
+            
+            
+            
         <div id="#vocabulary-codemeta">
             
             <table class="table metadata table-striped" >
@@ -7660,25 +8341,26 @@ While providing the formal specification for RO-Crate, this document also aims t
             <th style="text-align:left;" class="prop">@type</th>
             <td style='text-align:left'><span>ResourceDescriptor</span></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">hasArtifact</th>
+            <th style="text-align:left;" class="prop">hasArtifact<span>&nbsp;</span><a href="http://www.w3.org/ns/dx/prof/hasArtifact">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//codemeta.github.io/terms/">Codemeta Terms</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">hasRole</th>
+            <th style="text-align:left;" class="prop">hasRole<span>&nbsp;</span><a href="http://www.w3.org/ns/dx/prof/hasRole">[?]</a></th>
             <td style='text-align:left'><a href="#http%3A//www.w3.org/ns/dx/prof/role/vocabulary">Vocabulary</a></td>
             </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
-            <th style="text-align:left;" class="prop">hasResource</th>
+            <th style="text-align:left;" class="prop">hasResource<span>&nbsp;</span><a href="http://www.w3.org/ns/dx/prof/hasResource">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//w3id.org/ro/crate/1.2">RO-Crate specification 1.2</a></td>
             </tr></tbody>
             </table>
         </div>
-            </div>
+
+        </div>
         <hr/><br/><br/>
-            <div>
-                <h3> #specification</h3>
-                
-                
-                
-                
+           <div>
+            <h3> #specification</h3>
+            
+            
+            
+            
         <div id="#specification">
             
             <table class="table metadata table-striped" >
@@ -7689,25 +8371,26 @@ While providing the formal specification for RO-Crate, this document also aims t
             <th style="text-align:left;" class="prop">@type</th>
             <td style='text-align:left'><span>ResourceDescriptor</span></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">hasArtifact</th>
+            <th style="text-align:left;" class="prop">hasArtifact<span>&nbsp;</span><a href="http://www.w3.org/ns/dx/prof/hasArtifact">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//github.com/ResearchObject/ro-crate/releases/download/1.2.0/ro-crate-1.2.0.html">RO-Crate Metadata Specification 1.2 (single-page HTML)</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">hasRole</th>
+            <th style="text-align:left;" class="prop">hasRole<span>&nbsp;</span><a href="http://www.w3.org/ns/dx/prof/hasRole">[?]</a></th>
             <td style='text-align:left'><a href="#http%3A//www.w3.org/ns/dx/prof/role/specification">Specification</a></td>
             </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
-            <th style="text-align:left;" class="prop">hasResource</th>
+            <th style="text-align:left;" class="prop">hasResource<span>&nbsp;</span><a href="http://www.w3.org/ns/dx/prof/hasResource">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//w3id.org/ro/crate/1.2">RO-Crate specification 1.2</a></td>
             </tr></tbody>
             </table>
         </div>
-            </div>
+
+        </div>
         <hr/><br/><br/>
-            <div>
-                <h3> #example-rainfall</h3>
-                
-                
-                
-                
+           <div>
+            <h3> #example-rainfall</h3>
+            
+            
+            
+            
         <div id="#example-rainfall">
             
             <table class="table metadata table-striped" >
@@ -7718,18 +8401,19 @@ While providing the formal specification for RO-Crate, this document also aims t
             <th style="text-align:left;" class="prop">@type</th>
             <td style='text-align:left'><span>ResourceDescriptor</span></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">hasArtifact</th>
+            <th style="text-align:left;" class="prop">hasArtifact<span>&nbsp;</span><a href="http://www.w3.org/ns/dx/prof/hasArtifact">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//www.researchobject.org/ro-crate/1.2/examples/rainfall-1.2.0/">Example dataset for RO-Crate specification</a></td>
             </tr><tr>
-            <th style="text-align:left;" class="prop">hasRole</th>
+            <th style="text-align:left;" class="prop">hasRole<span>&nbsp;</span><a href="http://www.w3.org/ns/dx/prof/hasRole">[?]</a></th>
             <td style='text-align:left'><a href="#http%3A//www.w3.org/ns/dx/prof/role/example">Example</a></td>
             </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
-            <th style="text-align:left;" class="prop">hasResource</th>
+            <th style="text-align:left;" class="prop">hasResource<span>&nbsp;</span><a href="http://www.w3.org/ns/dx/prof/hasResource">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//w3id.org/ro/crate/1.2">RO-Crate specification 1.2</a></td>
             </tr></tbody>
             </table>
         </div>
-            </div>
+
+        </div>
         <hr/><br/><br/></div>
 </div>
 


### PR DESCRIPTION
As pointed out in #466 we use `rdfs:` properties however these are not all defined in the core RO-Crate profile. This adds `rdfs:comment`, `rdfs:label`, `rdfs:subClassOf`, `rdfs:subPropertyOf` with links to the RDFS specification, which inconveniently is not resolved from the `@id` itself. I've also added definition of `domainIncludes` and `rangeInclude` and used these here in schema.org-style-schema way.

<img width="1128" height="644" alt="image" src="https://github.com/user-attachments/assets/efae2db9-aa46-4550-9758-cdc5bb2e833e" />

As this is not modifying the spec itself, I think it's sufficient to version as a patch update (1.2.1).