### PR TITLE
Mention profiles in topnav to make it easier to find them

### DIFF
--- a/docs/_data/sidebars/resources.yml
+++ b/docs/_data/sidebars/resources.yml
@@ -1,4 +1,4 @@
-title: Resources
+title: Resources & Profiles
 title_url: tutorials
 subitems:
   - title: Tutorials

--- a/docs/_data/topnav.yml
+++ b/docs/_data/topnav.yml
@@ -7,7 +7,7 @@ subitems:
     url: /use_cases
   - title: "Community"
     url: /community
-  - title: "Resources"
+  - title: "Resources & Profiles"
     url: /tutorials
   - title: "Specification"
     url: /specification


### PR DESCRIPTION
People often struggle to find the profiles on the website, they are under "Resources" but people don't often look there.

This PR renames "Resources" to "Resources & Profiles" in the navbar & sidebar to help people get to the right section. Screenshot below.

Fixes #330.

<img width="1871" height="737" alt="Screenshot of updated navbar and sidebar" src="https://github.com/user-attachments/assets/3a9d7406-e68a-44d3-adea-1b9212bf66af" />

