### PR TITLE
Add related use cases to blog posts

### DIFF
--- a/docs/_blog/.template.md
+++ b/docs/_blog/.template.md
@@ -2,6 +2,8 @@
 title:  "Template for RO-Crate blog posts"
 author: ["Eli Chadwick"]
 date: 2025-06-12
+related_pages:
+    use_cases: [page_id1, page_id2] # should match items in pages/use_cases
 ---
 
 This template assumes you have some familiarity with Git, GitHub, and Markdown.
@@ -18,6 +20,7 @@ If you don't have those skills, but you'd like to contribute a post, you can wri
     1. Add a `title` for the post. This will be used as the first heading on the rendered page.
     1. Add `author`s to the array, separated by commas, e.g. `["Person A", "Person B"].
     1. Change the `date` to the intended publication date in `yyyy-mm-dd` format. This should match the name of the folder.
+    1. Update the `use_cases` list to include the IDs of any related [use case pages](https://www.researchobject.org/ro-crate/use_cases). To find the ID of a page, go to its [Markdown file](https://github.com/ResearchObject/ro-crate/tree/main/docs/pages/use_cases) and copy the `page_id` from its front matter. Use cases referenced in this list will automatically appear at the end of the blog post.
 
 ## Writing the post
 

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -77,6 +77,7 @@ defaults:
     values:
       layout: "post"
       sidebar: blog
+      type: blog_posts
 
   - scope:
       path: "pages/about"

--- a/docs/_includes/related_use_cases.html
+++ b/docs/_includes/related_use_cases.html
@@ -1,20 +1,27 @@
 <h2>Related use cases</h2>
 
 <!-- find use cases that match this entry -->
-{% assign all_use_cases = site.pages | where:"type", "use_cases" %}
-{% assign matched_cases = "" | split: "," %} <!-- hack to initialise an empty array -->
-{% for case in all_use_cases %}
-    {% if page.type == "domains" %}
-        {% assign metadata = case.domains %}
-    {% elsif page.type == "tasks" %}
-        {% assign metadata = case.tasks %}
-    {% elsif page.type == "roles" %}
-        {% assign metadata = case.roles %}
-    {% endif %}
-    {% if metadata contains page.page_id %}
-        {% assign matched_cases = matched_cases | push: case.page_id %}
-    {% endif %}
-{% endfor %}
+{% if page.type == "blog_posts" %}
+    <!-- for blog posts the related use cases are set directly -->
+    {% assign matched_cases = page.related_pages.use_cases %}
+{% else %}
+    <!-- for domains/tasks/roles (DTR), the cross-links are set on the use case pages, -->
+    <!-- so search all use case pages for those which connect to the desired DTR -->
+    {% assign all_use_cases = site.pages | where:"type", "use_cases" %}
+    {% assign matched_cases = "" | split: "," %} <!-- hack to initialise an empty array -->
+    {% for case in all_use_cases %}
+        {% if page.type == "domains" %}
+            {% assign metadata = case.domains %}
+        {% elsif page.type == "tasks" %}
+            {% assign metadata = case.tasks %}
+        {% elsif page.type == "roles" %}
+            {% assign metadata = case.roles %}
+        {% endif %}
+        {% if metadata contains page.page_id %}
+            {% assign matched_cases = matched_cases | push: case.page_id %}
+        {% endif %}
+    {% endfor %}
+{% endif %}
 
 {% if matched_cases.size == 0 %}
 <p>No use cases found.</p>

--- a/docs/_includes/section-navigation-tiles.html
+++ b/docs/_includes/section-navigation-tiles.html
@@ -87,7 +87,7 @@
                   <div class="px-3 pb-3 d-flex justify-content-between align-items-center">                    
                     <h3 class="card-title ml-3">{{current_page.title}}</h3>
                     {%- if current_page.image %}
-                    <img alt="logo of {{current_page.title}}" src="assets/img/{{current_page.image }}" class="d-inline tile-img-sm">
+                    <img alt="logo of {{current_page.title}}" src="{{site.baseurl}}/assets/img/{{current_page.image }}" class="d-inline tile-img-sm">
                     {%- endif %}
                     {%- if current_page.icon %}
                     <i class="fa fa-2x {{ current_page.icon }}"></i>
@@ -154,7 +154,7 @@
                     {%- elsif filter_affiliation %}
                     <a role="button" href="{{filter_affiliation.url}}" data-bs-toggle="tooltip" data-bs-original-title="{{affiliation}}" class="btn btn-sm bg-white hover-primary">
                         {%- if filter_affiliation.image_url %}
-                        <img alt="logo of {{filter_affiliation.name}}" src="{{filter_affiliation.image_url | relative_url }}" class="d-inline affiliation-img-sm">
+                        <img alt="logo of {{filter_affiliation.name}}" src="{{site.baseurl}}/{{filter_affiliation.image_url | relative_url }}" class="d-inline affiliation-img-sm">
                         {%- else %}
                         {{filter_affiliation.name}}
                         {%- endif %}

--- a/docs/_layouts/post.html
+++ b/docs/_layouts/post.html
@@ -8,3 +8,5 @@ layout: default
 <hr>
 
 {{ content }}
+
+{% include related_use_cases.html %}


### PR DESCRIPTION
This will allow blog posts to include related use cases in the front matter, and they will be displayed at the end of the blog post.

For example, adding the following front matter to an example post:
```
related_pages:
    use_cases: [workflowhub, digital-twins]
```

Will result in the following rendering:

<img width="1865" height="793" alt="Screenshot showing related use cases" src="https://github.com/user-attachments/assets/4b41a9bd-5ca5-465c-95a5-172b866d162a" />

Inspired by #478 