### PR TITLE
Improve page metadata handling for better SEO and thumbnail rendering in chats

### DIFF
--- a/docs/_includes/head.html
+++ b/docs/_includes/head.html
@@ -1,8 +1,4 @@
 <head>
-  <meta charset="utf-8">
-  <meta http-equiv="X-UA-Compatible" content="IE=edge">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="description" content="{% if page.description %}{{ page.description | strip_html | strip_newlines | truncate: 160 }}{% else %}{{ site.description }}{% endif %}">
   {%- capture keywords %}
   {%- if page.related_pages %}
   {%- for section in page.related_pages %}
@@ -19,20 +15,28 @@
   {%- endfor %}{{allkeywords}}
   {%- endif %}
   {%- endcapture %}
+  {%- if page.type %}
+  {%- assign subtitle = page.type | replace: "_", " " %}
+  {%- endif %}
+  {%- capture title %}{% if page.url == "/" %}{{site.title}}{% elsif page.title %}{% if subtitle %}{{subtitle}}: {% endif %}{{ page.title }} | {{ site.title }}{%- else %}{{ site.title }}{% endif %}{% endcapture %}
+  {%- capture description %}{% if page.url == "/" %}{{site.description}}{% elsif page.description %}{{ page.description | strip_html | replace: '\n', ' ' | truncatewords: 30, '...' }}{% elsif page.summary %}{{ page.summary | strip_html | replace: '\n', ' ' | truncatewords: 30, '...' }}{% else %}{{ page.content | strip_html | replace: '\n', ' ' | truncatewords: 30, '...' }}{% endif %}{% endcapture %}  
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <title>{{title}}</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="{{description}}">
   <meta name="keywords" content="{{keywords}}">
-  <meta property="og:title" content="{{ site.title }}" />
-  <meta property="og:description" content="{{ site.description }}" />
+  <meta property="og:title" content="{{title}}" />
+  <meta property="og:description" content="{{description}}" />
+  <meta property="og:type" content="article">
+  <meta property="og:url" content="{{ page.url | absolute_url }}">
   <meta property="og:image" content="//{{site.github.url | remove: 'https://' | remove: 'http://'}}/assets/img/apple-touch-icon.png" />
-  <meta name="apple-mobile-web-app-title" content="{{site.title}}">
+  <meta name="apple-mobile-web-app-title" content="{{title}}">
   <meta name="msapplication-TileColor" content="#{{site.theme_variables.theme_color | default: 0d6efd }}">
   <meta name="theme-color" content="#{{site.theme_variables.theme_color | default: 0d6efd }}">
   {%- if page.no_robots %}
   <meta name="robots" content="noindex" />
   {%- endif %}
-  {%- if page.type %}
-  {%- assign subtitle = page.type | replace: "_", " " | capitalize %}
-  {%- endif %}
-  <title>{% if page.title %}{% if subtitle %}{{subtitle}}: {% endif %}{{ page.title }} | {{ site.title }}{%- else %}{{ site.title }}{% endif %}</title>
   <!-- Syntax highlighting  -->
   <link rel="stylesheet" href="{{ 'assets/css/syntax.css' | relative_url }}">
   <!-- Country flags  -->


### PR DESCRIPTION
This will improve the previews when pages from the RO-Crate website are linked in places like Slack. See https://github.com/ELIXIR-Belgium/elixir-toolkit-theme/issues/349 for details.

I've copied @bedroesb's solution from https://github.com/ELIXIR-Belgium/elixir-toolkit-theme/pull/351 (since we are still using ETT v2 and it will take us some effort to upgrade to v5 where this feature is included).