### PR TITLE
Make sorting pages case insensitive

### DIFF
--- a/docs/_includes/section-navigation-tiles.html
+++ b/docs/_includes/section-navigation-tiles.html
@@ -50,15 +50,15 @@
     {%- if include.custom %}
     {%- assign related_pages = include.custom | split: ", " %}
     {%- unless include.sort == false %}
-    {%- assign related_pages = related_pages | sort %}
+    {%- assign related_pages = related_pages | sort_natural %}
     {%- endunless %}
     {%- elsif include.type %}
     {%- assign related_pages = site.pages | where:"type", include.type %}
     {%- else %}
     {%- assign related_pages = site.pages %}
     {%- endif %}
-    {%- unless include.sort == false %}
-    {%- assign related_pages = related_pages | sort: 'title'%}
+    {%- unless include.sort == false or include.custom %}
+    {%- assign related_pages = related_pages | sort_natural: 'title'%}
     {%- endunless %}
     {%- for related_page in related_pages %}
     {%- if include.custom %}

--- a/docs/_includes/sidebar.html
+++ b/docs/_includes/sidebar.html
@@ -95,7 +95,7 @@
       </a>
       {%- if folder.submenu_type | size > 0 %}
       <ul class="list-unstyled">
-        {% assign linked_pages = site.pages | sort: 'title' %}
+        {% assign linked_pages = site.pages | sort_natural: 'title' %}
         {%- for linked_page in linked_pages %}
         {%- if linked_page.type == folder.submenu_type %}
         {%- if page.url == linked_page.url %}


### PR DESCRIPTION
`sort` is case-sensitive, but `sort_natural` is not.

We may have occasional pages with titles starting with a lowercase letter. This change ensures those pages get sorted sensibly - e.g. "nf-prov" (proposed in #489 ) should be between "Machine-actionable DMPs" and "PARADISEC", not after "ZBMed".