### PR TITLE
Add ROCratePCC to tools_list

### DIFF
--- a/docs/_data/tools_list.yml
+++ b/docs/_data/tools_list.yml
@@ -187,12 +187,12 @@
   level:
   url: https://pypi.org/project/roc-validator/
   subitems:
-   - name: Documentation
-     url: https://rocrate-validator.readthedocs.io/
-   - name: Source code
-     url: https://github.com/crs4/rocrate-validator
-   - name: Cratey-Validator (REST API front end)
-     url: https://github.com/eScienceLab/Cratey-Validator
+    - name: Documentation
+      url: https://rocrate-validator.readthedocs.io/
+    - name: Source code
+      url: https://github.com/crs4/rocrate-validator
+    - name: Cratey-Validator (REST API front end)
+      url: https://github.com/eScienceLab/Cratey-Validator
 
 - name: provenance-storage (provstor)
   description: RO-Crate storage and graph database, loaded from disk/URL into Apache Fuseki and MinIO, to then be queried using SPARQL. Targetting Workflow Run RO-Crates and other crates.
@@ -283,8 +283,8 @@
       url: https://kit-data-manager.github.io/NovaCrate/editor
     - name: GitHub
       url: https://github.com/kit-data-manager/NovaCrate
-    
-- name: ROCrate Profile Crate Creator
+
+- name: RO-Crate Profile Crate Creator
   description: Polyglot library for creation of RO-Crate Profile Crates (Available in Python, Typescript and FSharp)
   status: beta
   url: https://github.com/nfdi4plants/ROCratePCC


### PR DESCRIPTION
The [ROCrate Profile Crate Creator](https://github.com/nfdi4plants/ROCratePCC) is a small software library initiated at the Biohackathon Europe 2025 in consultation with @elichad.

It aims to provide a quick code based interface for creation of [Profile Crates](https://www.researchobject.org/ro-crate/specification/1.2/profiles.html#profile-crate). 

The source code is in FSharp, but there is a transpiled version published on Pypi and one on npm. I expect mainly the Python version to be used.