### PR TITLE
Fix incorrect links in spec index

### DIFF
--- a/docs/_specification/1.1/_metadata.liquid
+++ b/docs/_specification/1.1/_metadata.liquid
@@ -8,7 +8,7 @@
 * This version: <https://w3id.org/ro/crate/1.1>
 * Alternate formats: [Web pages](https://www.researchobject.org/ro-crate/1.1/),
   [single-page HTML](https://github.com/ResearchObject/ro-crate/releases/download/1.1.2/ro-crate-1.1.2.html),
-  [PDF](https://github.com/ResearchObject/ro-crate/releases/download/1.1.2/ro-crate-1.1.2.html),
+  [PDF](https://github.com/ResearchObject/ro-crate/releases/download/1.1.2/ro-crate-1.1.2.pdf),
   [RO-Crate JSON-LD](ro-crate-metadata.json), [RO-Crate HTML](ro-crate-preview.html)
 * Previous version: <https://w3id.org/ro/crate/1.0>
 * Cite as: <https://doi.org/10.5281/zenodo.7867028> (this version)
@@ -41,5 +41,3 @@ Unless required by applicable law or agreed to in writing, software distributed 
 **Note**: The RO-Crate [JSON-LD context](https://w3id.org/ro/crate/1.1/context) and JSON-LD examples within this specification are distributed under [CC0 1.0 Universal (CC0 1.0) Public Domain Dedication][CC0]. 
 
 > The key words MUST, MUST NOT, REQUIRED, SHALL, SHALL NOT, SHOULD, SHOULD NOT, RECOMMENDED, MAY, and OPTIONAL in this document are to be interpreted as described in [RFC 2119].
-
-

--- a/docs/_specification/1.1/ro-crate-metadata.json
+++ b/docs/_specification/1.1/ro-crate-metadata.json
@@ -528,7 +528,7 @@
       ],
       "name": "RO-Crate Metadata Specification 1.1 (PDF)",
       "sameAs": {
-        "@id": "https://zenodo.org/record/5841615/files/ro-crate-1.1.pdf"
+        "@id": "https://zenodo.org/record/5841615/files/ro-crate-1.1.2.pdf"
       },
       "isBasedOn": [
         { "@id": "https://www.researchobject.org/ro-crate/1.1/index.html"},

--- a/docs/_specification/1.2/_metadata.liquid
+++ b/docs/_specification/1.2/_metadata.liquid
@@ -6,9 +6,9 @@
 * Status: Recommendation
 * JSON-LD context: <https://w3id.org/ro/crate/1.2/context>
 * This version: <https://w3id.org/ro/crate/1.2>
-* Alternate formats: [Web pages](https://www.researchobject.org/ro-crate/1.2/),
+* Alternate formats: [Web pages](https://www.researchobject.org/ro-crate/specification/1.2/),
   [single-page HTML](https://github.com/ResearchObject/ro-crate/releases/download/1.2.0/ro-crate-1.2.0.html),
-  [PDF](https://github.com/ResearchObject/ro-crate/releases/download/1.2.0/ro-crate-1.2.0.html),
+  [PDF](https://github.com/ResearchObject/ro-crate/releases/download/1.2.0/ro-crate-1.2.0.pdf),
   [RO-Crate JSON-LD](ro-crate-metadata.json), [RO-Crate HTML](ro-crate-preview.html)
 * Previous version: <https://w3id.org/ro/crate/1.1>
 * Cite as: <https://doi.org/10.5281/zenodo.13751027> (this version)
@@ -43,5 +43,3 @@ Unless required by applicable law or agreed to in writing, software distributed 
 **Note**: The RO-Crate [JSON-LD context](https://w3id.org/ro/crate/1.2/context) and JSON-LD examples within this specification are distributed under [CC0 1.0 Universal (CC0 1.0) Public Domain Dedication][CC0]. 
 
 > The key words MUST, MUST NOT, REQUIRED, SHALL, SHALL NOT, SHOULD, SHOULD NOT, RECOMMENDED, MAY, and OPTIONAL in this document are to be interpreted as described in [RFC 2119].
-
-

--- a/docs/_specification/1.2/ro-crate-metadata.json
+++ b/docs/_specification/1.2/ro-crate-metadata.json
@@ -1217,7 +1217,7 @@
       ],
       "name": "RO-Crate Metadata Specification 1.2 (PDF)",
       "sameAs": {
-        "@id": "https://zenodo.org/record/13751027/files/ro-crate-1.2.pdf"
+        "@id": "https://zenodo.org/record/13751027/files/ro-crate-1.2.0.pdf"
       },
       "version": "1.2.0"
     },

--- a/docs/_specification/1.3-DRAFT/_metadata.liquid
+++ b/docs/_specification/1.3-DRAFT/_metadata.liquid
@@ -8,11 +8,11 @@ END NOTE -->
 * Status: Editor's Draft
 * JSON-LD context: <https://w3id.org/ro/crate/1.3-DRAFT/context>
 * This version: <https://w3id.org/ro/crate/1.3-DRAFT>
-* Alternate formats: [Web pages](https://www.researchobject.org/ro-crate/1.3-DRAFT/),
+* Alternate formats: [Web pages](https://www.researchobject.org/ro-crate/specification/1.3-DRAFT/),
   [single-page HTML](https://github.com/ResearchObject/ro-crate/releases/download/TAG/ro-crate-TAG.html),
-  [PDF](https://github.com/ResearchObject/ro-crate/releases/download/TAG/ro-crate-TAG.html),
+  [PDF](https://github.com/ResearchObject/ro-crate/releases/download/TAG/ro-crate-TAG.pdf),
   [RO-Crate JSON-LD](ro-crate-metadata.json), [RO-Crate HTML](ro-crate-preview.html)
-* Previous version: <https://w3id.org/ro/crate/1.1>
+* Previous version: <https://w3id.org/ro/crate/1.2>
 * Cite as: <!-- <https://doi.org/10.5281/zenodo.13751027> (this version)   -->
   <https://doi.org/10.5281/zenodo.3406497> (any version)
 * Editors: [Peter Sefton](https://orcid.org/0000-0002-3545-944X), [Stian Soiland-Reyes](https://orcid.org/0000-0001-9842-9718)
@@ -44,5 +44,3 @@ Unless required by applicable law or agreed to in writing, software distributed 
 **Note**: The RO-Crate [JSON-LD context](https://w3id.org/ro/crate/1.3-DRAFT/context) and JSON-LD examples within this specification are distributed under [CC0 1.0 Universal (CC0 1.0) Public Domain Dedication][CC0]. 
 
 > The key words MUST, MUST NOT, REQUIRED, SHALL, SHALL NOT, SHOULD, SHOULD NOT, RECOMMENDED, MAY, and OPTIONAL in this document are to be interpreted as described in [RFC 2119].
-
-


### PR DESCRIPTION
Fixes #169 in 1.1, 1.2, and the template (1.3-DRAFT), with the exception of:

> * single-page HTML is a reference to https://github.com/ResearchObject/ro-crate/releases/download/1.2.0/ro-crate-1.2.0.html which returns a Location header to an asset in github causing the content to be returned as an octet-stream rather than rendered directly ( that may be intended but was not expected behaviour )

I'm not sure if anything should change there since we don't host the single-page HTML on the website.