### PR TITLE
Add GitHub Actions workflow to schedule and auto-merge blog PRs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,8 +7,10 @@ on:
   push:
     branches: ["main"]
 
+  # Rebuild weekly at 03:36 on Tuesday
+  # helps to flag bugs that appear when dependencies are updated
   schedule:
-    - cron: "36 2 * * *"
+    - cron: "36 3 * * 2"
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/schedule_merge_prs.yml
+++ b/.github/workflows/schedule_merge_prs.yml
@@ -1,0 +1,35 @@
+# This workflow is used for scheduling blog posts to be merged on their publication date.
+# To activate the scheduler, include `/schedule <date>` at the end of the PR description, e.g.:
+# /schedule 2022-06-08
+# More info: https://github.com/gr2m/merge-schedule-action
+name: Schedule merge for pull request
+
+on:
+  # pull request updates trigger the action to check for the presence of
+  # `/schedule <date>` in the PR description and mark the PR pending if appropriate
+  pull_request:
+    types:
+      - opened
+      - edited
+      - synchronize
+  # daily cron job merges pending PRs on the appropriate date
+  schedule:
+    - cron: '36 2 * * *'
+
+jobs:
+  merge_schedule:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: gr2m/merge-schedule-action@v2
+        with:
+          # Merge method to use. Possible values are merge, squash or
+          # rebase. Default is merge.
+          merge_method: rebase
+          # Require all pull request statuses to be successful before
+          # merging. Default is `false`.
+          require_statuses_success: 'true'
+          # Label to apply to the pull request if the merge fails. Default is
+          # `automerge-fail`.
+          automerge_fail_label: 'automerge-fail'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Can work for any PR, but we'd use it for blog posts.

Currently we merge blog posts ahead of their intended publication date, and rebuild the site daily to publish the posts. However, the RSS feed gets updated with the post immediately after merging - this is inconvenient for anyone who subscribes to the feed as they will get a notification but the post link won't yet work. In particular, I would like to automatically cross-post the RSS feed to Slack (and in future other platforms) but the RSS Slack app doesn't support scheduling the message into the future, it just sends right when the feed is updated.

Changing the publication date before merging is a bit of a faff. Remembering to merge on the correct date is also impractical. So this workflow handles scheduling a merge on the correct date. All we need to do is add the following syntax at the end of the description in PRs that we want to schedule:

/schedule 2026-01-15