### PR TITLE
Resolve #527: Changes Place example key to url

### DIFF
--- a/docs/_specification/1.1/contextual-entities.md
+++ b/docs/_specification/1.1/contextual-entities.md
@@ -501,7 +501,7 @@ This example shows how to define a place, using a [geonames] ID:
     "@id": "#b4168a98-8534-4c6d-a568-64a55157b656"
   },
   "identifier": "http://sws.geonames.org/8152662/",
-  "uri": "https://www.geonames.org/8152662/catalina-park.html",
+  "url": "https://www.geonames.org/8152662/catalina-park.html",
   "name": "Catalina Park"
 },
 ```

--- a/docs/_specification/1.2/contextual-entities.md
+++ b/docs/_specification/1.2/contextual-entities.md
@@ -496,7 +496,7 @@ This example shows how to define a place, using a [geonames] ID:
     "@id": "_:Geometry-1"
   },
   "identifier": "http://sws.geonames.org/8152662/",
-  "uri": "https://www.geonames.org/8152662/catalina-park.html",
+  "url": "https://www.geonames.org/8152662/catalina-park.html",
   "name": "Catalina Park"
 },
 {


### PR DESCRIPTION
Closes #527 

Updates the examples for the `Place` contextual entity in both the 1.1 and 1.2 specs to use `url`. 