### PR TITLE
Converting to detached: metadata descriptor must be ro-crate-metadata.json

### DIFF
--- a/docs/_specification/1.3-DRAFT/appendix/relative-uris.md
+++ b/docs/_specification/1.3-DRAFT/appendix/relative-uris.md
@@ -114,7 +114,7 @@ Example output (abbreviated):
 }
 ```
 
-Notice how identifiers like `ro-crate-metadata.json`, `./`, `index.html` and `example/` have been translated to absolute URIs.
+Identifiers like `ro-crate-metadata.json`, `./`, `index.html` and `example/` have been translated to absolute URIs. However, even in detached RO-Crates, the [RO-Crate Metadata Descriptor](../root-data-entity#ro-crate-metadata-descriptor) is required to have an `@id` of `ro-crate-metadata.json`, so this needs to be manually changed to the required value.
 
 The above JSON-LD processing will also expand any `#`-based local identifiers of contextual entities:
 
@@ -130,7 +130,7 @@ The above JSON-LD processing will also expand any `#`-based local identifiers of
     }
 ```
 
-In this approach, the Detached RO-Crate Package can be resolved to the corresponding Attached RO-Crate Package by following the `@id` of the Root Data Set or the Root Metadata File entity.
+In this approach, the Detached RO-Crate Package can be resolved to the corresponding Attached RO-Crate Package by following the `@id` of the Root Data Set.
 
 If the new Detached RO-Crate Package is not meant as a snapshot of the corresponding Attached RO-Crate Package, then such contextual entities should be assigned new `@id`, e.g. by generating random UUIDs like `urn:uuid:e47e41d9-f924-4c07-bc90-97e7ed34fe35`. Such tranformations are typically not catered for by traditional JSON-LD tooling and require additional implementation.
 

--- a/docs/_specification/1.3-DRAFT/appendix/relative-uris.md
+++ b/docs/_specification/1.3-DRAFT/appendix/relative-uris.md
@@ -114,7 +114,28 @@ Example output (abbreviated):
 }
 ```
 
-Identifiers like `ro-crate-metadata.json`, `./`, `index.html` and `example/` have been translated to absolute URIs. However, even in detached RO-Crates, the [RO-Crate Metadata Descriptor](../root-data-entity#ro-crate-metadata-descriptor) is required to have an `@id` of `ro-crate-metadata.json`, so this needs to be manually changed to the required value.
+Identifiers like `ro-crate-metadata.json`, `./`, `index.html` and `example/` have been translated to absolute URIs. However, even in detached RO-Crates, the [RO-Crate Metadata Descriptor](../root-data-entity#ro-crate-metadata-descriptor) is required to have an `@id` of `ro-crate-metadata.json`, so this needs to be manually changed to the required value. The full URI can be provided by adding a `contentUrl` that points to it:
+
+
+```json
+{
+  "@context": [
+    {"@base": "arcp://uuid,d6be5c9b-132a-4a93-9837-3e02e06c08e6/"},
+    "https://w3id.org/ro/crate/1.1/context"
+  ],
+  "@graph": [
+    {
+      "@id": "ro-crate-metadata.json",
+      "@type": "CreativeWork",
+      "conformsTo": {"@id": "https://w3id.org/ro/crate/1.1"},
+      "about": {"@id": "https://about.workflowhub.eu/Workflow-RO-Crate/1.0/"},
+      "contentUrl": "https://about.workflowhub.eu/Workflow-RO-Crate/1.0/ro-crate-metadata.json",
+      "creator": {"@id": "https://orcid.org/0000-0001-9842-9718"}
+    },
+    ...
+  ]
+}
+```
 
 The above JSON-LD processing will also expand any `#`-based local identifiers of contextual entities:
 


### PR DESCRIPTION
Fixes #524.

This PR attempts to resolve #524 by adding instructions to manually change the metadata descriptor's `@id` to `ro-crate-metadata.json` after the conversion.
