### PR TITLE
Bring latest ETT branch work into sidebar subbranch

### DIFF
--- a/docs/_data/sidebars/main.yml
+++ b/docs/_data/sidebars/main.yml
@@ -3,7 +3,85 @@ title_url: use_cases
 subitems:
   - title: Use Cases
     url: /use_cases
-    submenu_type: use_cases
+    subitems:
+    - title: Arkisto
+      url: /arkisto
+    - title: AROMA ARP RO-Crate Manager
+      url: /aroma
+    - title: Autosubmit
+      url: /autosubmit
+    - title: BioConnect 
+      url: /bioconnect
+    - title: COMPSs
+      url: /compss
+    - title: Data Stewardship Wizard
+      url: /datastewardship
+    - title: DataPLANT
+      url: /dataplant
+    - title: DataVerse
+      url: /dataverse
+    - title: DeSci Nodes
+      url: /desci
+    - title: Digital Twins
+      url: /digital-twins
+    - title: EGI's Application Database
+      url: /appdb
+    - title: Electronic Lab Notebook
+      url: /eln
+    - title: FAIRSCAPE
+      url: /fairscape
+    - title: Five Safes Crate
+      url: /5s-crate
+    - title: Galaxy
+      url: /galaxy
+    - title: KEDO Data Lake
+      url: /datalake
+    - title: Lab Integrated Data (LabID)
+      url: /lab-integrated-data
+    - title: Language Data Commons of Australia
+      url: /language-data-commons-of-australia
+    - title: LifeMonitor
+      url: /lifemonitor
+    - title: "LivePublication: Executable Paper"
+      url: /livepublication-executable-paper
+    - title: "M@TE (Model Atlas of the Earth)"
+      url: /mate-model-atlas-of-the-earth
+    - title: Machine-actionable data management plans
+      url: /madmp
+    - title: nf-prov Nextflow plugin
+      url: /nf-prov-nextflow-plugin
+    - title: Open Microscopy Environment
+      url: /open-microscopy-environment
+    - title: PARADISEC
+      url: /paradisec
+    - title: PILARS
+      url: /pilars
+    - title: Reproducible XAFS Analyses
+      url: /reproducible-xafs-analyses
+    - title: Research Object Composer
+      url: /research-object-composer
+    - title: ROHub
+      url: /rohub
+    - title: RRkive
+      url: /rrkive
+    - title: Sciebo RDS
+      url: /sciebo-rds
+    - title: Survey Ontolgy
+      url: /survey-ontology
+    - title: Time Layered Cultural Map (TLCMap)
+      url: /time-layered-cultural-map
+    - title: UTS Cultural Datasets
+      url: /uts-cultural-datasets 
+    - title: UTS Research Data Repository
+      url: /uts-research-data-repository  
+    - title: Wildlive portal
+      url: /wildlive
+    - title: Workflow Execution Service (WfExS)
+      url: /wfexs
+    - title: WorkflowHub
+      url: /workflowhub
+    - title: ZBMed SemTec web pages
+      url: /zbmed
 
   - title: Your Domain
     url: /domains

--- a/docs/_data/sidebars/main.yml
+++ b/docs/_data/sidebars/main.yml
@@ -113,7 +113,22 @@ subitems:
 
   - title: Your Task
     url: /tasks
-    submenu_type: tasks
+    subitems:
+    - title: Compliance
+      url: /compliance
+    - title: Conduct Research
+      url: /conduct_research
+    - title: Data Curation
+      url: /curation
+    - title: Data Handling
+      url: /data_handling
+    - title: Managing Research Data
+      url: /manage_data
+    - title: Software Development
+      url: /software_development
+    - title: Training
+      url: /training
+
 
   - title: Your Role
     url: /roles

--- a/docs/_data/sidebars/main.yml
+++ b/docs/_data/sidebars/main.yml
@@ -132,4 +132,22 @@ subitems:
 
   - title: Your Role
     url: /roles
-    submenu_type: roles
+    subitems:
+    - title: Compliance Officer
+      url: /compliance_officer
+    - title: Data Analyst
+      url: /data_analyst
+    - title: Data Steward
+      url: /data_steward
+    - title: Information Architect
+      url: /information_architect
+    - title: Managerial
+      url: /managerial
+    - title: Repository Manager
+      url: /repository_manager
+    - title: Researcher
+      url: /researcher
+    - title: Software Developer
+      url: /software_developer
+    - title: Trainer
+      url: /trainer

--- a/docs/_data/sidebars/main.yml
+++ b/docs/_data/sidebars/main.yml
@@ -85,7 +85,31 @@ subitems:
 
   - title: Your Domain
     url: /domains
-    submenu_type: domains
+    subitems:
+    - title: Biology
+      url: /biology
+    - title: Biomedical Science
+      url: /biomedical_science
+    - title: Chemistry
+      url: /chemistry 
+    - title: "Climate Science & Earth sciences"
+      url: /earth_science
+    - title: Ecology and Biodiversity
+      url: /ecology
+    - title: History
+      url: /humanities
+    - title: Informatics
+      url: /informatics
+    - title: Language and Text Analytics
+      url: /language_text
+    - title: Medicine and Health
+      url: /medicine
+    - title: Omics and Bioinformatics
+      url: /omics
+    - title: Social science
+      url: /social_science
+
+
 
   - title: Your Task
     url: /tasks

--- a/docs/_data/sidebars/main.yml
+++ b/docs/_data/sidebars/main.yml
@@ -13,7 +13,7 @@ subitems:
     - title: BioConnect 
       url: /bioconnect
     - title: COMPSs
-      url: /compss
+      url: /COMPSs
     - title: Data Stewardship Wizard
       url: /datastewardship
     - title: DataPLANT
@@ -37,43 +37,43 @@ subitems:
     - title: KEDO Data Lake
       url: /datalake
     - title: Lab Integrated Data (LabID)
-      url: /lab-integrated-data
+      url: /labid
     - title: Language Data Commons of Australia
-      url: /language-data-commons-of-australia
+      url: /ldaca
     - title: LifeMonitor
-      url: /lifemonitor
+      url: /life-monitor
     - title: "LivePublication: Executable Paper"
-      url: /livepublication-executable-paper
+      url: /livepublication
     - title: "M@TE (Model Atlas of the Earth)"
-      url: /mate-model-atlas-of-the-earth
+      url: /mate
     - title: Machine-actionable data management plans
       url: /madmp
     - title: nf-prov Nextflow plugin
-      url: /nf-prov-nextflow-plugin
+      url: /nf-prov
     - title: Open Microscopy Environment
-      url: /open-microscopy-environment
+      url: /ome
     - title: PARADISEC
       url: /paradisec
     - title: PILARS
       url: /pilars
     - title: Reproducible XAFS Analyses
-      url: /reproducible-xafs-analyses
+      url: /rexafs
     - title: Research Object Composer
-      url: /research-object-composer
+      url: /ro-compose
     - title: ROHub
       url: /rohub
     - title: RRkive
       url: /rrkive
     - title: Sciebo RDS
-      url: /sciebo-rds
+      url: /sciebo
     - title: Survey Ontolgy
       url: /survey-ontology
     - title: Time Layered Cultural Map (TLCMap)
-      url: /time-layered-cultural-map
+      url: /tlcmap
     - title: UTS Cultural Datasets
-      url: /uts-cultural-datasets 
+      url: /uts-cultural
     - title: UTS Research Data Repository
-      url: /uts-research-data-repository  
+      url: /uts-research-data
     - title: Wildlive portal
       url: /wildlive
     - title: Workflow Execution Service (WfExS)

--- a/docs/_sass/_custom_classes.scss
+++ b/docs/_sass/_custom_classes.scss
@@ -87,10 +87,10 @@ body {
 
 /*-----Section navigation tiles-----*/
 .navigation-tiles {
-    .align-items-center {
-        // Hide the type of tile label
-        display: none !important;
-    }
+    //.align-items-center {
+    //    // Hide the type of tile label
+    //    display: none !important;
+    //}
 
     .btn.py-4.hover-primary {
         border-left: 0px solid $primary;

--- a/docs/_specification/1.1/index.md
+++ b/docs/_specification/1.1/index.md
@@ -39,7 +39,7 @@ excerpt: |
 
 {%- assign sidebar = site.data.sidebars[page.sidebar] %}
 <ul>
-{% for version in sidebar.versions %}
+{% for version in sidebar.subitems %}
 {%- if page.url == version.url %}
   {% for item in version.subitems %}
   <li><a href="{{item.url | relative_url}}">{{item.title}}</a>

--- a/docs/_specification/1.2/index.md
+++ b/docs/_specification/1.2/index.md
@@ -40,7 +40,7 @@ excerpt: |
 
 {%- assign sidebar = site.data.sidebars[page.sidebar] %}
 <ul>
-{% for version in sidebar.versions %}
+{% for version in sidebar.subitems %}
 {%- if page.url == version.url %}
   {% for item in version.subitems %}
   <li><a href="{{item.url | relative_url}}">{{item.title}}</a>

--- a/docs/_specification/1.3/index.md
+++ b/docs/_specification/1.3/index.md
@@ -38,7 +38,7 @@ excerpt: |
 
 {%- assign sidebar = site.data.sidebars[page.sidebar] %}
 <ul>
-{% for version in sidebar.versions %}
+{% for version in sidebar.subitems %}
 {%- if page.url == version.url %}
   {% for item in version.subitems %}
   <li><a href="{{item.url | relative_url}}">{{item.title}}</a>

--- a/docs/_specification/1.4-DRAFT/index.md
+++ b/docs/_specification/1.4-DRAFT/index.md
@@ -38,7 +38,7 @@ excerpt: |
 
 {%- assign sidebar = site.data.sidebars[page.sidebar] %}
 <ul>
-{% for version in sidebar.versions %}
+{% for version in sidebar.subitems %}
 {%- if page.url == version.url %}
   {% for item in version.subitems %}
   <li><a href="{{item.url | relative_url}}">{{item.title}}</a>

--- a/docs/pages/domains/biology.md
+++ b/docs/pages/domains/biology.md
@@ -12,5 +12,3 @@ toc: false
 {% include item_details.html %}
 
 {% include related_use_cases.html %}
-
-{% include related_pages.html %}

--- a/docs/pages/domains/biomedical_science.md
+++ b/docs/pages/domains/biomedical_science.md
@@ -13,4 +13,3 @@ toc: false
 
 {% include related_use_cases.html %}
 
-{% include related_pages.html %}

--- a/docs/pages/domains/chemistry.md
+++ b/docs/pages/domains/chemistry.md
@@ -13,4 +13,3 @@ toc: false
 
 {% include related_use_cases.html %}
 
-{% include related_pages.html %}

--- a/docs/pages/domains/earth_science.md
+++ b/docs/pages/domains/earth_science.md
@@ -13,5 +13,3 @@ toc: false
 {% include item_details.html %}
 
 {% include related_use_cases.html %}
-
-{% include related_pages.html %}

--- a/docs/pages/domains/ecology.md
+++ b/docs/pages/domains/ecology.md
@@ -13,4 +13,3 @@ toc: false
 
 {% include related_use_cases.html %}
 
-{% include related_pages.html %}

--- a/docs/pages/domains/humanities.md
+++ b/docs/pages/domains/humanities.md
@@ -12,4 +12,3 @@ toc: false
 
 {% include related_use_cases.html %}
 
-{% include related_pages.html %}

--- a/docs/pages/domains/informatics.md
+++ b/docs/pages/domains/informatics.md
@@ -13,4 +13,3 @@ toc: false
 
 {% include related_use_cases.html %}
 
-{% include related_pages.html %}

--- a/docs/pages/domains/language_text.md
+++ b/docs/pages/domains/language_text.md
@@ -13,4 +13,3 @@ toc: false
 
 {% include related_use_cases.html %}
 
-{% include related_pages.html %}

--- a/docs/pages/domains/medicine.md
+++ b/docs/pages/domains/medicine.md
@@ -13,4 +13,3 @@ toc: false
 
 {% include related_use_cases.html %}
 
-{% include related_pages.html %}

--- a/docs/pages/domains/omics.md
+++ b/docs/pages/domains/omics.md
@@ -13,4 +13,3 @@ toc: false
 
 {% include related_use_cases.html %}
 
-{% include related_pages.html %}

--- a/docs/pages/domains/social_science.md
+++ b/docs/pages/domains/social_science.md
@@ -12,4 +12,3 @@ toc: false
 
 {% include related_use_cases.html %}
 
-{% include related_pages.html %}

--- a/docs/pages/use_cases/README.md
+++ b/docs/pages/use_cases/README.md
@@ -2,7 +2,7 @@
 
 If you are using RO-Crate in your project, we welcome you to add your use case here. The use case should be written in [Markdown](https://www.markdownguide.org/),  include a description of the project, how it uses RO-Crate, and any relevant links. You may also include a logo and screenshots.
 
-See example: <https://www.researchobject.org/ro-crate/in-use/rohub.html>
+See example: <https://www.researchobject.org/ro-crate/rohub>
 
 ## How to add a new use case
 First upload logo in SVG or PNG format to [assets.img](../assets/img), naming it same as the new page, e.g. `example.svg` to match `example.md` - you may also add a `example-screenshot.png` to illustrate how RO-Crate is used.
@@ -10,6 +10,8 @@ First upload logo in SVG or PNG format to [assets.img](../assets/img), naming it
 Then in this folder, create a new Markdown file using the [template](.template.md), e.g. `example.md`.
 
 Save a copy of the logo to [/docs/images](../../images) as required by the ETT template so we can use the `page_img` feature. This means the logo will appear in the sidebar of the page and on the list of all use cases.
+
+Add the use case to the sidebar in [/docs/_data/sidebars/main.yml](../../_data/sidebars/main.yml) in the correct place alphabetically. 
 
 ## Template
 The template [here](.template.md) provides a structure for your use case to get started. Your use case should contain the following page data values:

--- a/docs/pages/use_cases/dataverse.md
+++ b/docs/pages/use_cases/dataverse.md
@@ -11,7 +11,6 @@ tasks: [data_handling, manage_data]
 roles: [data_steward, repository_manager]
 ---
 
-# Dataverse
  
 [Dataverse](https://dataverse.org) is open source research data repository software with over 130 [installations](https://dataverse.org/installations) across research institutions. It has support for RO-Crate export, preview and metadata editing.
 

--- a/docs/pages/use_cases/madmp.md
+++ b/docs/pages/use_cases/madmp.md
@@ -10,5 +10,6 @@ tasks: [manage_data]
 roles: [data_steward]
 ---
 
+## About
 
 [RDA maDMP Mapper](https://github.com/GhaithArf/ro-crate-rda-madmp-mapper) and [Ro-Crate\_2\_ma-DMP](https://github.com/BrennerG/Ro-Crate_2_ma-DMP/tree/r2d_) can convert between machine-actionable data management plans (maDMP) and RO-Crate. See <https://doi.org/10.4126/frl01-006423291> for details.

--- a/docs/pages/use_cases/ro-compose.md
+++ b/docs/pages/use_cases/ro-compose.md
@@ -10,5 +10,6 @@ tasks: [conduct_research, software_development]
 roles: [researcher, software_developer]
 ---
 
+## About
 
 [Research Object Composer](https://github.com/researchobject/research-object-composer) is a REST API for gradually building and depositing Research Objects according to a pre-defined profile. It uses JSON as an intermediate format and modified JSON schemas to define a Profile (RO-Crate support _alpha_)

--- a/docs/pages/use_cases/uts-cultural.md
+++ b/docs/pages/use_cases/uts-cultural.md
@@ -10,5 +10,6 @@ tasks: [data_handling, manage_data]
 roles: [data_steward, information_architect,managerial]
 ---
 
+## About
 
 The [UTS Cultural Datasets](https://arkisto-platform.github.io/case-studies/uts-cultural/) project is collaborating with Humanities and Social Science (HASS) researchers and is re-using existing UTS Data infrastructure to build interactive services that allow people to use the data. They make use of RO-Crate to be able to directly transfer data and mappings to the [Expert Nation database](https://expertnation.org/).

--- a/docs/pages/use_cases/uts-research-data.md
+++ b/docs/pages/use_cases/uts-research-data.md
@@ -10,6 +10,6 @@ tasks: [conduct_research, data_handling]
 roles: [repository_manager]
 ---
 
-
+## About
 
 The [UTS Research Data Repository](https://arkisto-platform.github.io/case-studies/uts-repo/) is a searchable portal for discovering and accessing public datasets by UTS researchers. Datasets are described with RO-Crates and published either through the University’s institutional research data management system or direct import from research storage devices for very large datasets.

--- a/docs/pages/use_cases/workflowhub.md
+++ b/docs/pages/use_cases/workflowhub.md
@@ -11,6 +11,8 @@ tasks: [conduct_research, data_handling, manage_data]
 roles: [information_architect, managerial, repository_manager, researcher]
 ---
 
+## About
+
 [WorkflowHub](https://about.workflowhub.eu/) is a registry for describing, sharing and publishing scientific computational workflows.
 
 WorkflowHub aims to facilitate discovery and re-use of workflows in an accessible and interoperable way. This is achieved through extensive use of open standards and tools, including CWL, RO-Crate, Bioschemas and GA4GH's TRS API, in accordance with the FAIR principles.


### PR DESCRIPTION
Use cases, tasks, domains, roles are all now manually managed in the main sidebar.

The tile again shows the type (eg tasks). This is useful when showing related pages.

The related pages is no longer duplicated. I took out the call to the custom related pages in each domain page (that gave a list of tasks and a list of roles) because the overall page layout already includes related pages in titles. 